### PR TITLE
Add Gemini LLM provider support with multi-provider abstraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,22 @@
-# LLM 設定 (ベンダーニュートラル。後方互換のため OPENAI_* も使用可)
+# LLM プロバイダ設定
+# LLM_PROVIDER: openai (デフォルト) または gemini
+LLM_PROVIDER=openai
+
+# API キー — OpenAI の場合は sk-... / Gemini の場合は AI Studio の APIキー
+# 後方互換: OPENAI_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY も使用可
 LLM_API_KEY=sk-your-api-key-here
+
+# --- OpenAI 利用時 ---
 LLM_ANALYSIS_MODEL=o3-mini
 LLM_EMBEDDING_MODEL=text-embedding-3-large
+LLM_EMBEDDING_DIM=3072
+
+# --- Gemini 利用時 (例) ---
+# LLM_PROVIDER=gemini
+# LLM_API_KEY=your-gemini-api-key
+# LLM_ANALYSIS_MODEL=gemini-2.0-flash
+# LLM_EMBEDDING_MODEL=text-embedding-004
+# LLM_EMBEDDING_DIM=768
 
 # LLM マルチモード設定 (Fast / Standard / Deep)
 LLM_FAST_MODEL=gpt-5.4-nano

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ PDF文献から概念・関係性を自動抽出してナレッジグラフを�
 |---|---|
 | フロントエンド | Vanilla JS SPA + nginx |
 | APIサーバー | FastAPI (Python 3.11) |
-| RDB + ベクトル検索 | PostgreSQL 16 + pgvector (cosine, 3072次元) |
+| RDB + ベクトル検索 | PostgreSQL 16 + pgvector (cosine, 次元数は `LLM_EMBEDDING_DIM` で設定) |
 | グラフDB | Neo4j 5（概念グラフ走査専用） |
 | オブジェクトストレージ | MinIO（S3互換） |
-| LLM | OpenAI API (gpt-4o, text-embedding-3-large) |
+| LLM | OpenAI API または Google Gemini API（`LLM_PROVIDER` で切替） |
 | TTS 音声合成 | OpenAI TTS API (tts-1) |
 | 認証 | JWT (HS256) + bcrypt |
 
@@ -29,14 +29,15 @@ PDF文献から概念・関係性を自動抽出してナレッジグラフを�
 ### 前提条件
 
 - Docker & Docker Compose
-- OpenAI APIキー
+- LLM APIキー（OpenAI または Google Gemini）
 
 ### 起動手順
 
 ```bash
 # 1. 環境変数を設定
 cp .env.example .env
-# .env を編集: OPENAI_API_KEY, ADMIN_PASSWORD, JWT_SECRET を必ず設定
+# .env を編集: LLM_API_KEY (または OPENAI_API_KEY / GEMINI_API_KEY), ADMIN_PASSWORD, JWT_SECRET を必ず設定
+# Gemini を使う場合は LLM_PROVIDER=gemini, LLM_EMBEDDING_DIM=768 なども設定
 
 # 2. 全サービスを起動
 docker compose up -d
@@ -89,7 +90,7 @@ docker compose logs -f api-server
 PDF アップロード
   → PyMuPDF テキスト抽出
   → LLM 仮説駆動型分析 → PaperStructure 生成
-  → テキストチャンク → PostgreSQL pgvector（3072次元）
+  → テキストチャンク → PostgreSQL pgvector（次元数は `LLM_EMBEDDING_DIM` 準拠）
   → 概念ノード・エッジ → Neo4j（REQUIRES / RELATES_TO / CONTAINS）
   → PaperStructure JSON → MinIO（extracted-structures バケット）
 ```
@@ -188,7 +189,7 @@ episteme-graph/
 │   │   ├── embedder.py        # pgvector ベクトル保存・検索
 │   │   ├── chat.py            # RAG チャットロジック
 │   │   ├── lecture.py         # レクチャーシーケンス生成・TTS補助
-│   │   ├── llm.py             # OpenAI クライアント
+│   │   ├── llm.py             # LLM アダプタ（OpenAI / Gemini 切替）
 │   │   ├── storage.py         # MinIO S3互換ストレージ
 │   │   ├── batch.py           # 構造的同型性評価バッチ
 │   │   ├── meta_analyzer.py   # 未回答クエリ → スキーマ拡張提案

