### PR TITLE
feat: RAG検索結果ゼロ時の「わからない」応答強制とつまづきデータの蓄積

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -134,12 +134,55 @@ def _run_migrations() -> None:
             WHERE is_published = true AND is_template = true
         """))
 
+        # 003: unanswered_query_logs テーブル
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS unanswered_query_logs (
+                id        TEXT PRIMARY KEY,
+                user_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                course_id TEXT NOT NULL,
+                topic_id  TEXT NOT NULL,
+                question  TEXT NOT NULL,
+                asked_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_unanswered_course ON unanswered_query_logs(course_id)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_unanswered_user ON unanswered_query_logs(user_id)"
+        ))
+
         session.commit()
-        logger.info("Migration 002 (A1/A2/A3) applied successfully.")
+        logger.info("Migrations (002 A1/A2/A3, 003 unanswered_queries) applied successfully.")
     except Exception as exc:
         session.rollback()
-        logger.error("Migration 002 failed: %s", exc)
+        logger.error("Migration failed: %s", exc)
         raise
+    finally:
+        session.close()
+
+
+def _log_unanswered_query(user_id: str, course_id: str, topic_id: str, question: str) -> None:
+    """RAG検索で回答できなかった質問をDBに記録する。"""
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO unanswered_query_logs (id, user_id, course_id, topic_id, question)
+                VALUES (:id, CAST(:user_id AS uuid), :course_id, :topic_id, :question)
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "course_id": course_id,
+                "topic_id": topic_id,
+                "question": question,
+            },
+        )
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        logger.warning("Failed to log unanswered query: %s", exc)
     finally:
         session.close()
 
@@ -1125,17 +1168,20 @@ def learning_chat(
         body.message, arxiv_ids, material_ids=material_ids, top_k=5
     )
 
-    # 3a. フェイルセーフ: 関連チャンクが0件またはスコアが極端に低い場合はLLMをスキップ
+    # 3a. フェイルセーフ: 関連チャンクが0件またはスコアが閾値未満の場合はLLMを呼ばずに応答
     _RELEVANCE_THRESHOLD = 0.35
     if not relevant_chunks or (relevance_scores and max(relevance_scores) < _RELEVANCE_THRESHOLD):
-        guidance_answer = _generate_guidance_without_rag(
-            course_data, topic_title, body.message, body.history,
+        _log_unanswered_query(current_user["id"], course_id, topic_id, body.message)
+        no_answer = (
+            "申し訳ありませんが、ご質問の内容はこのコースの教材には見つかりませんでした。\n\n"
+            "教材に含まれていない内容についてはお答えできません。\n"
+            "別の表現で質問するか、担当教員にお問い合わせください。"
         )
         _persist_chat_history(
             current_user["id"], course_id, topic_id,
-            body.history, body.message, guidance_answer,
+            body.history, body.message, no_answer,
         )
-        return LearningChatResponse(answer=guidance_answer, course_update=None)
+        return LearningChatResponse(answer=no_answer, course_update=None)
 
     context_parts: list[str] = []
     if relevant_chunks:
@@ -2315,6 +2361,40 @@ def publish_course(
         raise HTTPException(status_code=404, detail="Course not found")
     logger.info("Course %s published by user=%s", course_id, current_user["id"])
     return {"course_id": course_id, "is_published": True}
+
+
+@app.get("/api/admin/courses/{course_id}/unanswered-queries")
+def list_unanswered_queries(
+    course_id: str,
+    current_user: dict = Depends(_require_teacher),
+) -> list[dict]:
+    """コースに紐づくつまづきデータ（RAG未回答クエリ）を返す。TEACHER 以上のみ。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                SELECT uql.id, uql.topic_id, uql.question, uql.asked_at,
+                       u.display_name AS student_name
+                FROM unanswered_query_logs uql
+                JOIN users u ON uql.user_id = u.id
+                WHERE uql.course_id = :course_id
+                ORDER BY uql.asked_at DESC
+                LIMIT 200
+            """),
+            {"course_id": course_id},
+        ).fetchall()
+    finally:
+        session.close()
+    return [
+        {
+            "id": r[0],
+            "topic_id": r[1],
+            "question": r[2],
+            "asked_at": r[3].isoformat() if r[3] else "",
+            "student_name": r[4] or "",
+        }
+        for r in rows
+    ]
 
 
 @app.post("/api/learning/courses/{course_id}/enroll", response_model=LearningCourseOut, status_code=201)

--- a/backend/db/003_unanswered_queries.sql
+++ b/backend/db/003_unanswered_queries.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Migration 003: つまづきデータ蓄積テーブル
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS unanswered_query_logs (
+    id          TEXT PRIMARY KEY,
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    course_id   TEXT NOT NULL,
+    topic_id    TEXT NOT NULL,
+    question    TEXT NOT NULL,
+    asked_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_unanswered_course ON unanswered_query_logs(course_id);
+CREATE INDEX IF NOT EXISTS idx_unanswered_user   ON unanswered_query_logs(user_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/db/init.sql:/docker-entrypoint-initdb.d/01_init.sql
       - ./backend/db/002_a1_a2_a3.sql:/docker-entrypoint-initdb.d/02_a1_a2_a3.sql
+      - ./backend/db/003_unanswered_queries.sql:/docker-entrypoint-initdb.d/03_unanswered_queries.sql
     networks:
       - episteme
     healthcheck:

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -27,6 +27,7 @@
     <div class="admin-tabs" id="adminTabs">
       <button class="admin-tab on" data-tab="materials">教材管理</button>
       <button class="admin-tab" data-tab="course-builder">コース構築</button>
+      <button class="admin-tab" data-tab="stumbles">つまづきデータ</button>
     </div>
 
     <!-- Materials tab -->
@@ -99,6 +100,36 @@
             <button id="cb-approve-btn" class="cb-approve-btn">承認してコースを登録</button>
           </div>
         </div>
+      </div>
+    </div>
+    <!-- Stumbles tab -->
+    <div class="admin-panel" id="tab-stumbles">
+      <div class="admin-section">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+          <h3 class="admin-section-title" style="margin-bottom:0">学生のつまづきデータ</h3>
+          <div style="display:flex;gap:8px;align-items:center">
+            <select id="stumbles-course-select" style="padding:4px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+              <option value="">コースを選択...</option>
+            </select>
+            <button id="refresh-stumbles" class="admin-action-btn">更新</button>
+          </div>
+        </div>
+        <p style="font-size:12px;color:var(--color-text-tertiary);margin-bottom:12px">
+          RAG検索で教材から回答できなかった質問の一覧です。教材の補強やコース改善に活用してください。
+        </p>
+        <table class="admin-table" id="stumbles-table">
+          <thead>
+            <tr>
+              <th>日時</th>
+              <th>学生</th>
+              <th>トピック</th>
+              <th>質問内容</th>
+            </tr>
+          </thead>
+          <tbody id="stumbles-tbody">
+            <tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">コースを選択してください</td></tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -669,6 +669,69 @@
       });
   }
 
+  // ── Stumbles (Unanswered Queries) ──────────────────────────────────
+  function initStumbles() {
+    var select = document.getElementById("stumbles-course-select");
+    var refreshBtn = document.getElementById("refresh-stumbles");
+
+    // コース一覧をセレクトボックスに読み込む
+    apiFetch("/learning/courses")
+      .then(function (res) { return res.json(); })
+      .then(function (courses) {
+        courses.forEach(function (c) {
+          if (c.is_template || c.is_published) {
+            var opt = document.createElement("option");
+            opt.value = c.id;
+            opt.textContent = c.title;
+            select.appendChild(opt);
+          }
+        });
+      })
+      .catch(function () {});
+
+    function loadStumbles() {
+      var courseId = select.value;
+      var tbody = document.getElementById("stumbles-tbody");
+      if (!courseId) {
+        tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">コースを選択してください</td></tr>';
+        return;
+      }
+      tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>';
+      apiFetch("/admin/courses/" + courseId + "/unanswered-queries")
+        .then(function (res) { return res.json(); })
+        .then(function (rows) {
+          if (!rows || rows.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">つまづきデータはまだありません</td></tr>';
+            return;
+          }
+          var html = "";
+          rows.forEach(function (r) {
+            var dt = "";
+            if (r.asked_at) {
+              try {
+                var d = new Date(r.asked_at);
+                dt = d.getFullYear() + "/" + (d.getMonth() + 1) + "/" + d.getDate() + " " +
+                  d.getHours() + ":" + String(d.getMinutes()).padStart(2, "0");
+              } catch (e) { dt = r.asked_at; }
+            }
+            html += "<tr>";
+            html += "<td style='white-space:nowrap'>" + escHtml(dt) + "</td>";
+            html += "<td>" + escHtml(r.student_name) + "</td>";
+            html += "<td>" + escHtml(r.topic_id) + "</td>";
+            html += "<td style='max-width:400px;word-break:break-word'>" + escHtml(r.question) + "</td>";
+            html += "</tr>";
+          });
+          tbody.innerHTML = html;
+        })
+        .catch(function () {
+          tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-danger)">読み込みに失敗しました</td></tr>';
+        });
+    }
+
+    select.addEventListener("change", loadStumbles);
+    refreshBtn.addEventListener("click", loadStumbles);
+  }
+
   // ── Logout ─────────────────────────────────────────────────────────
   function initLogout() {
     document.getElementById("logout-btn").addEventListener("click", function () {
@@ -839,6 +902,7 @@
     initTabs();
     initUpload();
     initCourseBuilder();
+    initStumbles();
     initUserManagement();
     initLogout();
     loadMaterials();


### PR DESCRIPTION
fixes #20

- RAGゼロ件・低スコア時にLLM呼び出しを完全に禁止し、テンプレート応答を返す 従来は _generate_guidance_without_rag でLLMを呼んでいたが、本変更で廃止
- unanswered_query_logs テーブルを追加し、未回答質問を自動記録 カラム: user_id / course_id / topic_id / question / asked_at
- GET /api/admin/courses/{course_id}/unanswered-queries エンドポイントを追加
- 管理画面に「つまづきデータ」タブを追加し、コース別に一覧表示
- _run_migrations() と docker-compose.yml に migration 003 を追加