### PR TITLE
Add Vertex AI ADC authentication support (deprecated)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ LLM_EMBEDDING_DIM=3072
 # LLM_EMBEDDING_MODEL=text-embedding-004
 # LLM_EMBEDDING_DIM=768
 
+# --- Gemini / Vertex AI ADC 認証 (廃止予定) ---
+# gcloud auth application-default login を実行してから使用する。
+# LLM_API_KEY は不要 (ADC を使用)。
+# LLM_PROVIDER=gemini-vertex
+# LLM_ANALYSIS_MODEL=gemini-2.0-flash
+# LLM_EMBEDDING_MODEL=text-embedding-004
+# LLM_EMBEDDING_DIM=768
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# GOOGLE_CLOUD_LOCATION=us-central1
+
 # LLM マルチモード設定 (Fast / Standard / Deep)
 LLM_FAST_MODEL=gpt-5.4-nano
 LLM_FAST_EFFORT=low

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -35,8 +35,9 @@ class Settings(BaseSettings):
     )
 
     # --- LLM ---
-    # プロバイダ切替 (openai | gemini)。.env の LLM_PROVIDER で切り替える。
-    llm_provider: Literal["openai", "gemini"] = Field(
+    # プロバイダ切替 (openai | gemini | gemini-vertex)。.env の LLM_PROVIDER で切り替える。
+    # gemini-vertex: Vertex AI ADC 認証 (廃止予定)
+    llm_provider: Literal["openai", "gemini", "gemini-vertex"] = Field(
         default="openai",
         validation_alias=AliasChoices("LLM_PROVIDER"),
     )
@@ -97,6 +98,18 @@ class Settings(BaseSettings):
 
     # --- ISOM ---
     isom_output_dir: str = "output/incoming"
+
+    # --- Google Cloud / Vertex AI (廃止予定) ---
+    # LLM_PROVIDER=gemini-vertex のときのみ参照される。
+    # ADC は gcloud auth application-default login で設定すること。
+    google_cloud_project: str = Field(
+        default="",
+        validation_alias=AliasChoices("GOOGLE_CLOUD_PROJECT"),
+    )
+    google_cloud_location: str = Field(
+        default="us-central1",
+        validation_alias=AliasChoices("GOOGLE_CLOUD_LOCATION"),
+    )
 
 
 @lru_cache(maxsize=1)

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -184,6 +184,54 @@ def _get_gemini_module():
     return genai
 
 
+# ---------------------------------------------------------------------------
+# Gemini Vertex AI Adapter（廃止予定 / Deprecated）
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _get_gemini_vertex_module():
+    """Vertex AI ADC で初期化した google-generativeai モジュールを返す。
+
+    .. deprecated::
+        この認証方式は廃止予定です。
+        将来的には ``LLM_PROVIDER=gemini`` と ``LLM_API_KEY`` による認証に移行してください。
+
+    ADC の設定手順::
+
+        gcloud auth application-default login
+
+    ``GOOGLE_CLOUD_PROJECT`` と ``GOOGLE_CLOUD_LOCATION`` 環境変数も参照する。
+    """
+    import google.auth  # type: ignore[import]
+    import google.auth.exceptions  # type: ignore[import]
+    import google.generativeai as genai  # type: ignore[import]
+
+    settings = get_settings()
+    location = settings.google_cloud_location or "us-central1"
+
+    try:
+        credentials, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+    except google.auth.exceptions.DefaultCredentialsError as exc:
+        raise EnvironmentError(
+            "Vertex AI ADC が見つかりません。\n"
+            "  gcloud auth application-default login\n"
+            "を実行してから再起動してください。"
+        ) from exc
+
+    genai.configure(
+        credentials=credentials,
+        client_options={"api_endpoint": f"{location}-aiplatform.googleapis.com"},
+    )
+    logger.info(
+        "Gemini Vertex AI adapter initialized (project=%s, location=%s) [DEPRECATED]",
+        settings.google_cloud_project or "<ADC default>",
+        location,
+    )
+    return genai
+
+
 def _messages_to_gemini(
     messages: list[dict[str, str]],
 ) -> tuple[str | None, list[dict[str, Any]]]:
@@ -212,10 +260,11 @@ def _gemini_generate_text(
     messages: list[dict[str, str]],
     model_name: str,
     *,
+    genai_module: Any,
     temperature: float | None = None,
     max_tokens: int | None = None,
 ) -> str:
-    genai = _get_gemini_module()
+    genai = genai_module
     system_instruction, contents = _messages_to_gemini(messages)
     generation_config: dict[str, Any] = {}
     if temperature is not None:
@@ -238,8 +287,10 @@ def _gemini_generate_structured(
     messages: list[dict[str, str]],
     response_format: type[T],
     model_name: str,
+    *,
+    genai_module: Any,
 ) -> T:
-    genai = _get_gemini_module()
+    genai = genai_module
     system_instruction, contents = _messages_to_gemini(messages)
     schema = response_format.model_json_schema()
     model = genai.GenerativeModel(
@@ -264,8 +315,10 @@ def _gemini_generate_structured(
 def _gemini_generate_embeddings(
     texts: list[str],
     model_name: str,
+    *,
+    genai_module: Any,
 ) -> list[list[float]]:
-    genai = _get_gemini_module()
+    genai = genai_module
     # Gemini の embed_content は text 単位のためループで呼び出す。
     result: list[list[float]] = []
     for t in texts:
@@ -318,6 +371,16 @@ def generate_text(
         return _gemini_generate_text(
             messages,
             model_name,
+            genai_module=_get_gemini_module(),
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    if settings.llm_provider == "gemini-vertex":  # 廃止予定
+        return _gemini_generate_text(
+            messages,
+            model_name,
+            genai_module=_get_gemini_vertex_module(),
             temperature=temperature,
             max_tokens=max_tokens,
         )
@@ -368,7 +431,10 @@ def generate_text_with_structured_output(
     model_name = model or settings.llm_analysis_model
 
     if settings.llm_provider == "gemini":
-        return _gemini_generate_structured(messages, response_format, model_name)
+        return _gemini_generate_structured(messages, response_format, model_name, genai_module=_get_gemini_module())
+
+    if settings.llm_provider == "gemini-vertex":  # 廃止予定
+        return _gemini_generate_structured(messages, response_format, model_name, genai_module=_get_gemini_vertex_module())
 
     client = _get_openai_client()
 
@@ -412,7 +478,10 @@ def generate_embeddings(
     model_name = model or settings.llm_embedding_model
 
     if settings.llm_provider == "gemini":
-        return _gemini_generate_embeddings(texts, model_name)
+        return _gemini_generate_embeddings(texts, model_name, genai_module=_get_gemini_module())
+
+    if settings.llm_provider == "gemini-vertex":  # 廃止予定
+        return _gemini_generate_embeddings(texts, model_name, genai_module=_get_gemini_vertex_module())
 
     client = _get_openai_client()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,13 @@ services:
       - "8001:8001"
     environment:
       JWT_SECRET: ${JWT_SECRET:-episteme-dev-secret-change-in-prod}
+      LLM_PROVIDER: ${LLM_PROVIDER:-openai}
       LLM_API_KEY: ${LLM_API_KEY:-${OPENAI_API_KEY}}
       LLM_ANALYSIS_MODEL: ${LLM_ANALYSIS_MODEL:-${OPENAI_ANALYSIS_MODEL:-o3-mini}}
       LLM_EMBEDDING_MODEL: ${LLM_EMBEDDING_MODEL:-${OPENAI_EMBEDDING_MODEL:-text-embedding-3-large}}
+      # Vertex AI ADC 設定 (LLM_PROVIDER=gemini-vertex のときのみ有効、廃止予定)
+      GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
+      GOOGLE_CLOUD_LOCATION: ${GOOGLE_CLOUD_LOCATION:-us-central1}
       NEO4J_URI: bolt://neo4j:7687
       NEO4J_AUTH: neo4j/episteme
       DATABASE_URL: postgresql://episteme:episteme@postgres:5432/episteme
@@ -68,6 +72,9 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+    # LLM_PROVIDER=gemini-vertex を使う場合は ADC 認証ファイルのマウントが必要 (廃止予定):
+    #   volumes:
+    #     - ~/.config/gcloud:/root/.config/gcloud:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
This PR adds support for Vertex AI authentication using Application Default Credentials (ADC) as an alternative to the standard Gemini API key authentication. This authentication method is marked as deprecated and will be phased out in favor of the standard `gemini` provider with `LLM_API_KEY`.

## Key Changes

- **New Gemini Vertex AI Adapter**: Added `_get_gemini_vertex_module()` function that initializes the google-generativeai module using Vertex AI ADC credentials instead of API keys
  - Supports configurable GCP project and location via environment variables
  - Includes proper error handling for missing ADC credentials
  - Marked as deprecated with migration guidance in docstring

- **Refactored Gemini Helper Functions**: Modified `_gemini_generate_text()`, `_gemini_generate_structured()`, and `_gemini_generate_embeddings()` to accept a `genai_module` parameter instead of always calling `_get_gemini_module()`
  - Allows these functions to work with either standard Gemini or Vertex AI ADC authentication
  - Improves testability and flexibility

- **Updated Provider Configuration**: Extended `llm_provider` setting to support three options: `openai`, `gemini`, and `gemini-vertex`
  - Added `google_cloud_project` and `google_cloud_location` configuration fields for Vertex AI setup

- **Public API Updates**: Updated `generate_text()`, `generate_text_with_structured_output()`, and `generate_embeddings()` to route to appropriate authentication method based on `llm_provider` setting

- **Documentation & Examples**: Added configuration examples in `.env.example` and `docker-compose.yml` showing how to use Vertex AI ADC authentication with setup instructions

## Implementation Details

- Uses `gcloud auth application-default login` for credential management instead of API keys
- Configures the Gemini client with Vertex AI endpoint and credentials
- All Vertex AI-related code is clearly marked as deprecated with migration guidance
- Maintains backward compatibility with existing `gemini` provider configuration

https://claude.ai/code/session_01XVpzJqmenyZycceDZvmwK3