--- a/backend/api/requirements.txt
+++ b/backend/api/requirements.txt
@@ -2,6 +2,7 @@ fastapi>=0.111,<1
 uvicorn[standard]>=0.29,<1
 python-multipart>=0.0.7,<1
 openai>=1.30,<2
+google-generativeai>=0.7,<1
 neo4j>=5.19,<6
 PyJWT>=2.8,<3
 python-dotenv>=1.0,<2

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -17,7 +17,7 @@ from neo4j import GraphDatabase
 from sqlalchemy import text as sa_text
 
 from core.config import get_settings as _get_settings
-from core.llm import generate_text, generate_embeddings
+from core.llm import generate_text, generate_embeddings, get_embedding_dim
 from core.postgres import get_session as _pg_session
 
 logger = logging.getLogger(__name__)
@@ -242,13 +242,14 @@ def search_relevant_chunks(
             for i, mid in enumerate(material_ids):
                 params[f"mid_{i}"] = mid
 
+            dim = get_embedding_dim()
             rows = session.execute(
                 sa_text(f"""
                     SELECT c.text
                     FROM chunks c
                     WHERE c.material_id IN ({placeholders})
                       AND c.embedding IS NOT NULL
-                    ORDER BY c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+                    ORDER BY c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
                     LIMIT :limit
                 """),
                 params,
@@ -285,15 +286,16 @@ def search_relevant_chunks_with_scores(
                 params[f"mid_{i}"] = mid
 
             where_clause = f"c.material_id IN ({mid_placeholders})"
+            dim = get_embedding_dim()
 
             rows = session.execute(
                 sa_text(f"""
                     SELECT c.text,
-                           1 - (c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))) AS score
+                           1 - (c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))) AS score
                     FROM chunks c
                     WHERE ({where_clause})
                       AND c.embedding IS NOT NULL
-                    ORDER BY c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+                    ORDER BY c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
                     LIMIT :limit
                 """),
                 params,
@@ -323,17 +325,18 @@ def search_chunks_with_metadata(
     try:
         session = _pg_session()
         try:
+            dim = get_embedding_dim()
             rows = session.execute(
-                sa_text("""
+                sa_text(f"""
                     SELECT c.id,
                            c.text,
                            COALESCE(d.title, '') AS source_title,
                            COALESCE(d.filename, '') AS source_file,
-                           1 - (c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))) AS score
+                           1 - (c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))) AS score
                     FROM chunks c
                     LEFT JOIN documents d ON c.document_id = d.id
                     WHERE c.embedding IS NOT NULL
-                    ORDER BY c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+                    ORDER BY c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
                     LIMIT :limit
                 """),
                 {"query_vector": str(query_vector), "limit": top_k},

--- a/backend/core/chat.py
+++ b/backend/core/chat.py
@@ -14,7 +14,7 @@ import logging
 
 from sqlalchemy import text
 
-from core.llm import generate_text, generate_embeddings
+from core.llm import generate_text, generate_embeddings, get_embedding_dim
 from core.postgres import get_session
 
 logger = logging.getLogger(__name__)
@@ -62,16 +62,17 @@ def _embed_query(question: str) -> list[float]:
 def search_chunks(question: str, material_id: str, top_k: int = 5) -> list[str]:
     """PostgreSQL pgvector で material_id に属するチャンクを類似度検索して返す。"""
     query_vector = _embed_query(question)
+    dim = get_embedding_dim()
 
     session = get_session()
     try:
         rows = session.execute(
-            text("""
+            text(f"""
                 SELECT c.text
                 FROM chunks c
                 WHERE c.material_id = :material_id
                   AND c.embedding IS NOT NULL
-                ORDER BY c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+                ORDER BY c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
                 LIMIT :limit
             """),
             {

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,13 +31,21 @@ class Settings(BaseSettings):
         env_file=".env",
         env_file_encoding="utf-8",
         extra="ignore",
+        populate_by_name=True,
     )
 
     # --- LLM ---
-    # ベンダーニュートラルな変数名。後方互換のため OPENAI_* 環境変数も受け付ける。
+    # プロバイダ切替 (openai | gemini)。.env の LLM_PROVIDER で切り替える。
+    llm_provider: Literal["openai", "gemini"] = Field(
+        default="openai",
+        validation_alias=AliasChoices("LLM_PROVIDER"),
+    )
+    # ベンダーニュートラルな変数名。後方互換のため OPENAI_* / GEMINI_* 環境変数も受け付ける。
     llm_api_key: str = Field(
         default="",
-        validation_alias=AliasChoices("LLM_API_KEY", "OPENAI_API_KEY"),
+        validation_alias=AliasChoices(
+            "LLM_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"
+        ),
     )
     llm_analysis_model: str = Field(
         default="o3-mini",
@@ -46,6 +54,12 @@ class Settings(BaseSettings):
     llm_embedding_model: str = Field(
         default="text-embedding-3-large",
         validation_alias=AliasChoices("LLM_EMBEDDING_MODEL", "OPENAI_EMBEDDING_MODEL"),
+    )
+    # 埋め込みベクトルの次元数。pgvector のスキーマと一致させる必要がある。
+    # OpenAI text-embedding-3-large = 3072、Gemini text-embedding-004 = 768 など。
+    llm_embedding_dim: int = Field(
+        default=3072,
+        validation_alias=AliasChoices("LLM_EMBEDDING_DIM"),
     )
 
     # --- LLM マルチモード設定 ---

--- a/backend/core/embedder.py
+++ b/backend/core/embedder.py
@@ -11,13 +11,11 @@ import uuid
 
 from sqlalchemy import text
 
-from core.llm import generate_embeddings
+from core.llm import generate_embeddings, get_embedding_dim
 from core.postgres import get_session
 from core.schema import CausalEdge, PaperStructure
 
 logger = logging.getLogger(__name__)
-
-_VECTOR_DIM = 3072  # text-embedding-3-large の次元数
 
 
 def _build_ancestors_map(edges: list[CausalEdge]) -> dict[str, list[str]]:
@@ -216,12 +214,13 @@ def search_similar_papers(
     vectors = generate_embeddings([query_text])
     vector = vectors[0]
 
+    dim = get_embedding_dim()
     session = get_session()
     try:
-        inner = """
+        inner = f"""
             SELECT DISTINCT ON (c.material_id)
                    c.material_id,
-                   1 - (c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))) AS score,
+                   1 - (c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))) AS score,
                    c.text
             FROM chunks c
             WHERE c.material_id IS NOT NULL
@@ -233,8 +232,8 @@ def search_similar_papers(
             inner += " AND c.material_id != :exclude_id"
             params["exclude_id"] = exclude_material_id
 
-        inner += """
-            ORDER BY c.material_id, c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+        inner += f"""
+            ORDER BY c.material_id, c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
         """
 
         query = f"""
@@ -268,12 +267,13 @@ def search_fanns_hybrid(
     vectors = generate_embeddings([query_text])
     query_vector = vectors[0]
 
+    dim = get_embedding_dim()
     session = get_session()
     try:
-        inner = """
+        inner = f"""
             SELECT DISTINCT ON (c.material_id)
                    c.material_id,
-                   1 - (c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))) AS score,
+                   1 - (c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))) AS score,
                    c.text,
                    c.smiles_dsl,
                    c.variables
