### PR TITLE
feat: メタ対話ハンドリングと初期サジェストUI (#59)

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -31,7 +31,7 @@ from services import (
     delete_course_data,
     search_chunks_with_metadata,
 )
-from core.llm import generate_text
+from core.llm import generate_text, get_llm_params
 from core.postgres import get_session as _pg_session
 
 logger = logging.getLogger(__name__)
@@ -257,6 +257,54 @@ def enroll_course(
 # Chat (RAG)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Greeting / Meta-dialogue detection
+# ---------------------------------------------------------------------------
+
+_GREETING_PATTERNS = [
+    "こんにちは", "こんばんは", "おはよう", "はじめまして",
+    "よろしくお願い", "学習を始め", "学習を開始", "勉強を始め",
+    "始めたい", "開始したい", "スタート",
+    "第1章の学習を開始する", "前提知識を確認する",
+]
+
+
+def _is_greeting(message: str) -> bool:
+    """メッセージが挨拶・メタ対話かどうかを判定する。"""
+    msg = message.strip()
+    if len(msg) < 30 and any(p in msg for p in _GREETING_PATTERNS):
+        return True
+    return False
+
+
+def _generate_greeting_response(
+    course_title: str, topic_title: str, message: str,
+) -> str:
+    """挨拶・メタ対話に対するLLM応答を生成する (Fast モード)。"""
+    params = get_llm_params("fast")
+    prompt = (
+        f"あなたは「{course_title}」の学習をサポートするAIチューターです。\n"
+        f"学生から「{message}」というメッセージを受け取りました。\n\n"
+        "以下のルールで返答してください:\n"
+        "1. 学生を歓迎し、学習意欲を肯定する短い挨拶をする。\n"
+        f"2. 現在のトピックが「{topic_title}」であることを踏まえ、「まずは〇〇について確認しましょうか？」と最初のステップを提案する。\n"
+        "3. 物理学の具体的な解説はこの時点では行わない。\n"
+    )
+
+    try:
+        return generate_text(
+            messages=[{"role": "user", "content": prompt}],
+            model=params["model"],
+            reasoning_effort=params["reasoning_effort"],
+        )
+    except Exception:
+        logger.warning("Greeting response LLM call failed, returning fallback")
+        return (
+            f"こんにちは！「{course_title}」の学習サポートへようこそ。\n\n"
+            f"現在のトピックは「{topic_title}」です。まずはこのトピックについて確認しましょうか？"
+        )
+
+
 _LEARNING_SYSTEM_PROMPT = """あなたは素粒子物理学・場の量子論を専門とする学習者の深い理解を支援する家庭教師です。
 以下の原則に従ってください。
 
@@ -342,7 +390,17 @@ def learning_chat(
             break
     topic_title = topic_info["title"] if topic_info else topic_id
 
-    # 2. Adaptive Routing: 前提知識の自動判定
+    # 2. Greeting / メタ対話のバイパス: RAG検索をスキップ
+    course_title = course_data.get("title", course_id)
+    if _is_greeting(body.message):
+        greeting_answer = _generate_greeting_response(course_title, topic_title, body.message)
+        persist_chat_history(
+            current_user["id"], course_id, topic_id,
+            body.history, body.message, greeting_answer,
+        )
+        return LearningChatResponse(answer=greeting_answer, course_update=None)
+
+    # 3. Adaptive Routing: 前提知識の自動判定
     prerequisite_intervention = check_prerequisites(
         current_user["id"], course_id, course_data, topic_title, body.message
     )
@@ -353,11 +411,11 @@ def learning_chat(
         )
         return LearningChatResponse(answer=prerequisite_intervention, course_update=None)
 
-    # 3. RAG: システム全域のチャンクを検索（出典メタデータ付き）
+    # 4. RAG: システム全域のチャンクを検索（出典メタデータ付き）
     _RELEVANCE_THRESHOLD = 0.35
     chunk_results = search_chunks_with_metadata(body.message, top_k=8)
 
-    # 3a. フェイルセーフ: 閾値以上のチャンクが0件の場合
+    # 4a. フェイルセーフ: 閾値以上のチャンクが0件の場合
     above_threshold = [r for r in chunk_results if r["score"] >= _RELEVANCE_THRESHOLD]
     if not above_threshold:
         log_unanswered_query(current_user["id"], course_id, topic_id, body.message)
@@ -383,8 +441,7 @@ def learning_chat(
 
     context_block = "\n\n".join(context_parts)
 
-    # 5. LLM メッセージ構築
-    course_title = course_data.get("title", course_id)
+    # 6. LLM メッセージ構築
     messages: list[dict] = [
         {"role": "system", "content": _LEARNING_SYSTEM_PROMPT},
         {"role": "user", "content": (
@@ -402,21 +459,21 @@ def learning_chat(
         messages.append({"role": turn["role"], "content": turn["content"]})
     messages.append({"role": "user", "content": body.message})
 
-    # 6. LLM 呼び出し
+    # 7. LLM 呼び出し
     try:
         answer = generate_text(messages=messages, temperature=0.3)
     except Exception as exc:
         logger.exception("Learning chat LLM call failed for topic %s", topic_id)
         raise HTTPException(status_code=500, detail=f"Chat failed: {exc}") from exc
 
-    # 7. 誤解検出
+    # 8. 誤解検出
     course_update = None
     if topic_info and any(kw in answer for kw in ["訂正：", "訂正:", "【訂正】"]):
         course_update = detect_and_record_misconception(
             current_user["id"], course_id, course_data, topic_id, body.message, answer
         )
 
-    # 8. チャット履歴を永続化
+    # 9. チャット履歴を永続化
     persist_chat_history(
         current_user["id"], course_id, topic_id,
         body.history, body.message, answer,

--- a/backend/core/graphs/state.py
+++ b/backend/core/graphs/state.py
@@ -22,7 +22,7 @@ class StudentState(TypedDict, total=False):
     user_id: str
 
     # --- QueryAnalyzer 出力 ---
-    intent: str  # "factual" | "conceptual" | "misconception" | "formula" | "other"
+    intent: str  # "greeting" | "factual" | "conceptual" | "misconception" | "formula" | "other"
     search_keywords: list[str]
 
     # --- Retrieval 出力 ---

--- a/backend/core/graphs/student_graph.py
+++ b/backend/core/graphs/student_graph.py
@@ -2,7 +2,8 @@
 
 ワークフロー:
   QueryAnalyzer (Fast)
-    → Retrieval (LLM不使用)
+    → [greeting] → GreetingResponse (Fast) → FormatGuard → 最終出力
+    → [その他] → Retrieval (LLM不使用)
       → [チャンク0件] → 範囲外エラー応答で終了
       → [チャンクあり] → PedagogicalEval (Standard)
         → [誤解 or 複雑な数式] → GenerateDeep (Deep)
@@ -42,6 +43,7 @@ def query_analyzer_node(state: StudentState) -> dict[str, Any]:
         '{"intent": "<factual|conceptual|misconception|formula|other>", '
         '"search_keywords": ["keyword1", "keyword2", ...]}\n\n'
         "intent の判定基準:\n"
+        "- greeting: 挨拶、学習の開始・終了、システムへの一般的な要望（例：「学習を始めたい」「こんにちは」「よろしくお願いします」）\n"
         "- factual: 事実・定義を問う質問\n"
         "- conceptual: 概念の理解・関係性を問う質問\n"
         "- misconception: 誤った理解を含む質問\n"
@@ -66,6 +68,40 @@ def query_analyzer_node(state: StudentState) -> dict[str, Any]:
             "intent": "other",
             "search_keywords": [question],
         }
+
+
+def greeting_response_node(state: StudentState) -> dict[str, Any]:
+    """挨拶や学習開始の要求に対する応答 (Fast モード)。RAG検索は行わない。"""
+    params = get_llm_params("fast")
+    course_title = state.get("course_title", "未選択コース")
+    topic_title = state.get("topic_title", "最初のトピック")
+
+    prompt = (
+        f"あなたは「{course_title}」の学習をサポートするAIチューターです。\n"
+        f"学生から「{state['question']}」というメッセージを受け取りました。\n\n"
+        "以下のルールで返答してください:\n"
+        "1. 学生を歓迎し、学習意欲を肯定する短い挨拶をする。\n"
+        f"2. 現在のトピックが「{topic_title}」であることを踏まえ、「まずは〇〇について確認しましょうか？」と最初のステップを提案する。\n"
+        "3. 物理学の具体的な解説はこの時点では行わない。\n"
+    )
+
+    try:
+        answer = generate_text(
+            messages=[{"role": "user", "content": prompt}],
+            model=params["model"],
+            reasoning_effort=params["reasoning_effort"],
+        )
+        return {"raw_answer": answer}
+    except Exception:
+        logger.warning("GreetingResponse LLM call failed, returning fallback")
+        return {"raw_answer": "こんにちは！学習を始めましょう。まずはどのトピックから進めますか？"}
+
+
+def _route_after_analyzer(state: StudentState) -> str:
+    """QueryAnalyzer の直後に分岐: greeting ならRAGをスキップ。"""
+    if state.get("intent") == "greeting":
+        return "greeting"
+    return "retrieval"
 
 
 def retrieval_node(state: StudentState) -> dict[str, Any]:
@@ -280,6 +316,7 @@ def build_student_graph() -> StateGraph:
 
     # ノード登録
     graph.add_node("query_analyzer", query_analyzer_node)
+    graph.add_node("greeting_response", greeting_response_node)
     graph.add_node("retrieval", retrieval_node)
     graph.add_node("no_chunks_response", no_chunks_response_node)
     graph.add_node("pedagogical_eval", pedagogical_eval_node)
@@ -287,9 +324,19 @@ def build_student_graph() -> StateGraph:
     graph.add_node("generate_deep", generate_deep_node)
     graph.add_node("format_guard", format_guard_node)
 
-    # エッジ: エントリ → QueryAnalyzer → Retrieval
+    # エッジ: エントリ → QueryAnalyzer → (greeting | retrieval)
     graph.set_entry_point("query_analyzer")
-    graph.add_edge("query_analyzer", "retrieval")
+    graph.add_conditional_edges(
+        "query_analyzer",
+        _route_after_analyzer,
+        {
+            "greeting": "greeting_response",
+            "retrieval": "retrieval",
+        },
+    )
+
+    # GreetingResponse → FormatGuard へ合流
+    graph.add_edge("greeting_response", "format_guard")
 
     # 条件分岐: Retrieval → (no_chunks | has_chunks)
     graph.add_conditional_edges(

--- a/backend/tests/test_greeting_meta_dialogue.py
+++ b/backend/tests/test_greeting_meta_dialogue.py
@@ -1,0 +1,196 @@
+"""Issue #59: メタ対話（挨拶・学習開始）ハンドリングのテスト。
+
+- 挨拶パターン判定ロジック
+- greeting_response_node のフォールバック動作
+- _route_after_analyzer の分岐ロジック
+- StudentGraph にGreetingResponseノードが組み込まれていること
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. 挨拶パターン判定テスト
+# ---------------------------------------------------------------------------
+
+# learning.py の _is_greeting / _GREETING_PATTERNS と同等のロジックを
+# 直接テストする（learning.py は FastAPI + 多数の依存を import するため）。
+
+_GREETING_PATTERNS = [
+    "こんにちは", "こんばんは", "おはよう", "はじめまして",
+    "よろしくお願い", "学習を始め", "学習を開始", "勉強を始め",
+    "始めたい", "開始したい", "スタート",
+    "第1章の学習を開始する", "前提知識を確認する",
+]
+
+
+def _is_greeting(message: str) -> bool:
+    msg = message.strip()
+    if len(msg) < 30 and any(p in msg for p in _GREETING_PATTERNS):
+        return True
+    return False
+
+
+class TestIsGreeting:
+    """メタ対話パターンの判定ロジック。"""
+
+    def test_greeting_konnichiwa(self):
+        assert _is_greeting("こんにちは") is True
+
+    def test_greeting_start_learning(self):
+        assert _is_greeting("学習を始めたい") is True
+
+    def test_greeting_hajimemashite(self):
+        assert _is_greeting("はじめまして") is True
+
+    def test_greeting_yoroshiku(self):
+        assert _is_greeting("よろしくお願いします") is True
+
+    def test_greeting_start_chapter(self):
+        assert _is_greeting("第1章の学習を開始する") is True
+
+    def test_greeting_konbanwa(self):
+        assert _is_greeting("こんばんは") is True
+
+    def test_greeting_start_button_text(self):
+        assert _is_greeting("スタート") is True
+
+    def test_not_greeting_physics_question(self):
+        assert _is_greeting("ゲージ対称性とは何ですか？") is False
+
+    def test_not_greeting_formula_question(self):
+        assert _is_greeting("シュレーディンガー方程式を導出してください") is False
+
+    def test_not_greeting_long_message(self):
+        """長いメッセージは挨拶とみなさない（30文字超）。"""
+        long_msg = "こんにちは、今日はゲージ対称性について詳しく学びたいのですが、具体的にはどのような内容から始めればよいでしょうか？"
+        assert _is_greeting(long_msg) is False
+
+    def test_empty_string(self):
+        assert _is_greeting("") is False
+
+    def test_whitespace_only(self):
+        assert _is_greeting("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# 2. greeting_response_node テスト
+# ---------------------------------------------------------------------------
+
+
+class TestGreetingResponseNode:
+    """GreetingResponse ノードの動作テスト。"""
+
+    def test_fallback_on_llm_failure(self):
+        """LLM呼び出し失敗時にフォールバックメッセージを返すこと。"""
+        from core.graphs.student_graph import greeting_response_node
+
+        with patch("core.graphs.student_graph.generate_text", side_effect=Exception("LLM error")):
+            result = greeting_response_node({
+                "question": "こんにちは",
+                "course_title": "量子力学入門",
+                "topic_title": "波動関数",
+            })
+            assert "raw_answer" in result
+            assert "学習を始めましょう" in result["raw_answer"]
+
+    def test_returns_raw_answer_on_success(self):
+        """LLM呼び出し成功時にraw_answerを返すこと。"""
+        from core.graphs.student_graph import greeting_response_node
+
+        mock_response = "ようこそ！まずは波動関数について確認しましょうか？"
+        with patch("core.graphs.student_graph.generate_text", return_value=mock_response):
+            result = greeting_response_node({
+                "question": "学習を始めたい",
+                "course_title": "量子力学入門",
+                "topic_title": "波動関数",
+            })
+            assert result["raw_answer"] == mock_response
+
+    def test_uses_default_titles_when_missing(self):
+        """コース・トピックタイトルが未設定時にデフォルト値を使うこと。"""
+        from core.graphs.student_graph import greeting_response_node
+
+        with patch("core.graphs.student_graph.generate_text", return_value="テスト") as mock_gen:
+            greeting_response_node({"question": "こんにちは"})
+            prompt = mock_gen.call_args[1]["messages"][0]["content"]
+            assert "未選択コース" in prompt
+            assert "最初のトピック" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 3. _route_after_analyzer テスト
+# ---------------------------------------------------------------------------
+
+
+class TestRouteAfterAnalyzer:
+    """QueryAnalyzer 後の分岐ロジック。"""
+
+    def test_greeting_routes_to_greeting(self):
+        from core.graphs.student_graph import _route_after_analyzer
+
+        assert _route_after_analyzer({"intent": "greeting"}) == "greeting"
+
+    def test_factual_routes_to_retrieval(self):
+        from core.graphs.student_graph import _route_after_analyzer
+
+        assert _route_after_analyzer({"intent": "factual"}) == "retrieval"
+
+    def test_other_routes_to_retrieval(self):
+        from core.graphs.student_graph import _route_after_analyzer
+
+        assert _route_after_analyzer({"intent": "other"}) == "retrieval"
+
+    def test_conceptual_routes_to_retrieval(self):
+        from core.graphs.student_graph import _route_after_analyzer
+
+        assert _route_after_analyzer({"intent": "conceptual"}) == "retrieval"
+
+    def test_missing_intent_routes_to_retrieval(self):
+        from core.graphs.student_graph import _route_after_analyzer
+
+        assert _route_after_analyzer({}) == "retrieval"
+
+
+# ---------------------------------------------------------------------------
+# 4. StudentGraph 構造テスト (greeting ノード統合)
+# ---------------------------------------------------------------------------
+
+
+class TestStudentGraphGreetingIntegration:
+    """StudentGraph に greeting_response ノードが正しく組み込まれていること。"""
+
+    @pytest.fixture()
+    def graph(self):
+        from core.graphs.student_graph import build_student_graph
+
+        return build_student_graph()
+
+    def test_graph_compiles_with_greeting(self, graph):
+        """greeting ノード追加後もグラフがコンパイルできること。"""
+        assert graph is not None
+
+    def test_query_analyzer_detects_greeting(self):
+        """QueryAnalyzer が greeting インテントを返すこと。"""
+        from core.graphs.student_graph import query_analyzer_node
+
+        mock_response = json.dumps({"intent": "greeting", "search_keywords": []})
+        with patch("core.graphs.student_graph.generate_text", return_value=mock_response):
+            result = query_analyzer_node({"question": "こんにちは"})
+            assert result["intent"] == "greeting"
+            assert result["search_keywords"] == []
+
+    def test_query_analyzer_non_greeting(self):
+        """通常の質問では greeting 以外のインテントを返すこと。"""
+        from core.graphs.student_graph import query_analyzer_node
+
+        mock_response = json.dumps({"intent": "conceptual", "search_keywords": ["ゲージ対称性"]})
+        with patch("core.graphs.student_graph.generate_text", return_value=mock_response):
+            result = query_analyzer_node({"question": "ゲージ対称性とは？"})
+            assert result["intent"] == "conceptual"
+            assert result["search_keywords"] == ["ゲージ対称性"]

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -294,6 +294,36 @@ body {
   border-color: var(--color-border-info);
 }
 
+/* Initial suggestion buttons */
+.initial-suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 12px 0 8px 40px;
+}
+
+.initial-suggest-btn {
+  font-size: 13px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: var(--color-background-secondary);
+  border: 1px solid var(--color-border-info);
+  cursor: pointer;
+  color: var(--color-text-info);
+  transition: all 0.15s;
+  font-family: inherit;
+  text-align: left;
+}
+
+.initial-suggest-btn::before {
+  content: "\1F449 ";
+}
+
+.initial-suggest-btn:hover {
+  background: var(--color-background-info);
+  border-color: var(--color-text-info);
+}
+
 /* ── Input area ─────────────────────────────────────────────────── */
 .ia {
   display: flex;

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -221,6 +221,30 @@
   }
 
   // ── Render: Chat ───────────────────────────────────────────────────
+  function _getFirstTopicTitle() {
+    if (!state.course || !state.currentTopicId) return null;
+    var topic = (state.course.topics || []).find(function (t) { return t.id === state.currentTopicId; });
+    return topic ? topic.title : null;
+  }
+
+  function _renderInitialSuggestions() {
+    var courseTitle = state.course ? escHtml(state.course.title || "") : "";
+    var topicTitle = _getFirstTopicTitle();
+    var topicLabel = topicTitle ? escHtml(topicTitle) : "最初のトピック";
+
+    var html = '<div class="mg ai">';
+    html += "「" + courseTitle + "」の学習サポートへようこそ！<br>";
+    html += "現在のあなたのレベルと前提知識に合わせてサポートします。何から始めますか？";
+    html += "</div>";
+    html += '<div class="initial-suggestions">';
+    html += '<button class="suggest-btn initial-suggest-btn" data-suggest="' + topicLabel + 'の学習を開始する">';
+    html += topicLabel + "の学習を開始する</button>";
+    html += '<button class="suggest-btn initial-suggest-btn" data-suggest="このコースに必要な前提知識を確認する">';
+    html += "このコースに必要な前提知識を確認する</button>";
+    html += "</div>";
+    return html;
+  }
+
   function renderChat() {
     const ca = document.getElementById("chat-area");
     if (!state.course || !state.currentTopicId) {
@@ -229,6 +253,12 @@
     }
 
     let html = "";
+
+    // 初期状態（チャット履歴なし）ならサジェストUIを表示
+    if (state.chatMessages.length === 0 && !state.sending) {
+      html += _renderInitialSuggestions();
+    }
+
     state.chatMessages.forEach(function (msg) {
       if (msg.role === "user") {
         html += '<div class="mg usr">' + escHtml(msg.content) + "</div>";
@@ -244,7 +274,7 @@
     ca.innerHTML = html;
     ca.scrollTop = ca.scrollHeight;
 
-    // Bind suggest buttons (drill-down)
+    // Bind suggest buttons (drill-down + initial suggestions)
     ca.querySelectorAll(".suggest-btn").forEach(function (btn) {
       btn.addEventListener("click", function () {
         var suggest = this.getAttribute("data-suggest") || this.textContent.replace(/\s*↗$/, "");


### PR DESCRIPTION
## Summary

- **バックエンド**: `QueryAnalyzer` に `greeting` インテントを追加し、挨拶・学習開始メッセージでRAG検索をスキップする `greeting_response_node` バイパスルートを実装
- **バックエンド**: `learning.py` チャットエンドポイントに `_is_greeting()` パターンマッチによるメタ対話検出を追加し、LLM Fast モードで案内文を即座に返す
- **フロントエンド**: チャット初期状態（履歴なし）に「学習を開始する」「前提知識を確認する」サジェストボタンを表示

Closes #59

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/core/graphs/student_graph.py` | `greeting_response_node`, `_route_after_analyzer` 追加、グラフ分岐更新 |
| `backend/core/graphs/state.py` | `intent` コメントに `greeting` 追加 |
| `backend/api/routes/learning.py` | `_is_greeting()`, `_generate_greeting_response()` 追加、チャットフローにバイパス挿入 |
| `frontend/public/js/app.js` | `_renderInitialSuggestions()` 追加、`renderChat()` に初期サジェスト表示 |
| `frontend/public/css/styles.css` | `.initial-suggestions`, `.initial-suggest-btn` スタイル追加 |
| `backend/tests/test_greeting_meta_dialogue.py` | 23件のテスト新規追加 |

## Test plan

- [x] `pytest tests/test_greeting_meta_dialogue.py` — 23件全パス
- [ ] 「こんにちは」「学習を始めたい」送信時にRAGエラーにならず歓迎メッセージが返ること
- [ ] 「ゲージ対称性とは？」など物理の質問は通常のRAGルートで処理されること
- [ ] チャット画面初期表示でサジェストボタンが表示され、クリックで送信されること

https://claude.ai/code/session_01DB6Q6iLXGy47tDVzxcsiiE