### PR TITLE
feat: 教材処理パイプラインの非同期化とポーリングUI実装

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -179,8 +179,29 @@ def _run_migrations() -> None:
             "CREATE INDEX IF NOT EXISTS idx_reextraction_status ON reextraction_jobs(status)"
         ))
 
+        # Migration 005: background_tasks テーブル (Issue #63)
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS background_tasks (
+                id            TEXT PRIMARY KEY,
+                task_type     TEXT NOT NULL DEFAULT 'material_processing',
+                status        TEXT NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+                created_by    UUID REFERENCES users(id) ON DELETE SET NULL,
+                result_data   JSONB,
+                error_message TEXT,
+                created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_bg_tasks_status ON background_tasks(status)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_bg_tasks_created_by ON background_tasks(created_by)"
+        ))
+
         session.commit()
-        logger.info("Migrations (002-004) applied successfully.")
+        logger.info("Migrations (002-005) applied successfully.")
 
         # Seed builtin schema types/predicates
         from core.schema_registry import seed_builtin_schema

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -21,6 +21,7 @@ from dependencies import (
 )
 from schemas import (
     ApproveWithScopeRequest,
+    BackgroundTaskOut,
     CourseBuilderChatRequest,
     CourseBuilderChatResponse,
     CourseBuilderSessionCreate,
@@ -38,6 +39,8 @@ from schemas import (
 from services import (
     _material_lock,
     _material_status,
+    create_background_task,
+    get_background_task,
     process_material_background,
     save_cb_session,
 )
@@ -67,12 +70,15 @@ router = APIRouter(prefix="/api/admin", tags=["Admin"])
 # ---------------------------------------------------------------------------
 
 
-@router.post("/materials/upload", response_model=MaterialOut, status_code=202)
+@router.post("/materials/upload", status_code=202)
 def upload_material(
     file: UploadFile = File(...),
     current_user: dict = Depends(_require_teacher),
-) -> MaterialOut:
-    """PDF教材をアップロードし、バックグラウンドでグラフ化処理を開始する。"""
+) -> dict:
+    """PDF教材をアップロードし、バックグラウンドでグラフ化処理を開始する。
+
+    即座に task_id を返却し、処理完了はポーリングで確認する。
+    """
     import datetime
 
     if not file.filename or not file.filename.lower().endswith(".pdf"):
@@ -84,6 +90,7 @@ def upload_material(
 
     material_id = str(uuid.uuid4())[:12]
     doc_id = uuid.uuid4()
+    task_id = str(uuid.uuid4())[:12]
     now = datetime.datetime.utcnow().isoformat()
 
     session = _pg_session()
@@ -108,25 +115,28 @@ def upload_material(
     finally:
         session.close()
 
+    create_background_task(task_id, "material_processing", current_user["id"])
+
     thread = threading.Thread(
         target=process_material_background,
-        args=(material_id, str(doc_id), file.filename, pdf_bytes),
+        args=(material_id, str(doc_id), file.filename, pdf_bytes, task_id),
         daemon=True,
     )
     thread.start()
 
     logger.info(
-        "Material upload accepted: %s (%s) by user=%s",
-        material_id, file.filename, current_user["id"],
+        "Material upload accepted: %s (%s) task=%s by user=%s",
+        material_id, file.filename, task_id, current_user["id"],
     )
 
-    return MaterialOut(
-        material_id=material_id,
-        filename=file.filename,
-        title=os.path.splitext(file.filename)[0],
-        status="uploaded",
-        uploaded_at=now,
-    )
+    return {
+        "task_id": task_id,
+        "material_id": material_id,
+        "filename": file.filename,
+        "title": os.path.splitext(file.filename)[0],
+        "status": "pending",
+        "uploaded_at": now,
+    }
 
 
 @router.get("/materials", response_model=list[MaterialOut])
@@ -210,6 +220,23 @@ def get_material(
         uploaded_at=uploaded_at,
         knowledge_graph=kg,
     )
+
+
+# ---------------------------------------------------------------------------
+# Background Task Polling (Issue #63)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/tasks/{task_id}", response_model=BackgroundTaskOut)
+def get_task_status(
+    task_id: str,
+    current_user: dict = Depends(_require_teacher),
+) -> BackgroundTaskOut:
+    """バックグラウンドタスクのステータスを返す。ポーリング用エンドポイント。"""
+    task = get_background_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return BackgroundTaskOut(**task)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -314,3 +314,18 @@ class ApproveWithScopeRequest(BaseModel):
     """スコープ付き承認リクエスト。"""
     scope: str = "full"  # "full" or "canary"
     course_ids: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Background Tasks (Issue #63)
+# ---------------------------------------------------------------------------
+
+class BackgroundTaskOut(BaseModel):
+    """バックグラウンドタスクのステータス情報。"""
+    task_id: str
+    task_type: str = "material_processing"
+    status: str = "pending"  # pending | processing | completed | failed
+    result_data: dict | None = None
+    error_message: str | None = None
+    created_at: str = ""
+    updated_at: str = ""

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -41,6 +41,91 @@ def _neo4j_driver():
 _material_lock = threading.Lock()
 _material_status: dict[str, dict] = {}
 
+
+# ---------------------------------------------------------------------------
+# Background task DB helpers (Issue #63)
+# ---------------------------------------------------------------------------
+
+
+def create_background_task(
+    task_id: str,
+    task_type: str = "material_processing",
+    created_by: str | None = None,
+) -> None:
+    """background_tasks テーブルにタスクレコードを作成する。"""
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO background_tasks (id, task_type, status, created_by)
+                VALUES (:id, :task_type, 'pending', CAST(:created_by AS uuid))
+            """),
+            {"id": task_id, "task_type": task_type, "created_by": created_by},
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def update_background_task(
+    task_id: str,
+    status: str,
+    result_data: dict | None = None,
+    error_message: str | None = None,
+) -> None:
+    """background_tasks テーブルのステータスを更新する。"""
+    session = _pg_session()
+    try:
+        params: dict = {"id": task_id, "status": status}
+        set_clauses = ["status = :status", "updated_at = now()"]
+
+        if result_data is not None:
+            set_clauses.append("result_data = CAST(:result_data AS jsonb)")
+            params["result_data"] = json.dumps(result_data, ensure_ascii=False)
+        if error_message is not None:
+            set_clauses.append("error_message = :error_message")
+            params["error_message"] = error_message
+
+        session.execute(
+            sa_text(f"UPDATE background_tasks SET {', '.join(set_clauses)} WHERE id = :id"),
+            params,
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        logger.warning("Failed to update background task %s: %s", task_id, status, exc_info=True)
+    finally:
+        session.close()
+
+
+def get_background_task(task_id: str) -> dict | None:
+    """background_tasks テーブルからタスク情報を取得する。"""
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT id, task_type, status, result_data, error_message, created_at, updated_at
+                FROM background_tasks WHERE id = :id
+            """),
+            {"id": task_id},
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "task_id": row[0],
+            "task_type": row[1],
+            "status": row[2],
+            "result_data": row[3],
+            "error_message": row[4],
+            "created_at": row[5].isoformat() if row[5] else "",
+            "updated_at": row[6].isoformat() if row[6] else "",
+        }
+    finally:
+        session.close()
+
 # ---------------------------------------------------------------------------
 # Course CRUD helpers
 # ---------------------------------------------------------------------------
@@ -728,6 +813,7 @@ def process_material_background(
     doc_id: str,
     filename: str,
     pdf_bytes: bytes,
+    task_id: str | None = None,
 ) -> None:
     """バックグラウンドでPDF処理パイプラインを実行する。"""
     with _material_lock:
@@ -735,6 +821,9 @@ def process_material_background(
             "status": "processing",
             "filename": filename,
         }
+
+    if task_id:
+        update_background_task(task_id, "processing")
 
     try:
         extracted_text = extract_pdf_text(pdf_bytes)
@@ -776,12 +865,24 @@ def process_material_background(
         with _material_lock:
             _material_status[material_id]["status"] = "completed"
 
+        if task_id:
+            update_background_task(task_id, "completed", result_data={
+                "material_id": material_id,
+                "doc_id": doc_id,
+                "text_length": len(extracted_text),
+                "chunk_count": len(chunks),
+            })
+
         logger.info("Material processing completed: %s", material_id)
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Material processing failed: %s", material_id)
         with _material_lock:
             _material_status[material_id]["status"] = "failed"
+
+        error_msg = str(exc)
+        if task_id:
+            update_background_task(task_id, "failed", error_message=error_msg)
 
         try:
             session = _pg_session()

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -195,6 +195,19 @@ class LearnerMisconceptionCorrection(Base):
 # コース管理
 # ============================================================
 
+class BackgroundTask(Base):
+    __tablename__ = "background_tasks"
+
+    id = Column(Text, primary_key=True)
+    task_type = Column(Text, nullable=False, default="material_processing")
+    status = Column(Text, nullable=False, default="pending")  # pending | processing | completed | failed
+    created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    result_data = Column(JSONB, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
+
+
 class LearningCourse(Base):
     __tablename__ = "learning_courses"
 

--- a/backend/db/005_background_tasks.sql
+++ b/backend/db/005_background_tasks.sql
@@ -1,0 +1,17 @@
+-- Migration 005: background_tasks (Issue #63)
+-- バックグラウンドタスクの状態管理テーブル
+
+CREATE TABLE IF NOT EXISTS background_tasks (
+    id            TEXT PRIMARY KEY,
+    task_type     TEXT NOT NULL DEFAULT 'material_processing',
+    status        TEXT NOT NULL DEFAULT 'pending'
+                      CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    created_by    UUID REFERENCES users(id) ON DELETE SET NULL,
+    result_data   JSONB,
+    error_message TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bg_tasks_status ON background_tasks(status);
+CREATE INDEX IF NOT EXISTS idx_bg_tasks_created_by ON background_tasks(created_by);

--- a/backend/tests/test_background_tasks.py
+++ b/backend/tests/test_background_tasks.py
@@ -1,0 +1,262 @@
+"""Issue #63: 教材処理パイプラインの非同期化・ポーリングUIのテスト。
+
+バックグラウンドタスクのDB状態管理、ポーリングAPI、フロントエンドの
+ポーリングロジックが期待通りに動作することを検証する。
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure api/ is importable (schemas, services live there)
+_backend_dir = str(Path(__file__).resolve().parents[1])
+_api_dir = str(Path(__file__).resolve().parents[1] / "api")
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+# ---------------------------------------------------------------------------
+# Frontend DOM / JS tests (静的HTML/JS解析)
+# ---------------------------------------------------------------------------
+
+FRONTEND_DIR = Path(__file__).resolve().parents[2] / "frontend" / "public"
+ADMIN_HTML = FRONTEND_DIR / "admin.html"
+ADMIN_JS = FRONTEND_DIR / "js" / "admin.js"
+
+
+@pytest.fixture(autouse=True)
+def _no_backend_settings():
+    """フロントエンドテストではバックエンド設定のオーバーライドは不要。"""
+    yield
+
+
+class TestAdminJSPolling:
+    """admin.js にポーリング関連のロジックが正しく実装されていることを検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _load_js(self):
+        self.js = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_start_task_polling_function_exists(self):
+        """startTaskPolling 関数が定義されていること。"""
+        assert "function startTaskPolling" in self.js
+
+    def test_stop_task_polling_function_exists(self):
+        """stopTaskPolling 関数が定義されていること。"""
+        assert "function stopTaskPolling" in self.js
+
+    def test_polling_calls_tasks_endpoint(self):
+        """/admin/tasks/ エンドポイントをポーリングで呼び出していること。"""
+        assert "/admin/tasks/" in self.js
+
+    def test_polling_handles_completed_status(self):
+        """completed ステータスでポーリングを停止し、UIを更新すること。"""
+        assert 'task.status === "completed"' in self.js
+
+    def test_polling_handles_failed_status(self):
+        """failed ステータスでポーリングを停止し、エラーを表示すること。"""
+        assert 'task.status === "failed"' in self.js
+
+    def test_polling_uses_set_interval(self):
+        """setInterval を使って定期ポーリングを行っていること。"""
+        assert "setInterval(poll" in self.js
+
+    def test_polling_clears_interval_on_stop(self):
+        """ポーリング停止時に clearInterval を呼んでいること。"""
+        assert "clearInterval(" in self.js
+
+    def test_polling_has_retry_logic(self):
+        """ネットワークエラー時のリトライカウントが実装されていること。"""
+        assert "retryCount" in self.js
+
+    def test_upload_disables_ui_during_processing(self):
+        """アップロード中にUIを無効化する disableUploadUI 関数が存在すること。"""
+        assert "function disableUploadUI" in self.js
+
+    def test_upload_returns_task_id(self):
+        """アップロード後に data.task_id を使ってポーリングを開始すること。"""
+        assert "data.task_id" in self.js
+
+    def test_polling_shows_error_message_from_task(self):
+        """タスク失敗時にerror_messageを表示すること。"""
+        assert "task.error_message" in self.js
+
+
+# ---------------------------------------------------------------------------
+# Backend unit tests (services layer)
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundTaskSchema:
+    """BackgroundTaskOut Pydantic スキーマのテスト。"""
+
+    def test_schema_fields(self):
+        """BackgroundTaskOut に必要なフィールドが存在すること。"""
+        from schemas import BackgroundTaskOut
+
+        task = BackgroundTaskOut(
+            task_id="test-123",
+            task_type="material_processing",
+            status="pending",
+        )
+        assert task.task_id == "test-123"
+        assert task.status == "pending"
+        assert task.result_data is None
+        assert task.error_message is None
+
+    def test_schema_with_result_data(self):
+        """result_data が設定可能であること。"""
+        from schemas import BackgroundTaskOut
+
+        task = BackgroundTaskOut(
+            task_id="test-456",
+            status="completed",
+            result_data={"material_id": "abc", "chunk_count": 10},
+        )
+        assert task.result_data["chunk_count"] == 10
+
+    def test_schema_with_error_message(self):
+        """error_message が設定可能であること。"""
+        from schemas import BackgroundTaskOut
+
+        task = BackgroundTaskOut(
+            task_id="test-789",
+            status="failed",
+            error_message="PDF parse error",
+        )
+        assert task.error_message == "PDF parse error"
+
+
+class TestBackgroundTaskORM:
+    """BackgroundTask ORM モデルのテスト。"""
+
+    def test_model_has_required_columns(self):
+        """BackgroundTask モデルに必要なカラムが定義されていること。"""
+        from core.models import BackgroundTask
+
+        columns = {c.name for c in BackgroundTask.__table__.columns}
+        expected = {"id", "task_type", "status", "created_by", "result_data",
+                    "error_message", "created_at", "updated_at"}
+        assert expected.issubset(columns)
+
+    def test_model_table_name(self):
+        """テーブル名が background_tasks であること。"""
+        from core.models import BackgroundTask
+        assert BackgroundTask.__tablename__ == "background_tasks"
+
+
+class TestProcessMaterialBackgroundSignature:
+    """process_material_background に task_id パラメータが追加されたことを検証。"""
+
+    def test_accepts_task_id_parameter(self):
+        """task_id パラメータが受け入れられること。"""
+        import inspect
+        from services import process_material_background
+
+        sig = inspect.signature(process_material_background)
+        assert "task_id" in sig.parameters
+
+    def test_task_id_is_optional(self):
+        """task_id がオプショナル（デフォルト None）であること。"""
+        import inspect
+        from services import process_material_background
+
+        sig = inspect.signature(process_material_background)
+        param = sig.parameters["task_id"]
+        assert param.default is None
+
+
+class TestServiceHelpers:
+    """services.py のバックグラウンドタスクヘルパー関数のテスト。"""
+
+    def test_create_background_task_exists(self):
+        """create_background_task 関数がエクスポートされていること。"""
+        from services import create_background_task
+        assert callable(create_background_task)
+
+    def test_update_background_task_exists(self):
+        """update_background_task 関数がエクスポートされていること。"""
+        from services import update_background_task
+        assert callable(update_background_task)
+
+    def test_get_background_task_exists(self):
+        """get_background_task 関数がエクスポートされていること。"""
+        from services import get_background_task
+        assert callable(get_background_task)
+
+
+# ---------------------------------------------------------------------------
+# Migration SQL tests
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationSQL:
+    """マイグレーションSQLファイルのテスト。"""
+
+    MIGRATION_FILE = Path(__file__).resolve().parents[1] / "db" / "005_background_tasks.sql"
+
+    def test_migration_file_exists(self):
+        """005_background_tasks.sql が存在すること。"""
+        assert self.MIGRATION_FILE.exists()
+
+    def test_migration_creates_table(self):
+        """CREATE TABLE background_tasks が含まれていること。"""
+        sql = self.MIGRATION_FILE.read_text(encoding="utf-8")
+        assert "CREATE TABLE" in sql
+        assert "background_tasks" in sql
+
+    def test_migration_has_status_check(self):
+        """status カラムに CHECK 制約があること。"""
+        sql = self.MIGRATION_FILE.read_text(encoding="utf-8")
+        assert "pending" in sql
+        assert "processing" in sql
+        assert "completed" in sql
+        assert "failed" in sql
+
+    def test_migration_has_indexes(self):
+        """必要なインデックスが定義されていること。"""
+        sql = self.MIGRATION_FILE.read_text(encoding="utf-8")
+        assert "idx_bg_tasks_status" in sql
+        assert "idx_bg_tasks_created_by" in sql
+
+
+# ---------------------------------------------------------------------------
+# Admin routes tests (endpoint registration)
+# ---------------------------------------------------------------------------
+
+
+class TestAdminRoutesRegistration:
+    """admin.py のルーター定義にポーリングエンドポイントが含まれることを検証。"""
+
+    ADMIN_ROUTES = Path(__file__).resolve().parents[1] / "api" / "routes" / "admin.py"
+
+    @pytest.fixture(autouse=True)
+    def _load_source(self):
+        self.source = self.ADMIN_ROUTES.read_text(encoding="utf-8")
+
+    def test_tasks_endpoint_defined(self):
+        """/tasks/{task_id} エンドポイントが定義されていること。"""
+        assert "/tasks/{task_id}" in self.source
+
+    def test_tasks_endpoint_is_get(self):
+        """ポーリングエンドポイントが GET メソッドであること。"""
+        assert '@router.get("/tasks/{task_id}"' in self.source
+
+    def test_upload_returns_task_id(self):
+        """upload_material が task_id を生成していること。"""
+        # Check task_id creation in upload endpoint
+        assert "task_id = str(uuid.uuid4())" in self.source
+
+    def test_upload_status_code_202(self):
+        """upload エンドポイントが 202 を返すこと。"""
+        assert "status_code=202" in self.source
+
+    def test_upload_creates_background_task(self):
+        """upload が create_background_task を呼び出すこと。"""
+        assert "create_background_task(task_id" in self.source

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -251,6 +251,9 @@
     });
   }
 
+  // ── Task Polling State ──────────────────────────────────────────
+  var _activePollingTimers = {};
+
   function uploadFile(file) {
     if (!file.name.toLowerCase().endsWith(".pdf")) {
       showUploadStatus("PDFファイルのみアップロードできます。", "error");
@@ -258,6 +261,7 @@
     }
 
     showUploadStatus(escHtml(file.name) + " をアップロード中...", "info");
+    disableUploadUI(true);
 
     var formData = new FormData();
     formData.append("file", file);
@@ -272,12 +276,92 @@
         return res.json();
       })
       .then(function (data) {
-        showUploadStatus(escHtml(file.name) + " のアップロードが完了しました。バックグラウンドで処理中です。", "success");
+        showUploadStatus(
+          escHtml(file.name) + " のアップロードが完了しました。グラフ構築中..." +
+          '<span class="typing" style="display:inline-flex;margin-left:8px"><span></span><span></span><span></span></span>',
+          "info"
+        );
         loadMaterials();
+        if (data.task_id) {
+          startTaskPolling(data.task_id, file.name);
+        } else {
+          disableUploadUI(false);
+        }
       })
       .catch(function (err) {
         showUploadStatus("アップロードに失敗しました: " + (err.detail || "不明なエラー"), "error");
+        disableUploadUI(false);
       });
+  }
+
+  function disableUploadUI(disabled) {
+    var zone = document.getElementById("upload-zone");
+    var fileInput = document.getElementById("file-input");
+    if (zone) {
+      zone.style.opacity = disabled ? "0.5" : "1";
+      zone.style.pointerEvents = disabled ? "none" : "auto";
+    }
+    if (fileInput) fileInput.disabled = disabled;
+  }
+
+  function startTaskPolling(taskId, filename) {
+    var retryCount = 0;
+    var maxRetries = 3;
+    var intervalMs = 3000;
+
+    function poll() {
+      apiFetch("/admin/tasks/" + taskId)
+        .then(function (res) {
+          if (!res.ok) throw new Error("Status check failed");
+          return res.json();
+        })
+        .then(function (task) {
+          retryCount = 0; // reset on success
+
+          if (task.status === "completed") {
+            stopTaskPolling(taskId);
+            showUploadStatus(
+              escHtml(filename) + " のグラフ構築が完了しました。",
+              "success"
+            );
+            disableUploadUI(false);
+            loadMaterials();
+          } else if (task.status === "failed") {
+            stopTaskPolling(taskId);
+            var errMsg = task.error_message || "不明なエラー";
+            showUploadStatus(
+              escHtml(filename) + " の処理に失敗しました: " + escHtml(errMsg),
+              "error"
+            );
+            disableUploadUI(false);
+            loadMaterials();
+          }
+          // pending/processing: continue polling
+        })
+        .catch(function () {
+          retryCount++;
+          if (retryCount >= maxRetries) {
+            stopTaskPolling(taskId);
+            showUploadStatus(
+              escHtml(filename) + " の進捗確認に失敗しました。「更新」ボタンで教材一覧を確認してください。",
+              "error"
+            );
+            disableUploadUI(false);
+          }
+          // else: retry on next interval
+        });
+    }
+
+    _activePollingTimers[taskId] = setInterval(poll, intervalMs);
+    // Initial poll immediately
+    poll();
+  }
+
+  function stopTaskPolling(taskId) {
+    if (_activePollingTimers[taskId]) {
+      clearInterval(_activePollingTimers[taskId]);
+      delete _activePollingTimers[taskId];
+    }
   }
 
   function showUploadStatus(message, type) {


### PR DESCRIPTION
## Summary
- 教材アップロード時のグラフ構築処理を非同期化し、`background_tasks` テーブルでタスク状態をDB管理（pending/processing/completed/failed）
- `POST /admin/materials/upload` が即座に `HTTP 202` + `task_id` を返却するよう変更し、`GET /admin/tasks/{task_id}` ポーリング用エンドポイントを新設
- フロントエンドで3秒間隔のポーリングUI（ローディング表示・完了/失敗検知・ネットワークエラーリトライ）を実装

## 変更内容

### バックエンド
| ファイル | 変更内容 |
|---|---|
| `backend/core/models.py` | `BackgroundTask` ORM モデル追加 |
| `backend/api/main.py` | Migration 005: `background_tasks` テーブル作成 |
| `backend/db/005_background_tasks.sql` | マイグレーションSQL |
| `backend/api/schemas.py` | `BackgroundTaskOut` Pydantic スキーマ追加 |
| `backend/api/services.py` | `create/update/get_background_task` ヘルパー追加、`process_material_background` にtask_id対応 |
| `backend/api/routes/admin.py` | upload→202+task_id返却、`GET /admin/tasks/{task_id}` 追加 |

### フロントエンド
| ファイル | 変更内容 |
|---|---|
| `frontend/public/js/admin.js` | ポーリングロジック（startTaskPolling/stopTaskPolling）、UI無効化、エラーリトライ |

### テスト
| ファイル | 内容 |
|---|---|
| `backend/tests/test_background_tasks.py` | 30テスト（フロントJS解析、スキーマ、ORM、ルート定義、マイグレーション） |

## Test plan
- [x] `pytest tests/test_background_tasks.py` — 30テスト全パス
- [ ] Docker環境でPDFアップロード → task_idが返却されることを確認
- [ ] ポーリングUIがローディング表示→完了で教材一覧更新されることを確認
- [ ] 処理失敗時にエラーメッセージが表示されることを確認
- [ ] ブラウザリロードしてもバックエンド処理が継続完了することを確認

Closes #63

https://claude.ai/code/session_01KwPiJvWgQvosDDuUYNHmWs