@@ -287,8 +287,8 @@ def search_fanns_hybrid(
             inner += " AND c.smiles_dsl LIKE :dsl_pattern"
             params["dsl_pattern"] = f"%{query_dsl_regex}%"
 
-        inner += """
-            ORDER BY c.material_id, c.embedding::halfvec(3072) <=> CAST(:query_vector AS halfvec(3072))
+        inner += f"""
+            ORDER BY c.material_id, c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
         """
 
         query = f"""

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -20,6 +20,7 @@ Reasoning モデル（o1, o3-mini, gpt-5.x 等）向けの自動変換を行う:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from functools import lru_cache
@@ -32,6 +33,11 @@ from core.config import get_settings
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def get_embedding_dim() -> int:
+    """現在の埋め込みベクトル次元数を返す (pgvector スキーマと一致する必要がある)。"""
+    return int(get_settings().llm_embedding_dim)
 
 # ---------------------------------------------------------------------------
 # マルチモード LLM パラメータ取得
@@ -160,6 +166,119 @@ def _get_openai_client():
 
 
 # ---------------------------------------------------------------------------
+# Gemini Adapter（内部実装）
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _get_gemini_module():
+    """google-generativeai モジュールを初期化して返す。"""
+    import google.generativeai as genai  # type: ignore
+
+    settings = get_settings()
+    if not settings.llm_api_key:
+        raise EnvironmentError(
+            "LLM API キーが設定されていません。"
+            " .env ファイルに LLM_API_KEY=... (または GEMINI_API_KEY=...) を追記してください。"
+        )
+    genai.configure(api_key=settings.llm_api_key)
+    return genai
+
+
+def _messages_to_gemini(
+    messages: list[dict[str, str]],
+) -> tuple[str | None, list[dict[str, Any]]]:
+    """OpenAI 形式メッセージを Gemini 形式 (system_instruction, contents) に変換する。
+
+    - ``system`` → ``system_instruction`` に集約
+    - ``user`` → ``role="user"``
+    - ``assistant`` → ``role="model"``
+    """
+    system_parts: list[str] = []
+    contents: list[dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if role == "system":
+            system_parts.append(content)
+        elif role == "assistant":
+            contents.append({"role": "model", "parts": [content]})
+        else:
+            contents.append({"role": "user", "parts": [content]})
+    system_instruction = "\n\n".join(system_parts) if system_parts else None
+    return system_instruction, contents
+
+
+def _gemini_generate_text(
+    messages: list[dict[str, str]],
+    model_name: str,
+    *,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    genai = _get_gemini_module()
+    system_instruction, contents = _messages_to_gemini(messages)
+    generation_config: dict[str, Any] = {}
+    if temperature is not None:
+        generation_config["temperature"] = temperature
+    if max_tokens is not None:
+        generation_config["max_output_tokens"] = max_tokens
+
+    model = genai.GenerativeModel(
+        model_name=model_name,
+        system_instruction=system_instruction,
+    )
+    response = model.generate_content(
+        contents,
+        generation_config=generation_config or None,
+    )
+    return (getattr(response, "text", "") or "").strip()
+
+
+def _gemini_generate_structured(
+    messages: list[dict[str, str]],
+    response_format: type[T],
+    model_name: str,
+) -> T:
+    genai = _get_gemini_module()
+    system_instruction, contents = _messages_to_gemini(messages)
+    schema = response_format.model_json_schema()
+    model = genai.GenerativeModel(
+        model_name=model_name,
+        system_instruction=system_instruction,
+    )
+    response = model.generate_content(
+        contents,
+        generation_config={
+            "response_mime_type": "application/json",
+            "response_schema": schema,
+        },
+    )
+    raw = getattr(response, "text", "") or ""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Gemini の構造化レスポンスを JSON として解析できませんでした: {raw!r}") from exc
+    return response_format.model_validate(data)
+
+
+def _gemini_generate_embeddings(
+    texts: list[str],
+    model_name: str,
+) -> list[list[float]]:
+    genai = _get_gemini_module()
+    # Gemini の embed_content は text 単位のためループで呼び出す。
+    result: list[list[float]] = []
+    for t in texts:
+        resp = genai.embed_content(model=model_name, content=t)
+        # resp は dict-like: {"embedding": [...]} または {"embedding": {"values": [...]}}
+        emb = resp["embedding"] if isinstance(resp, dict) else getattr(resp, "embedding", None)
+        if isinstance(emb, dict) and "values" in emb:
+            emb = emb["values"]
+        result.append(list(emb or []))
+    return result
+
+
+# ---------------------------------------------------------------------------
 # 公開 API: テキスト生成
 # ---------------------------------------------------------------------------
 
@@ -194,6 +313,15 @@ def generate_text(
     """
     settings = get_settings()
     model_name = model or settings.llm_analysis_model
+
+    if settings.llm_provider == "gemini":
+        return _gemini_generate_text(
+            messages,
+            model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
     client = _get_openai_client()
 
     adapted_messages = _adapt_messages_for_model(messages, model_name)
@@ -238,6 +366,10 @@ def generate_text_with_structured_output(
     """
     settings = get_settings()
     model_name = model or settings.llm_analysis_model
+
+    if settings.llm_provider == "gemini":
+        return _gemini_generate_structured(messages, response_format, model_name)
+
     client = _get_openai_client()
 
     adapted_messages = _adapt_messages_for_model(messages, model_name)
@@ -278,6 +410,10 @@ def generate_embeddings(
 
     settings = get_settings()
     model_name = model or settings.llm_embedding_model
+
+    if settings.llm_provider == "gemini":
+        return _gemini_generate_embeddings(texts, model_name)
+
     client = _get_openai_client()
 
     resp = client.embeddings.create(model=model_name, input=texts)

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,0 +1,159 @@
+"""Issue #95: LLM プロバイダ抽象化 (OpenAI / Gemini) のテスト。"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+
+class _DummyStruct(BaseModel):
+    answer: str
+    score: int
+
+
+def _make_settings(provider: str, dim: int = 3072):
+    from core.config import Settings
+
+    return Settings(
+        _env_file=None,
+        llm_provider=provider,  # type: ignore[arg-type]
+        llm_api_key="key-test",
+        llm_analysis_model="gemini-2.0-flash" if provider == "gemini" else "gpt-4o",
+        llm_embedding_model="text-embedding-004" if provider == "gemini" else "text-embedding-3-large",
+        llm_embedding_dim=dim,
+    )
+
+
+class TestProviderConfig:
+    def test_default_provider_is_openai(self):
+        from core.config import Settings
+
+        s = Settings(_env_file=None, llm_api_key="sk-test")
+        assert s.llm_provider == "openai"
+        assert s.llm_embedding_dim == 3072
+
+    def test_provider_env_switch(self):
+        from core.config import Settings
+
+        s = Settings(_env_file=None, llm_provider="gemini", llm_api_key="g-test")
+        assert s.llm_provider == "gemini"
+
+    def test_gemini_api_key_alias(self, monkeypatch):
+        monkeypatch.delenv("LLM_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "g-alias")
+        from core.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.llm_api_key == "g-alias"
+
+    def test_embedding_dim_override(self):
+        from core.config import Settings
+
+        s = Settings(_env_file=None, llm_api_key="k", llm_embedding_dim=768)
+        assert s.llm_embedding_dim == 768
+
+
+class TestEmbeddingDimHelper:
+    def test_get_embedding_dim_reads_settings(self):
+        from core import llm
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("gemini", dim=768)):
+            assert llm.get_embedding_dim() == 768
+
+
+class TestMessageRoleMapping:
+    def test_system_user_assistant_mapped_to_gemini(self):
+        from core.llm import _messages_to_gemini
+
+        system, contents = _messages_to_gemini([
+            {"role": "system", "content": "sys1"},
+            {"role": "system", "content": "sys2"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "again"},
+        ])
+        assert system == "sys1\n\nsys2"
+        assert [m["role"] for m in contents] == ["user", "model", "user"]
+        assert contents[0]["parts"] == ["hi"]
+        assert contents[1]["parts"] == ["hello"]
+
+
+class TestProviderBranching:
+    def test_generate_text_uses_gemini_when_provider_gemini(self):
+        from core import llm
+
+        fake_resp = types.SimpleNamespace(text="gemini-response")
+        fake_model = MagicMock()
+        fake_model.generate_content.return_value = fake_resp
+        fake_genai = MagicMock()
+        fake_genai.GenerativeModel.return_value = fake_model
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("gemini")), \
+             patch.object(llm, "_get_gemini_module", return_value=fake_genai), \
+             patch.object(llm, "_get_openai_client") as openai_client:
+            out = llm.generate_text(
+                [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}],
+                temperature=0.5,
+                max_tokens=128,
+            )
+            assert out == "gemini-response"
+            openai_client.assert_not_called()
+            fake_genai.GenerativeModel.assert_called_once()
+            kwargs = fake_genai.GenerativeModel.call_args.kwargs
+            assert kwargs["model_name"] == "gemini-2.0-flash"
+            assert kwargs["system_instruction"] == "s"
+            gen_kwargs = fake_model.generate_content.call_args.kwargs
+            assert gen_kwargs["generation_config"]["temperature"] == 0.5
+            assert gen_kwargs["generation_config"]["max_output_tokens"] == 128
+
+    def test_generate_text_uses_openai_when_provider_openai(self):
+        from core import llm
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="openai-response"))]
+        )
+        with patch.object(llm, "get_settings", return_value=_make_settings("openai")), \
+             patch.object(llm, "_get_openai_client", return_value=fake_client), \
+             patch.object(llm, "_get_gemini_module") as gemini_mod:
+            out = llm.generate_text([{"role": "user", "content": "hi"}])
+            assert out == "openai-response"
+            gemini_mod.assert_not_called()
+
+    def test_generate_embeddings_uses_gemini(self):
+        from core import llm
+
+        fake_genai = MagicMock()
+        fake_genai.embed_content.side_effect = [
+            {"embedding": [0.1, 0.2, 0.3]},
+            {"embedding": {"values": [0.4, 0.5, 0.6]}},
+        ]
+        with patch.object(llm, "get_settings", return_value=_make_settings("gemini", dim=3)), \
+             patch.object(llm, "_get_gemini_module", return_value=fake_genai):
+            out = llm.generate_embeddings(["a", "b"])
+            assert out == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+            assert fake_genai.embed_content.call_count == 2
+
+    def test_generate_structured_uses_gemini(self):
+        from core import llm
+
+        fake_resp = types.SimpleNamespace(text='{"answer": "hi", "score": 7}')
+        fake_model = MagicMock()
+        fake_model.generate_content.return_value = fake_resp
+        fake_genai = MagicMock()
+        fake_genai.GenerativeModel.return_value = fake_model
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("gemini")), \
+             patch.object(llm, "_get_gemini_module", return_value=fake_genai):
+            parsed = llm.generate_text_with_structured_output(
+                [{"role": "user", "content": "q"}],
+                _DummyStruct,
+            )
+            assert isinstance(parsed, _DummyStruct)
+            assert parsed.answer == "hi"
+            assert parsed.score == 7


### PR DESCRIPTION
## Summary
This PR implements multi-provider LLM abstraction to support both OpenAI and Google Gemini APIs. It introduces a provider-agnostic interface that allows switching between LLM providers via configuration, while maintaining backward compatibility with existing OpenAI-based code.

## Key Changes

- **Provider Configuration**: Added `llm_provider` field to `Settings` to switch between "openai" and "gemini" providers via `LLM_PROVIDER` environment variable (defaults to "openai")

- **Gemini API Integration**: Implemented complete Gemini adapter with:
  - `_get_gemini_module()`: Lazy-loaded initialization of google-generativeai SDK
  - `_messages_to_gemini()`: Converts OpenAI message format to Gemini format (system instructions + contents)
  - `_gemini_generate_text()`: Text generation with temperature and max_tokens support
  - `_gemini_generate_structured()`: Structured output generation using JSON schema
  - `_gemini_generate_embeddings()`: Embedding generation with per-text API calls

- **Provider Branching**: Updated public API functions to route to appropriate provider:
  - `generate_text()`: Routes to Gemini or OpenAI based on provider setting
  - `generate_text_with_structured_output()`: Routes to Gemini or OpenAI
  - `generate_embeddings()`: Routes to Gemini or OpenAI

- **Embedding Dimension Abstraction**: 
  - Added `llm_embedding_dim` configuration field (defaults to 3072 for OpenAI)
  - Added `get_embedding_dim()` helper function to retrieve current dimension
  - Updated all pgvector queries to use dynamic dimension instead of hardcoded 3072

- **API Key Flexibility**: Extended `llm_api_key` validation aliases to accept `GEMINI_API_KEY` and `GOOGLE_API_KEY` environment variables

- **Comprehensive Test Coverage**: Added 159-line test suite covering:
  - Provider configuration and defaults
  - Environment variable aliasing
  - Message format conversion
  - Provider-specific branching logic
  - Embedding dimension handling

## Notable Implementation Details

- Message role mapping: "assistant" → "model" for Gemini compatibility
- System instructions are aggregated from multiple system messages with "\n\n" separator
- Gemini embeddings API returns variable response formats (direct array or nested "values" object)
- All hardcoded vector dimensions (3072) replaced with dynamic `get_embedding_dim()` calls across embedder, chat, and services modules
- Backward compatible: existing OpenAI configurations work unchanged

https://claude.ai/code/session_017UVEwDkUFJaym7jtP96Wjm