### PR TITLE
Add UUID validation guards to prevent crashes on non-UUID chunk IDs

### DIFF
--- a/backend/api/routes/lecture.py
+++ b/backend/api/routes/lecture.py
@@ -221,19 +221,33 @@ def _generate_sequence_from_search(
         )
 
     segments = []
+    chunks_to_update = []
     for i, cr in enumerate(chunk_results):
         if cr["score"] < 0.3:
             continue
+        chunk_id = cr.get("id", f"search_{i}")
         result = generate_spoken_text_and_formulas(cr["text"])
+        is_valid_uuid = _is_valid_uuid(chunk_id)
+
+        if is_valid_uuid:
+            chunks_to_update.append({
+                "id": chunk_id,
+                "spoken_text": result["spoken_text"],
+                "formulas": result["formulas"],
+            })
+
         segments.append(LectureSegment(
-            chunk_id=f"search_{i}",
+            chunk_id=chunk_id,
             chunk_index=i,
             text=cr["text"],
             spoken_text=result["spoken_text"],
             formulas=[LectureFormulaItem(**f) for f in result["formulas"]],
-            has_audio=False,
+            has_audio=_check_audio_cache(chunk_id) if is_valid_uuid else False,
             duration_ms=0,
         ))
+
+    if chunks_to_update:
+        _persist_spoken_text(chunks_to_update)
 
     return LectureSequenceResponse(
         course_id=course_id,
@@ -420,8 +434,19 @@ def lecture_interrupt_chat(
 # ---------------------------------------------------------------------------
 
 
+def _is_valid_uuid(value: str) -> bool:
+    """文字列が有効な UUID 形式かどうかを判定する。"""
+    try:
+        uuid.UUID(value)
+        return True
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
 def _check_audio_cache(chunk_id: str) -> bool:
     """指定チャンクの音声キャッシュが存在するか確認する。"""
+    if not _is_valid_uuid(chunk_id):
+        return False
     session = _pg_session()
     try:
         row = session.execute(
@@ -437,6 +462,8 @@ def _check_audio_cache(chunk_id: str) -> bool:
 
 def _get_audio_cache(chunk_id: str, voice: str) -> dict | None:
     """音声キャッシュを取得する。"""
+    if not _is_valid_uuid(chunk_id):
+        return None
     session = _pg_session()
     try:
         row = session.execute(
@@ -474,6 +501,9 @@ def _save_audio_cache(
     word_timestamps: list[dict],
 ) -> None:
     """音声キャッシュを保存する。"""
+    if not _is_valid_uuid(chunk_id):
+        logger.debug("Skipping audio cache save for non-UUID chunk_id: %s", chunk_id)
+        return
     session = _pg_session()
     try:
         session.execute(
@@ -504,6 +534,8 @@ def _save_audio_cache(
 
 def _get_chunk_spoken_text(chunk_id: str) -> str | None:
     """チャンクの spoken_text を取得する。なければ text から生成。"""
+    if not _is_valid_uuid(chunk_id):
+        return None
     session = _pg_session()
     try:
         row = session.execute(
@@ -530,7 +562,7 @@ def _get_chunk_spoken_text(chunk_id: str) -> str | None:
 
 def _get_chunk_text(chunk_id: str) -> str:
     """チャンクのテキストを取得する。"""
-    if chunk_id.startswith("search_"):
+    if not _is_valid_uuid(chunk_id):
         return ""
     session = _pg_session()
     try:
@@ -547,9 +579,12 @@ def _get_chunk_text(chunk_id: str) -> str:
 
 def _persist_spoken_text(chunks: list[dict]) -> None:
     """チャンクの spoken_text と formulas を DB に永続化する。"""
+    valid_chunks = [c for c in chunks if _is_valid_uuid(c["id"])]
+    if not valid_chunks:
+        return
     session = _pg_session()
     try:
-        for chunk in chunks:
+        for chunk in valid_chunks:
             session.execute(
                 sa_text("""
                     UPDATE chunks

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -336,7 +336,8 @@ def search_chunks_with_metadata(
         try:
             rows = session.execute(
                 sa_text("""
-                    SELECT c.text,
+                    SELECT c.id,
+                           c.text,
                            COALESCE(d.title, '') AS source_title,
                            COALESCE(d.filename, '') AS source_file,
                            1 - (c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))) AS score
@@ -350,13 +351,14 @@ def search_chunks_with_metadata(
             ).fetchall()
             return [
                 {
-                    "text": row[0],
-                    "source_title": row[1] or row[2] or "不明な教材",
-                    "source_file": row[2],
-                    "score": float(row[3]),
+                    "id": str(row[0]),
+                    "text": row[1],
+                    "source_title": row[2] or row[3] or "不明な教材",
+                    "source_file": row[3],
+                    "score": float(row[4]),
                 }
                 for row in rows
-                if row[0]
+                if row[1]
             ]
         finally:
             session.close()

--- a/backend/tests/test_lecture_mode.py
+++ b/backend/tests/test_lecture_mode.py
@@ -512,3 +512,127 @@ class TestLectureSchemasAdaptive:
         )
         assert resp.skipped_segments == 2
         assert resp.summary_segments == 1
+
+
+# ---------------------------------------------------------------------------
+# 9. UUID バリデーション / フォールバック安全性テスト (Issue #68)
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidUuid:
+    """_is_valid_uuid ヘルパーの検証。"""
+
+    def test_valid_uuid4(self):
+        from api.routes.lecture import _is_valid_uuid
+
+        assert _is_valid_uuid("550e8400-e29b-41d4-a716-446655440000") is True
+
+    def test_search_prefix_is_invalid(self):
+        from api.routes.lecture import _is_valid_uuid
+
+        assert _is_valid_uuid("search_0") is False
+        assert _is_valid_uuid("search_42") is False
+
+    def test_empty_string_is_invalid(self):
+        from api.routes.lecture import _is_valid_uuid
+
+        assert _is_valid_uuid("") is False
+
+    def test_arbitrary_string_is_invalid(self):
+        from api.routes.lecture import _is_valid_uuid
+
+        assert _is_valid_uuid("not-a-uuid") is False
+
+    def test_none_is_invalid(self):
+        from api.routes.lecture import _is_valid_uuid
+
+        assert _is_valid_uuid(None) is False
+
+
+class TestHelperUuidGuards:
+    """DB ヘルパー関数が非 UUID chunk_id でクラッシュしないことを検証 (Issue #68)。"""
+
+    def test_check_audio_cache_non_uuid(self):
+        from api.routes.lecture import _check_audio_cache
+
+        assert _check_audio_cache("search_0") is False
+
+    def test_get_audio_cache_non_uuid(self):
+        from api.routes.lecture import _get_audio_cache
+
+        assert _get_audio_cache("search_0", "alloy") is None
+
+    @patch("api.routes.lecture._pg_session")
+    def test_save_audio_cache_non_uuid_skips_db(self, mock_session):
+        from api.routes.lecture import _save_audio_cache
+
+        _save_audio_cache("search_0", "alloy", b"audio", 1000, [])
+        mock_session.assert_not_called()
+
+    def test_get_chunk_spoken_text_non_uuid(self):
+        from api.routes.lecture import _get_chunk_spoken_text
+
+        assert _get_chunk_spoken_text("search_0") is None
+
+    def test_get_chunk_text_non_uuid(self):
+        from api.routes.lecture import _get_chunk_text
+
+        assert _get_chunk_text("search_0") == ""
+
+    @patch("api.routes.lecture._pg_session")
+    def test_persist_spoken_text_filters_non_uuid(self, mock_session):
+        from api.routes.lecture import _persist_spoken_text
+
+        _persist_spoken_text([
+            {"id": "search_0", "spoken_text": "test", "formulas": []},
+            {"id": "search_1", "spoken_text": "test2", "formulas": []},
+        ])
+        # All entries are non-UUID, so DB should not be touched
+        mock_session.assert_not_called()
+
+
+class TestGenerateSequenceFromSearchUsesRealIds:
+    """_generate_sequence_from_search が検索結果の実 UUID を使用することを検証。"""
+
+    @patch("api.routes.lecture._persist_spoken_text")
+    @patch("api.routes.lecture._check_audio_cache", return_value=False)
+    @patch("api.routes.lecture.generate_spoken_text_and_formulas")
+    @patch("api.routes.lecture.search_chunks_with_metadata")
+    def test_uses_chunk_id_from_search_results(
+        self, mock_search, mock_gen, mock_cache, mock_persist,
+    ):
+        from api.routes.lecture import _generate_sequence_from_search
+
+        real_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        mock_search.return_value = [
+            {"id": real_uuid, "text": "test content", "score": 0.9},
+        ]
+        mock_gen.return_value = {"spoken_text": "spoken", "formulas": []}
+
+        result = _generate_sequence_from_search(
+            "course-1", "topic-1", "Test Topic", {}, {"id": "user-1"},
+        )
+
+        assert len(result.segments) == 1
+        assert result.segments[0].chunk_id == real_uuid
+
+    @patch("api.routes.lecture._persist_spoken_text")
+    @patch("api.routes.lecture.generate_spoken_text_and_formulas")
+    @patch("api.routes.lecture.search_chunks_with_metadata")
+    def test_fallback_id_when_no_id_in_result(
+        self, mock_search, mock_gen, mock_persist,
+    ):
+        from api.routes.lecture import _generate_sequence_from_search
+
+        mock_search.return_value = [
+            {"text": "test content", "score": 0.9},  # no "id" key
+        ]
+        mock_gen.return_value = {"spoken_text": "spoken", "formulas": []}
+
+        result = _generate_sequence_from_search(
+            "course-1", "topic-1", "Test Topic", {}, {"id": "user-1"},
+        )
+
+        assert len(result.segments) == 1
+        assert result.segments[0].chunk_id == "search_0"
+        assert result.segments[0].has_audio is False


### PR DESCRIPTION
## Summary
This PR adds comprehensive UUID validation to the lecture module to safely handle non-UUID chunk IDs (such as search result fallback IDs like "search_0") without crashing database operations. It addresses Issue #68 by ensuring all database helper functions validate chunk IDs before attempting queries.

## Key Changes

- **Added `_is_valid_uuid()` helper function**: Validates whether a string is a valid UUID format, with proper exception handling for edge cases (None, non-string types, etc.)

- **Added UUID guards to all database helper functions**:
  - `_check_audio_cache()`: Returns False for non-UUID chunk IDs
  - `_get_audio_cache()`: Returns None for non-UUID chunk IDs
  - `_save_audio_cache()`: Skips database operations and logs debug message for non-UUID chunk IDs
  - `_get_chunk_spoken_text()`: Returns None for non-UUID chunk IDs
  - `_get_chunk_text()`: Refactored to use `_is_valid_uuid()` instead of string prefix check
  - `_persist_spoken_text()`: Filters out non-UUID chunks before database operations

- **Updated `_generate_sequence_from_search()`**: 
  - Now uses actual chunk IDs from search results when available
  - Falls back to "search_{i}" format only when search results lack an ID field
  - Only attempts audio cache checks and database persistence for valid UUIDs
  - Properly tracks which chunks should be persisted to the database

- **Updated `search_chunks_with_metadata()`**: 
  - Now includes chunk ID in query results (added `c.id` to SELECT clause)
  - Returns chunk ID in the result dictionary for use by calling functions

## Notable Implementation Details

- All UUID validation is centralized in `_is_valid_uuid()` for consistency
- Non-UUID chunk IDs are handled gracefully with safe defaults (False, None, empty string) rather than exceptions
- Database operations are skipped entirely for non-UUID IDs, preventing unnecessary queries
- Comprehensive test coverage added for both valid and invalid UUID scenarios

https://claude.ai/code/session_015Qn9NMnqtW9qa1XgHyAdVZ