### PR TITLE
feat: RAGガードレールとつまづきデータ蓄積機能を復元 (fixes #30)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -99,7 +99,7 @@ _bearer = HTTPBearer()
 
 
 def _run_migrations() -> None:
-    """既存DBに対してマイグレーション002（A1/A2/A3）を適用する。IF NOT EXISTS で冪等。"""
+    """既存DBに対してマイグレーション002-003を適用する。IF NOT EXISTS で冪等。"""
     session = _pg_session()
     try:
         # A1: course_builder_sessions テーブル
@@ -134,12 +134,55 @@ def _run_migrations() -> None:
             WHERE is_published = true AND is_template = true
         """))
 
+        # Migration 003: unanswered_query_logs テーブル（つまづきデータ蓄積）
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS unanswered_query_logs (
+                id        TEXT PRIMARY KEY,
+                user_id   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                course_id TEXT NOT NULL,
+                topic_id  TEXT NOT NULL,
+                question  TEXT NOT NULL,
+                asked_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_unanswered_course ON unanswered_query_logs(course_id)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_unanswered_user ON unanswered_query_logs(user_id)"
+        ))
+
         session.commit()
-        logger.info("Migration 002 (A1/A2/A3) applied successfully.")
+        logger.info("Migrations (002 A1/A2/A3, 003 unanswered_queries) applied successfully.")
     except Exception as exc:
         session.rollback()
-        logger.error("Migration 002 failed: %s", exc)
+        logger.error("Migration failed: %s", exc)
         raise
+    finally:
+        session.close()
+
+
+def _log_unanswered_query(user_id: str, course_id: str, topic_id: str, question: str) -> None:
+    """RAG検索で回答できなかった質問をDBに記録する。"""
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO unanswered_query_logs (id, user_id, course_id, topic_id, question)
+                VALUES (:id, CAST(:user_id AS uuid), :course_id, :topic_id, :question)
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "course_id": course_id,
+                "topic_id": topic_id,
+                "question": question,
+            },
+        )
+        session.commit()
+    except Exception as exc:
+        session.rollback()
+        logger.warning("Failed to log unanswered query: %s", exc)
     finally:
         session.close()
 
@@ -938,136 +981,6 @@ _LEARNING_SYSTEM_PROMPT = """あなたは素粒子物理学・場の量子論を
 - 回答の末尾に深掘りできるトピックを `[〇〇について詳しく聞く]` の形式で提示（必ずこのフォーマットを使用）"""
 
 
-_GUIDANCE_SYSTEM_PROMPT = """あなたは素粒子物理学・場の量子論を専門とする学習者の深い理解を支援する家庭教師です。
-現在、教材テキストの検索結果がありません。しかし、コースの構造情報（章構成、トピック一覧、概念マップ、登録教材）は利用可能です。
-以下の方針で回答してください：
-1. コースの構造情報を使って、学習の道筋やトピックの概要を案内してください。
-2. 「何から学べばよいか」「このトピックの概要は？」といったメタ的な質問には、コースの章順序・トピック依存関係に基づいて具体的に案内してください。
-3. 数式の詳細な導出や教材の具体的な内容についての質問には、「この点は教材を参照する必要があります」と正直に伝え、どの章やトピックを参照すべきか示してください。
-4. 説明の最後に、関連する概念へのドリルダウン選択肢を `[〇〇について詳しく聞く]` の形式で提示してください。
-**フォーマット:**
-- 数式は必ず LaTeX 記法で記述（インラインは `$...$`、ディスプレイは `$$...$$`）
-- 回答の末尾に深掘りできるトピックを `[〇〇について詳しく聞く]` の形式で提示"""
-
-
-def _generate_guidance_without_rag(
-    course_data: dict,
-    topic_title: str,
-    user_message: str,
-    history: list[dict],
-) -> str:
-    """RAGチャンクが見つからない場合に、コース構造情報を使ってLLMに学習ガイダンスを生成させる。"""
-    course_title = course_data.get("title", "")
-    chapters = course_data.get("chapters", [])
-    topics = course_data.get("topics", [])
-    concepts = course_data.get("concepts", [])
-    sources = course_data.get("sources", [])
-
-    structure_parts: list[str] = []
-
-    # 章構成
-    if chapters:
-        chapter_lines = []
-        for i, ch in enumerate(chapters):
-            chapter_topics = [t for t in topics if t.get("chapter_index") == i]
-            topic_names = ", ".join(t.get("title", "") for t in chapter_topics)
-            status = ch.get("status", "locked")
-            chapter_lines.append(f"  第{i+1}章: {ch.get('title', '')} (状態: {status})")
-            if topic_names:
-                chapter_lines.append(f"    トピック: {topic_names}")
-        structure_parts.append("## コースの章構成\n" + "\n".join(chapter_lines))
-
-    # 概念マップ
-    if concepts:
-        concept_lines = []
-        for c in concepts:
-            name = c.get("name", "")
-            status = c.get("status", "future")
-            children = c.get("children", [])
-            line = f"  - {name} (状態: {status})"
-            if children:
-                line += f" → 子概念: {', '.join(children)}"
-            concept_lines.append(line)
-        structure_parts.append("## 概念マップ\n" + "\n".join(concept_lines))
-
-    # 登録教材
-    if sources:
-        source_lines = []
-        for s in sources:
-            title = s.get("title", "")
-            subtitle = s.get("subtitle", "")
-            info = title
-            if subtitle:
-                info += f" — {subtitle}"
-            source_lines.append(f"  - {info}")
-        structure_parts.append("## 登録済み教材\n" + "\n".join(source_lines))
-
-    # 現在のトピックの前後関係
-    current_topic_info = None
-    prev_topic = None
-    next_topic = None
-    for i, t in enumerate(topics):
-        if t.get("title") == topic_title or t.get("id") == topic_title:
-            current_topic_info = t
-            if i > 0:
-                prev_topic = topics[i - 1]
-            if i < len(topics) - 1:
-                next_topic = topics[i + 1]
-            break
-
-    if current_topic_info:
-        nav_info = f"## 現在のトピック: {topic_title}\n"
-        if prev_topic:
-            nav_info += f"  前のトピック: {prev_topic.get('title', '')}\n"
-        if next_topic:
-            nav_info += f"  次のトピック: {next_topic.get('title', '')}\n"
-        prereqs = current_topic_info.get("prerequisites", [])
-        if prereqs:
-            nav_info += f"  前提知識: {', '.join(p.get('name', '') for p in prereqs)}\n"
-        structure_parts.append(nav_info)
-
-    context_block = "\n\n".join(structure_parts) if structure_parts else "(コース構造情報なし)"
-
-    messages: list[dict] = [
-        {"role": "system", "content": _GUIDANCE_SYSTEM_PROMPT},
-        {"role": "user", "content": (
-            f"コース: {course_title}\n"
-            f"現在のトピック: {topic_title}\n\n"
-            f"{context_block}\n\n"
-            "上記のコース構造情報を使って質問に回答してください。\n"
-            "教材の具体的なテキストは現在利用できませんが、コースの構成に基づいて学習の案内ができます。"
-        )},
-        {"role": "assistant", "content": (
-            f"了解しました。「{topic_title}」について、コースの構成情報を参照しながらご案内します。"
-        )},
-    ]
-    for turn in history:
-        messages.append({"role": turn["role"], "content": turn["content"]})
-    messages.append({"role": "user", "content": user_message})
-
-    try:
-        client = _openai()
-        response = client.chat.completions.create(
-            model=_OPENAI_ANALYSIS_MODEL,
-            messages=messages,
-            temperature=0.4,
-        )
-        return response.choices[0].message.content or ""
-    except Exception as exc:
-        logger.exception("Guidance generation failed for topic %s", topic_title)
-        first_topic = topics[0].get("title", "") if topics else "最初のトピック"
-        return (
-            f"「{topic_title}」の学習を始めましょう。\n\n"
-            f"このコース「{course_title}」では以下の順序で学習を進めることをお勧めします：\n\n"
-            + "\n".join(
-                f"**第{i+1}章: {ch.get('title', '')}**"
-                for i, ch in enumerate(chapters)
-            )
-            + f"\n\nまずは最初のトピック「{first_topic}」から始めてみましょう。\n\n"
-            + f"[{first_topic}について詳しく聞く]"
-        )
-
-
 @app.post(
     "/api/learning/courses/{course_id}/topics/{topic_id}/chat",
     response_model=LearningChatResponse,
@@ -1115,17 +1028,20 @@ def learning_chat(
     _RELEVANCE_THRESHOLD = 0.35
     chunk_results = _search_chunks_with_metadata(body.message, top_k=8)
 
-    # 3a. フェイルセーフ: 閾値以上のチャンクが0件の場合はLLMをスキップ
+    # 3a. フェイルセーフ: 閾値以上のチャンクが0件の場合はLLMを呼ばずテンプレート返却
     above_threshold = [r for r in chunk_results if r["score"] >= _RELEVANCE_THRESHOLD]
     if not above_threshold:
-        guidance_answer = _generate_guidance_without_rag(
-            course_data, topic_title, body.message, body.history,
+        _log_unanswered_query(current_user["id"], course_id, topic_id, body.message)
+        no_answer = (
+            "申し訳ありませんが、ご質問の内容はシステムに登録された教材には見つかりませんでした。\n\n"
+            "教材に含まれていない内容についてはお答えできません。\n"
+            "別の表現で質問するか、担当教員にお問い合わせください。"
         )
         _persist_chat_history(
             current_user["id"], course_id, topic_id,
-            body.history, body.message, guidance_answer,
+            body.history, body.message, no_answer,
         )
-        return LearningChatResponse(answer=guidance_answer, course_update=None)
+        return LearningChatResponse(answer=no_answer, course_update=None)
 
     # 出典情報を付けてコンテキストブロックを構築
     cited_chunks = []
@@ -2344,6 +2260,40 @@ def publish_course(
         raise HTTPException(status_code=404, detail="Course not found")
     logger.info("Course %s published by user=%s", course_id, current_user["id"])
     return {"course_id": course_id, "is_published": True}
+
+
+@app.get("/api/admin/courses/{course_id}/unanswered-queries")
+def list_unanswered_queries(
+    course_id: str,
+    current_user: dict = Depends(_require_teacher),
+) -> list[dict]:
+    """コースに紐づくつまづきデータ（RAG未回答クエリ）を返す。TEACHER 以上のみ。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                SELECT uql.id, uql.topic_id, uql.question, uql.asked_at,
+                       u.display_name AS student_name
+                FROM unanswered_query_logs uql
+                JOIN users u ON uql.user_id = u.id
+                WHERE uql.course_id = :course_id
+                ORDER BY uql.asked_at DESC
+                LIMIT 200
+            """),
+            {"course_id": course_id},
+        ).fetchall()
+    finally:
+        session.close()
+    return [
+        {
+            "id": r[0],
+            "topic_id": r[1],
+            "question": r[2],
+            "asked_at": r[3].isoformat() if r[3] else "",
+            "student_name": r[4] or "",
+        }
+        for r in rows
+    ]
 
 
 @app.post("/api/learning/courses/{course_id}/enroll", response_model=LearningCourseOut, status_code=201)

--- a/backend/db/003_unanswered_queries.sql
+++ b/backend/db/003_unanswered_queries.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- Migration 003: つまづきデータ蓄積テーブル
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS unanswered_query_logs (
+    id          TEXT PRIMARY KEY,
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    course_id   TEXT NOT NULL,
+    topic_id    TEXT NOT NULL,
+    question    TEXT NOT NULL,
+    asked_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_unanswered_course ON unanswered_query_logs(course_id);
+CREATE INDEX IF NOT EXISTS idx_unanswered_user   ON unanswered_query_logs(user_id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/db/init.sql:/docker-entrypoint-initdb.d/01_init.sql
       - ./backend/db/002_a1_a2_a3.sql:/docker-entrypoint-initdb.d/02_a1_a2_a3.sql
+      - ./backend/db/003_unanswered_queries.sql:/docker-entrypoint-initdb.d/03_unanswered_queries.sql
     networks:
       - episteme
     healthcheck:

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -27,6 +27,7 @@
     <div class="admin-tabs" id="adminTabs">
       <button class="admin-tab on" data-tab="materials">教材管理</button>
       <button class="admin-tab" data-tab="course-builder">コース構築</button>
+      <button class="admin-tab" data-tab="stumbles">つまづきデータ</button>
     </div>
 
     <!-- Materials tab -->
@@ -99,6 +100,36 @@
             <button id="cb-approve-btn" class="cb-approve-btn">承認してコースを登録</button>
           </div>
         </div>
+      </div>
+    </div>
+    <!-- Stumbles tab -->
+    <div class="admin-panel" id="tab-stumbles">
+      <div class="admin-section">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+          <h3 class="admin-section-title" style="margin-bottom:0">学生のつまづきデータ</h3>
+          <div style="display:flex;gap:8px;align-items:center">
+            <select id="stumbles-course-select" style="padding:4px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+              <option value="">コースを選択...</option>
+            </select>
+            <button id="refresh-stumbles" class="admin-action-btn">更新</button>
+          </div>
+        </div>
+        <p style="font-size:12px;color:var(--color-text-tertiary);margin-bottom:12px">
+          RAG検索で教材から回答できなかった質問の一覧です。教材の補強やコース改善に活用してください。
+        </p>
+        <table class="admin-table" id="stumbles-table">
+          <thead>
+            <tr>
+              <th>日時</th>
+              <th>学生</th>
+              <th>トピック</th>
+              <th>質問内容</th>
+            </tr>
+          </thead>
+          <tbody id="stumbles-tbody">
+            <tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">コースを選択してください</td></tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -669,6 +669,66 @@
       });
   }
 
+  // ── Stumbles (Unanswered Queries) ──────────────────────────────────
+  function initStumbles() {
+    var select = document.getElementById("stumbles-course-select");
+    var refreshBtn = document.getElementById("refresh-stumbles");
+
+    apiFetch("/learning/courses")
+      .then(function (res) { return res.json(); })
+      .then(function (courses) {
+        courses.forEach(function (c) {
+          var opt = document.createElement("option");
+          opt.value = c.id;
+          opt.textContent = c.title + (c.is_published ? " [公開中]" : "");
+          select.appendChild(opt);
+        });
+      })
+      .catch(function () {});
+
+    function loadStumbles() {
+      var courseId = select.value;
+      var tbody = document.getElementById("stumbles-tbody");
+      if (!courseId) {
+        tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">コースを選択してください</td></tr>';
+        return;
+      }
+      tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>';
+      apiFetch("/admin/courses/" + courseId + "/unanswered-queries")
+        .then(function (res) { return res.json(); })
+        .then(function (rows) {
+          if (!rows || rows.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">つまづきデータはまだありません</td></tr>';
+            return;
+          }
+          var html = "";
+          rows.forEach(function (r) {
+            var dt = "";
+            if (r.asked_at) {
+              try {
+                var d = new Date(r.asked_at);
+                dt = d.getFullYear() + "/" + (d.getMonth() + 1) + "/" + d.getDate() + " " +
+                  d.getHours() + ":" + String(d.getMinutes()).padStart(2, "0");
+              } catch (e) { dt = r.asked_at; }
+            }
+            html += "<tr>";
+            html += "<td style='white-space:nowrap'>" + escHtml(dt) + "</td>";
+            html += "<td>" + escHtml(r.student_name) + "</td>";
+            html += "<td>" + escHtml(r.topic_id) + "</td>";
+            html += "<td style='max-width:400px;word-break:break-word'>" + escHtml(r.question) + "</td>";
+            html += "</tr>";
+          });
+          tbody.innerHTML = html;
+        })
+        .catch(function () {
+          tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-danger)">読み込みに失敗しました</td></tr>';
+        });
+    }
+
+    select.addEventListener("change", loadStumbles);
+    refreshBtn.addEventListener("click", loadStumbles);
+  }
+
   // ── Logout ─────────────────────────────────────────────────────────
   function initLogout() {
     document.getElementById("logout-btn").addEventListener("click", function () {
@@ -839,6 +899,7 @@
     initTabs();
     initUpload();
     initCourseBuilder();
+    initStumbles();
     initUserManagement();
     initLogout();
     loadMaterials();


### PR DESCRIPTION
- _run_migrations() に Migration 003 (unanswered_query_logs テーブル) を追加
- _log_unanswered_query() ヘルパー関数を追加
- learning_chat のフェイルセーフを変更: 閾値以上チャンクゼロ → LLM呼び出し禁止 + テンプレート応答 + _log_unanswered_query()
- _generate_guidance_without_rag() と _GUIDANCE_SYSTEM_PROMPT を削除
- GET /api/admin/courses/{course_id}/unanswered-queries エンドポイントを追加
- backend/db/003_unanswered_queries.sql マイグレーションファイルを追加
- docker-compose.yml に 003 マイグレーションをマウント
- 管理画面に「つまづきデータ」タブを追加 (admin.html + admin.js)