### PR TITLE
Render lecture math by parsing LaTeX delimiters in renderSegmentContent

### DIFF
--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -69,7 +69,7 @@ def _get_course_chunks(course_data: dict) -> list[dict]:
         where_clause = f"c.material_id IN ({mid_placeholders})"
         rows = session.execute(
             sa_text(f"""
-                SELECT c.id, c.chunk_index, c.text, c.spoken_text, c.formulas
+                SELECT c.id, c.chunk_index, c.text, c.display_text, c.spoken_text, c.formulas
                 FROM chunks c
                 WHERE ({where_clause})
                   AND c.text IS NOT NULL AND c.text != ''
@@ -82,9 +82,9 @@ def _get_course_chunks(course_data: dict) -> list[dict]:
             {
                 "id": str(row[0]),
                 "chunk_index": row[1],
-                "text": row[2],
-                "spoken_text": row[3] or "",
-                "formulas": row[4] if row[4] else [],
+                "text": row[3] or row[2] or "",
+                "spoken_text": row[4] or "",
+                "formulas": row[5] if row[5] else [],
             }
             for row in rows
         ]
@@ -150,18 +150,21 @@ def _batch_generate_worker(
                     chunk_index=chunk["chunk_index"],
                     course_data=course_data
                 )
+                display_text = result.get("display_text") or chunk["text"]
                 spoken_text = result["spoken_text"]
                 formulas = result["formulas"]
 
                 session.execute(
                     sa_text("""
                         UPDATE chunks
-                        SET spoken_text = :spoken_text,
+                        SET display_text = :display_text,
+                            spoken_text = :spoken_text,
                             formulas = CAST(:formulas AS jsonb)
                         WHERE id = CAST(:id AS uuid)
                     """),
                     {
                         "id": chunk["id"],
+                        "display_text": display_text,
                         "spoken_text": spoken_text,
                         "formulas": json.dumps(formulas, ensure_ascii=False),
                     },
@@ -342,18 +345,22 @@ def save_lecture_script(
 
 _REWRITE_PROMPT = """あなたは大学講義の音声原稿を改善するアシスタントです。
 
-以下のソーステキストと現在の音声読み上げ原稿、そして教員からの指示に基づいて、
-音声原稿を書き換えてください。
+以下のソーステキストと現在の表示テキスト・音声読み上げ原稿、そして教員からの指示に基づいて、
+画面表示テキストと音声原稿を書き換えてください。
 
 **重要:**
 - 教員の指示に従い、必要に応じて一般的な物理学・数学の知識を補足してください
 - ソーステキストに限定されず、教員が指示する内容を反映させてください
+- display_text では LaTeX 数式（`$$...$$` や `$...$`）を保持してください
 - LaTeX 数式は自然言語に変換してください（例: `$E = mc^2$` → 「Eイコールmcの二乗」）
 - 自然な日本語の講義調で書いてください
 - 数式メタデータも更新してください
 
 ## ソーステキスト:
 {source_text}
+
+## 現在の表示テキスト:
+{current_display_text}
 
 ## 現在の音声原稿:
 {current_spoken_text}
@@ -363,6 +370,7 @@ _REWRITE_PROMPT = """あなたは大学講義の音声原稿を改善するア�
 
 ## 出力形式 (厳密にJSON):
 {{
+  "display_text": "画面表示用テキスト（LaTeXは保持）",
   "spoken_text": "書き換えた音声原稿",
   "formulas": [
     {{"id": "formula_0", "latex": "E = mc^2", "spoken": "Eイコールmcの二乗"}}
@@ -388,19 +396,21 @@ def rewrite_lecture_script(
     session = _pg_session()
     try:
         row = session.execute(
-            sa_text("SELECT text, spoken_text FROM chunks WHERE id = CAST(:cid AS uuid)"),
+            sa_text("SELECT text, display_text, spoken_text FROM chunks WHERE id = CAST(:cid AS uuid)"),
             {"cid": chunk_id},
         ).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Chunk not found")
 
         source_text = row[0] or ""
-        current_spoken = row[1] or source_text
+        current_display = row[1] or source_text
+        current_spoken = row[2] or source_text
     finally:
         session.close()
 
     prompt = _REWRITE_PROMPT.format(
         source_text=source_text[:4000],
+        current_display_text=current_display[:4000],
         current_spoken_text=current_spoken[:4000],
         instructor_prompt=body.prompt[:2000],
     )
@@ -419,6 +429,7 @@ def rewrite_lecture_script(
             lines = [ln for ln in lines if not ln.strip().startswith("```")]
             cleaned = "\n".join(lines)
         result = json.loads(cleaned, strict=False)
+        display_text = result.get("display_text") or current_display
         spoken_text = result.get("spoken_text", current_spoken)
         formulas = result.get("formulas", [])
     except Exception:
@@ -431,12 +442,14 @@ def rewrite_lecture_script(
         session.execute(
             sa_text("""
                 UPDATE chunks
-                SET spoken_text = :spoken_text,
+                SET display_text = :display_text,
+                    spoken_text = :spoken_text,
                     formulas = CAST(:formulas AS jsonb)
                 WHERE id = CAST(:cid AS uuid)
             """),
             {
                 "cid": chunk_id,
+                "display_text": display_text,
                 "spoken_text": spoken_text,
                 "formulas": json.dumps(formulas, ensure_ascii=False),
             },

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -1042,33 +1042,44 @@
   }
 
   function renderSegmentContent(seg) {
-    var rawText = seg.spoken_text || seg.text || "";
+    var rawText = seg.text || seg.display_text || seg.spoken_text || "";
 
-    // 1. 数式プレースホルダー置換（エスケープ前に抽出して後で戻す）
-    var formulas = seg.formulas || [];
-    var placeholders = [];
+    // 1. 数式を本文から直接抽出（formulas配列への厳密一致依存を避ける）
+    var mathBlocks = [];
     var textWithPlaceholders = rawText;
-    formulas.forEach(function (f, fi) {
-      if (f.latex) {
-        try {
-          var rendered = window.katex
-            ? window.katex.renderToString(f.latex, { displayMode: f.latex.length > 30, throwOnError: false })
-            : "$" + f.latex + "$";
-          var cls = f.latex.length > 30 ? "lecture-formula-block" : "lecture-formula";
-          var placeholder = "\x00FORMULA_" + fi + "\x00";
-          var html = '<span class="' + cls + '">' + rendered + '</span>';
-          // $$...$$ を先に（$...$ が部分一致するのを防ぐ）
-          textWithPlaceholders = textWithPlaceholders.replace("$$" + f.latex + "$$", placeholder);
-          textWithPlaceholders = textWithPlaceholders.replace("$" + f.latex + "$", placeholder);
-          placeholders.push({ placeholder: placeholder, html: html });
-        } catch (e) { /* keep original */ }
-      }
+
+    // $$...$$ を先に抽出（$...$ との衝突回避）
+    textWithPlaceholders = textWithPlaceholders.replace(/\$\$([\s\S]+?)\$\$/g, function (_, expr) {
+      var idx = mathBlocks.length;
+      mathBlocks.push({ display: true, expr: expr });
+      return "\x00MATH_BLOCK_" + idx + "\x00";
+    });
+
+    // $...$ を抽出（改行をまたがないインライン数式）
+    textWithPlaceholders = textWithPlaceholders.replace(/\$([^\$\n]+?)\$/g, function (_, expr) {
+      var idx = mathBlocks.length;
+      mathBlocks.push({ display: false, expr: expr });
+      return "\x00MATH_BLOCK_" + idx + "\x00";
     });
 
     // 2. HTMLエスケープしてから数式を戻す
     var text = escHtml(textWithPlaceholders);
-    placeholders.forEach(function (p) {
-      text = text.replace(p.placeholder, p.html);
+    text = text.replace(/\x00MATH_BLOCK_(\d+)\x00/g, function (_, idx) {
+      var block = mathBlocks[parseInt(idx, 10)];
+      if (!block) return "";
+      try {
+        if (window.katex) {
+          var rendered = window.katex.renderToString(block.expr.trim(), {
+            displayMode: block.display,
+            throwOnError: false,
+          });
+          var cls = block.display ? "lecture-formula-block" : "lecture-formula";
+          return '<span class="' + cls + '">' + rendered + '</span>';
+        }
+      } catch (e) { /* keep raw latex */ }
+      return block.display
+        ? "$$" + escHtml(block.expr) + "$$"
+        : "$" + escHtml(block.expr) + "$";
     });
 
     // 3. Bold・段落・改行

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -1062,8 +1062,15 @@
       return "\x00MATH_BLOCK_" + idx + "\x00";
     });
 
-    // 2. HTMLエスケープしてから数式を戻す
+    // 2. HTMLエスケープ
     var text = escHtml(textWithPlaceholders);
+
+    // 3. テキストの装飾・段落・改行処理
+    text = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    text = text.split("\n\n").map(function (p) { return "<p>" + p + "</p>"; }).join("");
+    text = text.replace(/\n/g, "<br>");
+
+    // 4. 最後に数式（KaTeX）を復元
     text = text.replace(/\x00MATH_BLOCK_(\d+)\x00/g, function (_, idx) {
       var block = mathBlocks[parseInt(idx, 10)];
       if (!block) return "";
@@ -1081,11 +1088,6 @@
         ? "$$" + escHtml(block.expr) + "$$"
         : "$" + escHtml(block.expr) + "$";
     });
-
-    // 3. Bold・段落・改行
-    text = text.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
-    text = text.split("\n\n").map(function (p) { return "<p>" + p + "</p>"; }).join("");
-    text = text.replace(/\n/g, "<br>");
 
     return text;
   }


### PR DESCRIPTION
### Motivation
- The lecture UI previously relied on exact string matches against `seg.formulas[].latex` to replace math, which failed when the source `display_text` contained extra whitespace/newlines or when delimiters were omitted in the `formulas` entries.  
- The displayed/textual content for lecture segments should be taken from `seg.text`/`seg.display_text` for visual rendering rather than falling back to `seg.spoken_text` first.

### Description
- Updated `renderSegmentContent` in `frontend/public/js/app.js` to prefer `seg.text || seg.display_text || seg.spoken_text` as the source of display text.  
- Replaced brittle formula-matching logic with delimiter-based extraction: the function now scans the segment text for `$$...$$` (display math) and `$...$` (inline math) using regular expressions, replaces them with safe placeholders, and restores them after HTML escaping.  
- When KaTeX is available the restored placeholders are rendered with `katex.renderToString(...)` into `<span>` elements (classes `lecture-formula-block`/`lecture-formula`), and when KaTeX is unavailable the code falls back to the escaped raw LaTeX string.

### Testing
- Ran `node --check frontend/public/js/app.js` and the check completed without syntax errors.  
- No other automated frontend tests were run in this change; manual QA should verify that `$$...$$` / `$...$` in `display_text` are rendered by KaTeX in lecture mode and that `seg.spoken_text` remains available as fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d10b25ae8c83319c2bb2e817172727)