### PR TITLE
Add Google Vertex AI support with ADC authentication (Issue #99)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # LLM プロバイダ設定
-# LLM_PROVIDER: openai (デフォルト) または gemini
+# LLM_PROVIDER: openai (デフォルト) | gemini | google
+#   openai  — OpenAI API (LLM_API_KEY 必須)
+#   gemini  — Google AI Studio API (LLM_API_KEY 必須)
+#   google  — Google Vertex AI + ADC 認証 (LLM_API_KEY 不要、GCP 認証情報のみ必要)
 LLM_PROVIDER=openai
 
 # API キー — OpenAI の場合は sk-... / Gemini の場合は AI Studio の APIキー
 # 後方互換: OPENAI_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY も使用可
+# LLM_PROVIDER=google の場合は不要 (ADC を使用)
 LLM_API_KEY=sk-your-api-key-here
 
 # --- OpenAI 利用時 ---
@@ -11,20 +15,32 @@ LLM_ANALYSIS_MODEL=o3-mini
 LLM_EMBEDDING_MODEL=text-embedding-3-large
 LLM_EMBEDDING_DIM=3072
 
-# --- Gemini 利用時 (例) ---
+# --- Gemini (AI Studio) 利用時 ---
 # LLM_PROVIDER=gemini
 # LLM_API_KEY=your-gemini-api-key
 # LLM_ANALYSIS_MODEL=gemini-2.0-flash
 # LLM_EMBEDDING_MODEL=text-embedding-004
 # LLM_EMBEDDING_DIM=768
 
-# --- Gemini / Vertex AI ADC 認証 (廃止予定) ---
-# gcloud auth application-default login を実行してから使用する。
-# LLM_API_KEY は不要 (ADC を使用)。
-# LLM_PROVIDER=gemini-vertex
+# --- Google Vertex AI + ADC 認証 ---
+# LLM_API_KEY は不要。GCP 認証情報（ADC）を使用する。
+# 認証方法 (いずれか):
+#   1. ローカル開発: gcloud auth application-default login
+#   2. サービスアカウントキー: GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json
+#   3. GCE / Cloud Run 上: メタデータサーバーが自動的に認証情報を提供
+#
+# Docker で実行する場合は docker-compose.yml の volumes セクションのコメントを参照。
+# LLM_PROVIDER=google
 # LLM_ANALYSIS_MODEL=gemini-2.0-flash
 # LLM_EMBEDDING_MODEL=text-embedding-004
 # LLM_EMBEDDING_DIM=768
+# GCP_PROJECT_ID=your-gcp-project-id
+# GCP_LOCATION=us-central1
+# GCP_USE_VERTEX_AI=true
+# GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
+
+# --- Gemini / Vertex AI ADC 認証 (廃止予定: LLM_PROVIDER=google を使用してください) ---
+# LLM_PROVIDER=gemini-vertex
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 # GOOGLE_CLOUD_LOCATION=us-central1
 

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ LLM_EMBEDDING_DIM=3072
 #
 # Docker で実行する場合は docker-compose.yml の volumes セクションのコメントを参照。
 # LLM_PROVIDER=google
-# LLM_ANALYSIS_MODEL=gemini-2.0-flash
+# LLM_ANALYSIS_MODEL=gemini-2.5-flash
 # LLM_EMBEDDING_MODEL=text-embedding-004
 # LLM_EMBEDDING_DIM=768
 # GCP_PROJECT_ID=your-gcp-project-id

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# GCP
+.gcp/

--- a/backend/api/requirements.txt
+++ b/backend/api/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]>=0.29,<1
 python-multipart>=0.0.7,<1
 openai>=1.30,<2
 google-generativeai>=0.7,<1
+google-cloud-aiplatform>=1.60,<2
 neo4j>=5.19,<6
 PyJWT>=2.8,<3
 python-dotenv>=1.0,<2

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -35,9 +35,10 @@ class Settings(BaseSettings):
     )
 
     # --- LLM ---
-    # プロバイダ切替 (openai | gemini | gemini-vertex)。.env の LLM_PROVIDER で切り替える。
+    # プロバイダ切替 (openai | gemini | google | gemini-vertex)。.env の LLM_PROVIDER で切り替える。
+    # google: Vertex AI ADC 認証（google-cloud-aiplatform / vertexai SDK を使用）
     # gemini-vertex: Vertex AI ADC 認証 (廃止予定)
-    llm_provider: Literal["openai", "gemini", "gemini-vertex"] = Field(
+    llm_provider: Literal["openai", "gemini", "google", "gemini-vertex"] = Field(
         default="openai",
         validation_alias=AliasChoices("LLM_PROVIDER"),
     )
@@ -99,9 +100,24 @@ class Settings(BaseSettings):
     # --- ISOM ---
     isom_output_dir: str = "output/incoming"
 
+    # --- Google Cloud / Vertex AI ---
+    # LLM_PROVIDER=google または gemini-vertex のときに参照される。
+    # ADC は gcloud auth application-default login または GOOGLE_APPLICATION_CREDENTIALS で設定すること。
+    gcp_project_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT"),
+    )
+    gcp_location: str = Field(
+        default="us-central1",
+        validation_alias=AliasChoices("GCP_LOCATION", "GOOGLE_CLOUD_LOCATION"),
+    )
+    gcp_use_vertex_ai: bool = Field(
+        default=True,
+        validation_alias=AliasChoices("GCP_USE_VERTEX_AI"),
+    )
+
     # --- Google Cloud / Vertex AI (廃止予定) ---
-    # LLM_PROVIDER=gemini-vertex のときのみ参照される。
-    # ADC は gcloud auth application-default login で設定すること。
+    # 後方互換のため残存。新規利用には gcp_project_id / gcp_location を使用すること。
     google_cloud_project: str = Field(
         default="",
         validation_alias=AliasChoices("GOOGLE_CLOUD_PROJECT"),

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -115,6 +115,13 @@ class Settings(BaseSettings):
         default=True,
         validation_alias=AliasChoices("GCP_USE_VERTEX_AI"),
     )
+    # GCP 認証ファイルの絶対パス。設定されている場合は llm.py 内で
+    # os.environ["GOOGLE_APPLICATION_CREDENTIALS"] に明示的にセットする。
+    # Docker では /app/.gcp/credentials.json が既定値 (docker-compose.yml 参照)。
+    google_application_credentials: str = Field(
+        default="",
+        validation_alias=AliasChoices("GOOGLE_APPLICATION_CREDENTIALS"),
+    )
 
     # --- Google Cloud / Vertex AI (廃止予定) ---
     # 後方互換のため残存。新規利用には gcp_project_id / gcp_location を使用すること。

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -185,6 +185,121 @@ def _get_gemini_module():
 
 
 # ---------------------------------------------------------------------------
+# Google Vertex AI Adapter（google-cloud-aiplatform / vertexai SDK）
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=1)
+def _get_vertex_ai_client():
+    """Vertex AI SDK (google-cloud-aiplatform) を初期化して返す。
+
+    ADC（Application Default Credentials）を自動参照する:
+
+    - ``gcloud auth application-default login`` で設定したクレデンシャル
+    - ``GOOGLE_APPLICATION_CREDENTIALS`` 環境変数で指定したサービスアカウントキー
+    - GCE / Cloud Run 上のメタデータサーバー
+
+    ``GCP_PROJECT_ID`` および ``GCP_LOCATION`` 環境変数も参照する。
+    ``LLM_API_KEY`` / ``GEMINI_API_KEY`` は不要。
+    """
+    import vertexai  # type: ignore[import]
+    import google.auth.exceptions  # type: ignore[import]
+
+    settings = get_settings()
+    project = settings.gcp_project_id or settings.google_cloud_project or None
+    location = settings.gcp_location or settings.google_cloud_location or "us-central1"
+
+    try:
+        vertexai.init(project=project, location=location)
+    except google.auth.exceptions.DefaultCredentialsError as exc:
+        raise EnvironmentError(
+            "Vertex AI ADC が見つかりません。以下のいずれかを設定してください:\n"
+            "  1. gcloud auth application-default login\n"
+            "  2. GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json\n"
+            "  3. GCP 環境（GCE / Cloud Run）上で実行する"
+        ) from exc
+
+    logger.info(
+        "Vertex AI adapter initialized (project=%s, location=%s)",
+        project or "<ADC default>",
+        location,
+    )
+    import vertexai as _vtx  # noqa: F811
+    return _vtx
+
+
+def _vertex_ai_generate_text(
+    messages: list[dict[str, str]],
+    model_name: str,
+    *,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    from vertexai.generative_models import GenerativeModel, GenerationConfig  # type: ignore[import]
+
+    system_instruction, contents = _messages_to_gemini(messages)
+    config_kwargs: dict[str, Any] = {}
+    if temperature is not None:
+        config_kwargs["temperature"] = temperature
+    if max_tokens is not None:
+        config_kwargs["max_output_tokens"] = max_tokens
+    generation_config = GenerationConfig(**config_kwargs) if config_kwargs else None
+
+    model = GenerativeModel(
+        model_name=model_name,
+        system_instruction=system_instruction,
+    )
+    # Vertex AI の contents は {"role": ..., "parts": [...]} 形式でそのまま使用可
+    response = model.generate_content(
+        contents,
+        generation_config=generation_config,
+    )
+    return (getattr(response, "text", "") or "").strip()
+
+
+def _vertex_ai_generate_structured(
+    messages: list[dict[str, str]],
+    response_format: type[T],
+    model_name: str,
+) -> T:
+    from vertexai.generative_models import GenerativeModel, GenerationConfig  # type: ignore[import]
+
+    system_instruction, contents = _messages_to_gemini(messages)
+    schema = response_format.model_json_schema()
+
+    model = GenerativeModel(
+        model_name=model_name,
+        system_instruction=system_instruction,
+    )
+    response = model.generate_content(
+        contents,
+        generation_config=GenerationConfig(
+            response_mime_type="application/json",
+            response_schema=schema,
+        ),
+    )
+    raw = getattr(response, "text", "") or ""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"Vertex AI の構造化レスポンスを JSON として解析できませんでした: {raw!r}"
+        ) from exc
+    return response_format.model_validate(data)
+
+
+def _vertex_ai_generate_embeddings(
+    texts: list[str],
+    model_name: str,
+) -> list[list[float]]:
+    from vertexai.language_models import TextEmbeddingModel, TextEmbeddingInput  # type: ignore[import]
+
+    model = TextEmbeddingModel.from_pretrained(model_name)
+    inputs = [TextEmbeddingInput(text=t) for t in texts]
+    embeddings = model.get_embeddings(inputs)
+    return [list(e.values) for e in embeddings]
+
+
+# ---------------------------------------------------------------------------
 # Gemini Vertex AI Adapter（廃止予定 / Deprecated）
 # ---------------------------------------------------------------------------
 
@@ -194,7 +309,7 @@ def _get_gemini_vertex_module():
 
     .. deprecated::
         この認証方式は廃止予定です。
-        将来的には ``LLM_PROVIDER=gemini`` と ``LLM_API_KEY`` による認証に移行してください。
+        ``LLM_PROVIDER=google`` への移行を推奨します。
 
     ADC の設定手順::
 
@@ -376,6 +491,15 @@ def generate_text(
             max_tokens=max_tokens,
         )
 
+    if settings.llm_provider == "google":
+        _get_vertex_ai_client()  # ADC 初期化（キャッシュ済み）
+        return _vertex_ai_generate_text(
+            messages,
+            model_name,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
     if settings.llm_provider == "gemini-vertex":  # 廃止予定
         return _gemini_generate_text(
             messages,
@@ -433,6 +557,10 @@ def generate_text_with_structured_output(
     if settings.llm_provider == "gemini":
         return _gemini_generate_structured(messages, response_format, model_name, genai_module=_get_gemini_module())
 
+    if settings.llm_provider == "google":
+        _get_vertex_ai_client()  # ADC 初期化（キャッシュ済み）
+        return _vertex_ai_generate_structured(messages, response_format, model_name)
+
     if settings.llm_provider == "gemini-vertex":  # 廃止予定
         return _gemini_generate_structured(messages, response_format, model_name, genai_module=_get_gemini_vertex_module())
 
@@ -479,6 +607,10 @@ def generate_embeddings(
 
     if settings.llm_provider == "gemini":
         return _gemini_generate_embeddings(texts, model_name, genai_module=_get_gemini_module())
+
+    if settings.llm_provider == "google":
+        _get_vertex_ai_client()  # ADC 初期化（キャッシュ済み）
+        return _vertex_ai_generate_embeddings(texts, model_name)
 
     if settings.llm_provider == "gemini-vertex":  # 廃止予定
         return _gemini_generate_embeddings(texts, model_name, genai_module=_get_gemini_vertex_module())

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from functools import lru_cache
 from typing import Any, Literal, TypeVar
@@ -192,36 +193,53 @@ def _get_gemini_module():
 def _get_vertex_ai_client():
     """Vertex AI SDK (google-cloud-aiplatform) を初期化して返す。
 
-    ADC（Application Default Credentials）を自動参照する:
+    認証は以下の優先順で解決される:
 
-    - ``gcloud auth application-default login`` で設定したクレデンシャル
-    - ``GOOGLE_APPLICATION_CREDENTIALS`` 環境変数で指定したサービスアカウントキー
-    - GCE / Cloud Run 上のメタデータサーバー
+    1. ``settings.google_application_credentials`` (= ``GOOGLE_APPLICATION_CREDENTIALS`` 環境変数)
+       が設定されていればそのファイルを使用。Docker では ``/app/.gcp/credentials.json`` が既定。
+    2. ``gcloud auth application-default login`` で生成された ADC クレデンシャル。
+    3. GCE / Cloud Run 上のメタデータサーバー（サービスアカウント自動付与）。
 
-    ``GCP_PROJECT_ID`` および ``GCP_LOCATION`` 環境変数も参照する。
     ``LLM_API_KEY`` / ``GEMINI_API_KEY`` は不要。
     """
-    import vertexai  # type: ignore[import]
-    import google.auth.exceptions  # type: ignore[import]
-
     settings = get_settings()
     project = settings.gcp_project_id or settings.google_cloud_project or None
     location = settings.gcp_location or settings.google_cloud_location or "us-central1"
+
+    # ① 認証ファイルパスを os.environ に明示セット（Google SDK が自動参照する）
+    #    import より前に行うことでファイル不在を早期に検出できる。
+    cred_path = settings.google_application_credentials
+    if cred_path:
+        if not os.path.isfile(cred_path):
+            raise EnvironmentError(
+                f"GOOGLE_APPLICATION_CREDENTIALS に指定されたファイルが見つかりません: {cred_path}\n"
+                "  - .gcp/credentials.json が存在するか確認してください。\n"
+                "  - docker-compose.yml の volumes で .gcp/ がマウントされているか確認してください。"
+            )
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_path
+        logger.debug("GOOGLE_APPLICATION_CREDENTIALS を設定しました: %s", cred_path)
+
+    # ② SDK インポート & Vertex AI 初期化
+    #    ADC は Google SDK が GOOGLE_APPLICATION_CREDENTIALS を自動参照する。
+    import vertexai  # type: ignore[import]
+    import google.auth.exceptions  # type: ignore[import]
 
     try:
         vertexai.init(project=project, location=location)
     except google.auth.exceptions.DefaultCredentialsError as exc:
         raise EnvironmentError(
             "Vertex AI ADC が見つかりません。以下のいずれかを設定してください:\n"
-            "  1. gcloud auth application-default login\n"
-            "  2. GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json\n"
+            "  1. .gcp/credentials.json にサービスアカウントキーを配置\n"
+            "     (GOOGLE_APPLICATION_CREDENTIALS=/app/.gcp/credentials.json)\n"
+            "  2. gcloud auth application-default login を実行し ADC を生成\n"
             "  3. GCP 環境（GCE / Cloud Run）上で実行する"
         ) from exc
 
     logger.info(
-        "Vertex AI adapter initialized (project=%s, location=%s)",
+        "Vertex AI adapter initialized (project=%s, location=%s, creds=%s)",
         project or "<ADC default>",
         location,
+        cred_path or "<ADC auto>",
     )
     import vertexai as _vtx  # noqa: F811
     return _vtx

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -376,15 +376,19 @@ def _messages_to_gemini(
     """
     system_parts: list[str] = []
     contents: list[dict[str, Any]] = []
+
     for msg in messages:
         role = msg.get("role", "user")
         content = msg.get("content", "")
+        
         if role == "system":
             system_parts.append(content)
         elif role == "assistant":
-            contents.append({"role": "model", "parts": [content]})
+            # Vertex AI SDK の厳格な仕様に合わせて {"text": content} とする
+            contents.append({"role": "model", "parts": [{"text": content}]})
         else:
-            contents.append({"role": "user", "parts": [content]})
+            contents.append({"role": "user", "parts": [{"text": content}]})
+            
     system_instruction = "\n\n".join(system_parts) if system_parts else None
     return system_instruction, contents
 

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -309,3 +310,75 @@ class TestGoogleVertexAIProvider:
         )
         assert s.llm_provider == "google"
         assert s.llm_api_key == ""
+
+    def test_config_google_application_credentials_field(self, monkeypatch):
+        """GOOGLE_APPLICATION_CREDENTIALS が Settings に読み込まれる。"""
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/app/.gcp/credentials.json")
+        from core.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.google_application_credentials == "/app/.gcp/credentials.json"
+
+    def test_get_vertex_ai_client_raises_when_cred_file_missing(self, tmp_path):
+        """GOOGLE_APPLICATION_CREDENTIALS に存在しないパスを指定すると EnvironmentError。"""
+        from core import llm
+        from core.config import Settings
+
+        missing_path = str(tmp_path / "nonexistent.json")
+        settings = Settings(
+            _env_file=None,
+            llm_provider="google",
+            google_application_credentials=missing_path,
+        )
+
+        with patch.object(llm, "get_settings", return_value=settings):
+            llm._get_vertex_ai_client.cache_clear()
+            with pytest.raises(EnvironmentError, match="GOOGLE_APPLICATION_CREDENTIALS"):
+                llm._get_vertex_ai_client()
+            llm._get_vertex_ai_client.cache_clear()
+
+    def test_get_vertex_ai_client_sets_env_var_from_settings(self, tmp_path):
+        """設定ファイルが存在する場合、os.environ に GOOGLE_APPLICATION_CREDENTIALS がセットされる。"""
+        import json as _json
+        from core import llm
+        from core.config import Settings
+
+        # ダミーサービスアカウント JSON を作成
+        cred_file = tmp_path / "credentials.json"
+        cred_file.write_text(_json.dumps({"type": "service_account"}))
+
+        settings = Settings(
+            _env_file=None,
+            llm_provider="google",
+            gcp_project_id="test-proj",
+            google_application_credentials=str(cred_file),
+        )
+
+        fake_vertexai = MagicMock()
+
+        # google.auth.exceptions のモック階層
+        class FakeDCE(Exception):
+            pass
+
+        fake_exc_mod = types.ModuleType("google.auth.exceptions")
+        fake_exc_mod.DefaultCredentialsError = FakeDCE
+        fake_auth_mod = types.ModuleType("google.auth")
+        fake_auth_mod.exceptions = fake_exc_mod
+        fake_google_mod = types.ModuleType("google")
+        fake_google_mod.auth = fake_auth_mod
+
+        with patch.object(llm, "get_settings", return_value=settings), \
+             patch.dict("sys.modules", {
+                 "vertexai": fake_vertexai,
+                 "google": fake_google_mod,
+                 "google.auth": fake_auth_mod,
+                 "google.auth.exceptions": fake_exc_mod,
+             }), \
+             patch.dict("os.environ", {}, clear=False):
+            llm._get_vertex_ai_client.cache_clear()
+            llm._get_vertex_ai_client()
+            assert os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == str(cred_file)
+            fake_vertexai.init.assert_called_once_with(
+                project="test-proj", location="us-central1"
+            )
+            llm._get_vertex_ai_client.cache_clear()

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,4 +1,4 @@
-"""Issue #95: LLM プロバイダ抽象化 (OpenAI / Gemini) のテスト。"""
+"""Issue #95 / #99: LLM プロバイダ抽象化 (OpenAI / Gemini / Google Vertex AI) のテスト。"""
 
 from __future__ import annotations
 
@@ -15,16 +15,18 @@ class _DummyStruct(BaseModel):
     score: int
 
 
-def _make_settings(provider: str, dim: int = 3072):
+def _make_settings(provider: str, dim: int = 3072, **kwargs):
     from core.config import Settings
 
+    gemini_like = provider in ("gemini", "google")
     return Settings(
         _env_file=None,
         llm_provider=provider,  # type: ignore[arg-type]
-        llm_api_key="key-test",
-        llm_analysis_model="gemini-2.0-flash" if provider == "gemini" else "gpt-4o",
-        llm_embedding_model="text-embedding-004" if provider == "gemini" else "text-embedding-3-large",
+        llm_api_key="key-test" if provider not in ("google",) else "",
+        llm_analysis_model="gemini-2.0-flash" if gemini_like else "gpt-4o",
+        llm_embedding_model="text-embedding-004" if gemini_like else "text-embedding-3-large",
         llm_embedding_dim=dim,
+        **kwargs,
     )
 
 
@@ -157,3 +159,153 @@ class TestProviderBranching:
             assert isinstance(parsed, _DummyStruct)
             assert parsed.answer == "hi"
             assert parsed.score == 7
+
+
+# ---------------------------------------------------------------------------
+# Issue #99: LLM_PROVIDER=google (Vertex AI ADC) テスト
+# ---------------------------------------------------------------------------
+
+class TestGoogleVertexAIProvider:
+    """LLM_PROVIDER=google のルーティング・初期化テスト。"""
+
+    def _make_fake_vertex_model(self, text: str):
+        fake_resp = types.SimpleNamespace(text=text)
+        fake_model = MagicMock()
+        fake_model.generate_content.return_value = fake_resp
+        return fake_model
+
+    def test_config_accepts_google_provider(self):
+        from core.config import Settings
+
+        s = Settings(
+            _env_file=None,
+            llm_provider="google",
+            gcp_project_id="my-project",
+            gcp_location="asia-northeast1",
+        )
+        assert s.llm_provider == "google"
+        assert s.gcp_project_id == "my-project"
+        assert s.gcp_location == "asia-northeast1"
+        assert s.gcp_use_vertex_ai is True  # デフォルト値
+
+    def test_config_gcp_fields_default(self):
+        from core.config import Settings
+
+        s = Settings(_env_file=None, llm_provider="google")
+        assert s.gcp_project_id == ""
+        assert s.gcp_location == "us-central1"
+        assert s.gcp_use_vertex_ai is True
+
+    def test_config_gcp_project_id_env_alias(self, monkeypatch):
+        monkeypatch.setenv("GCP_PROJECT_ID", "proj-from-env")
+        monkeypatch.setenv("GCP_LOCATION", "us-east1")
+        from core.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.gcp_project_id == "proj-from-env"
+        assert s.gcp_location == "us-east1"
+
+    def test_config_gcp_backward_compat_alias(self, monkeypatch):
+        """GOOGLE_CLOUD_PROJECT も gcp_project_id にマップされる。"""
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "legacy-proj")
+        monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+        from core.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.gcp_project_id == "legacy-proj"
+
+    def test_generate_text_uses_vertex_ai_when_provider_google(self):
+        from core import llm
+
+        fake_model = self._make_fake_vertex_model("vertex-response")
+
+        fake_generative_model_cls = MagicMock(return_value=fake_model)
+        fake_generation_config_cls = MagicMock()
+
+        vertex_module = MagicMock()
+        vertex_module.GenerativeModel = fake_generative_model_cls
+        vertex_module.GenerationConfig = fake_generation_config_cls
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("google")), \
+             patch.object(llm, "_get_vertex_ai_client", return_value=MagicMock()), \
+             patch.object(llm, "_get_openai_client") as openai_client, \
+             patch.object(llm, "_get_gemini_module") as gemini_mod, \
+             patch("core.llm._vertex_ai_generate_text", return_value="vertex-response") as vtx_gen:
+            out = llm.generate_text(
+                [{"role": "user", "content": "hello"}],
+                temperature=0.7,
+            )
+            assert out == "vertex-response"
+            vtx_gen.assert_called_once()
+            openai_client.assert_not_called()
+            gemini_mod.assert_not_called()
+
+    def test_generate_embeddings_uses_vertex_ai_when_provider_google(self):
+        from core import llm
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("google")), \
+             patch.object(llm, "_get_vertex_ai_client", return_value=MagicMock()), \
+             patch("core.llm._vertex_ai_generate_embeddings", return_value=[[0.1, 0.2]]) as vtx_emb:
+            out = llm.generate_embeddings(["text"])
+            assert out == [[0.1, 0.2]]
+            vtx_emb.assert_called_once()
+
+    def test_generate_structured_uses_vertex_ai_when_provider_google(self):
+        from core import llm
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("google")), \
+             patch.object(llm, "_get_vertex_ai_client", return_value=MagicMock()), \
+             patch("core.llm._vertex_ai_generate_structured",
+                   return_value=_DummyStruct(answer="v", score=1)) as vtx_struct:
+            out = llm.generate_text_with_structured_output(
+                [{"role": "user", "content": "q"}],
+                _DummyStruct,
+            )
+            assert isinstance(out, _DummyStruct)
+            vtx_struct.assert_called_once()
+
+    def test_get_vertex_ai_client_raises_on_missing_adc(self):
+        """ADC が見つからない場合は EnvironmentError を投げる。"""
+        from core import llm
+
+        # google.auth.exceptions.DefaultCredentialsError を模倣するダミー例外クラス
+        class FakeDefaultCredentialsError(Exception):
+            pass
+
+        fake_vertexai = MagicMock()
+        fake_vertexai.init.side_effect = FakeDefaultCredentialsError("no credentials")
+
+        # google / google.auth / google.auth.exceptions のモジュール階層を構築
+        fake_google_auth_exceptions = types.ModuleType("google.auth.exceptions")
+        fake_google_auth_exceptions.DefaultCredentialsError = FakeDefaultCredentialsError
+
+        fake_google_auth = types.ModuleType("google.auth")
+        fake_google_auth.exceptions = fake_google_auth_exceptions
+
+        fake_google = types.ModuleType("google")
+        fake_google.auth = fake_google_auth
+
+        with patch.object(llm, "get_settings", return_value=_make_settings("google")), \
+             patch.dict("sys.modules", {
+                 "vertexai": fake_vertexai,
+                 "google": fake_google,
+                 "google.auth": fake_google_auth,
+                 "google.auth.exceptions": fake_google_auth_exceptions,
+             }):
+            llm._get_vertex_ai_client.cache_clear()
+            with pytest.raises(EnvironmentError, match="Vertex AI ADC"):
+                llm._get_vertex_ai_client()
+            llm._get_vertex_ai_client.cache_clear()
+
+    def test_no_api_key_required_for_google_provider(self):
+        """LLM_PROVIDER=google は llm_api_key が空でも設定を受け付ける。"""
+        from core.config import Settings
+
+        s = Settings(
+            _env_file=None,
+            llm_provider="google",
+            llm_api_key="",
+            gcp_project_id="my-project",
+        )
+        assert s.llm_provider == "google"
+        assert s.llm_api_key == ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,11 @@ services:
       LLM_API_KEY: ${LLM_API_KEY:-${OPENAI_API_KEY}}
       LLM_ANALYSIS_MODEL: ${LLM_ANALYSIS_MODEL:-${OPENAI_ANALYSIS_MODEL:-o3-mini}}
       LLM_EMBEDDING_MODEL: ${LLM_EMBEDDING_MODEL:-${OPENAI_EMBEDDING_MODEL:-text-embedding-3-large}}
+      # Vertex AI ADC 設定 (LLM_PROVIDER=google)
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:-${GOOGLE_CLOUD_PROJECT:-}}
+      GCP_LOCATION: ${GCP_LOCATION:-${GOOGLE_CLOUD_LOCATION:-us-central1}}
+      GCP_USE_VERTEX_AI: ${GCP_USE_VERTEX_AI:-true}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
       # Vertex AI ADC 設定 (LLM_PROVIDER=gemini-vertex のときのみ有効、廃止予定)
       GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
       GOOGLE_CLOUD_LOCATION: ${GOOGLE_CLOUD_LOCATION:-us-central1}
@@ -72,9 +77,19 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
-    # LLM_PROVIDER=gemini-vertex を使う場合は ADC 認証ファイルのマウントが必要 (廃止予定):
+    # LLM_PROVIDER=google (Vertex AI ADC) を使う場合はいずれかの方法で認証情報をマウントする:
+    #
+    # 方法1: gcloud ADC クレデンシャルを直接マウント
     #   volumes:
     #     - ~/.config/gcloud:/root/.config/gcloud:ro
+    #
+    # 方法2: サービスアカウントキーファイルをマウント
+    #   volumes:
+    #     - /path/to/service-account.json:/secrets/sa.json:ro
+    #   environment:
+    #     GOOGLE_APPLICATION_CREDENTIALS: /secrets/sa.json
+    #
+    # LLM_PROVIDER=gemini-vertex を使う場合も同様 (廃止予定):
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       GCP_USE_VERTEX_AI: ${GCP_USE_VERTEX_AI:-true}
       # 認証ファイルパス: ホストの .gcp/ をコンテナ内 /app/.gcp/ にマウントした場合の固定パス。
       # .env で上書き可能 (例: GOOGLE_APPLICATION_CREDENTIALS=/app/.gcp/sa.json)
-      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/.gcp/credentials.json}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/.gcp/application_default_credentials.json}
       # Vertex AI ADC 設定 (LLM_PROVIDER=gemini-vertex のときのみ有効、廃止予定)
       GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
       GOOGLE_CLOUD_LOCATION: ${GOOGLE_CLOUD_LOCATION:-us-central1}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,9 @@ services:
       GCP_PROJECT_ID: ${GCP_PROJECT_ID:-${GOOGLE_CLOUD_PROJECT:-}}
       GCP_LOCATION: ${GCP_LOCATION:-${GOOGLE_CLOUD_LOCATION:-us-central1}}
       GCP_USE_VERTEX_AI: ${GCP_USE_VERTEX_AI:-true}
-      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
+      # 認証ファイルパス: ホストの .gcp/ をコンテナ内 /app/.gcp/ にマウントした場合の固定パス。
+      # .env で上書き可能 (例: GOOGLE_APPLICATION_CREDENTIALS=/app/.gcp/sa.json)
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/.gcp/credentials.json}
       # Vertex AI ADC 設定 (LLM_PROVIDER=gemini-vertex のときのみ有効、廃止予定)
       GOOGLE_CLOUD_PROJECT: ${GOOGLE_CLOUD_PROJECT:-}
       GOOGLE_CLOUD_LOCATION: ${GOOGLE_CLOUD_LOCATION:-us-central1}
@@ -77,19 +79,13 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
-    # LLM_PROVIDER=google (Vertex AI ADC) を使う場合はいずれかの方法で認証情報をマウントする:
-    #
-    # 方法1: gcloud ADC クレデンシャルを直接マウント
-    #   volumes:
-    #     - ~/.config/gcloud:/root/.config/gcloud:ro
-    #
-    # 方法2: サービスアカウントキーファイルをマウント
-    #   volumes:
-    #     - /path/to/service-account.json:/secrets/sa.json:ro
-    #   environment:
-    #     GOOGLE_APPLICATION_CREDENTIALS: /secrets/sa.json
-    #
-    # LLM_PROVIDER=gemini-vertex を使う場合も同様 (廃止予定):
+    # ローカルの .gcp/ をコンテナに読み取り専用でマウントする。
+    # ファイルが存在しない場合は空ディレクトリとしてマウントされる（エラーにはならない）。
+    # サービスアカウントキーを使う場合: .gcp/credentials.json に配置する。
+    # gcloud ADC を使う場合: .gcp/application_default_credentials.json に配置し
+    #   GOOGLE_APPLICATION_CREDENTIALS=/app/.gcp/application_default_credentials.json を .env に記載。
+    volumes:
+      - ./.gcp:/app/.gcp:ro
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
This PR adds support for Google Vertex AI as an LLM provider using Application Default Credentials (ADC) authentication, addressing Issue #99. The new `google` provider option enables users to leverage Vertex AI's generative models without requiring API keys, instead relying on GCP authentication credentials.

## Key Changes

- **New LLM Provider**: Added `google` as a new `llm_provider` option alongside existing `openai`, `gemini`, and `gemini-vertex` providers
  
- **Vertex AI Adapter Implementation** (`core/llm.py`):
  - `_get_vertex_ai_client()`: Initializes Vertex AI SDK with ADC support, supporting multiple credential sources (gcloud CLI, service account keys, GCP metadata server)
  - `_vertex_ai_generate_text()`: Text generation using Vertex AI's GenerativeModel API
  - `_vertex_ai_generate_structured()`: Structured output generation with JSON schema support
  - `_vertex_ai_generate_embeddings()`: Text embedding generation using TextEmbeddingModel
  - Integrated routing in `generate_text()`, `generate_text_with_structured_output()`, and `generate_embeddings()` functions

- **Configuration Updates** (`core/config.py`):
  - Added GCP-specific settings: `gcp_project_id`, `gcp_location`, `gcp_use_vertex_ai`
  - Support for environment variable aliases: `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_USE_VERTEX_AI`
  - Backward compatibility with legacy `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` variables
  - Made `llm_api_key` optional when using `google` provider

- **Documentation & Examples**:
  - Updated `.env.example` with comprehensive Vertex AI setup instructions including three authentication methods
  - Enhanced `docker-compose.yml` with volume mounting examples for ADC credentials
  - Updated docstrings and comments to reflect new provider option

- **Test Coverage** (`tests/test_llm_provider.py`):
  - Added `TestGoogleVertexAIProvider` class with 8 new test cases covering:
    - Configuration validation for GCP fields
    - Environment variable aliasing and backward compatibility
    - ADC credential error handling with proper exception messages
    - Routing verification for text generation, embeddings, and structured output
    - API key requirement validation (not required for google provider)

## Implementation Details

- ADC initialization is cached using `@lru_cache` to avoid repeated credential lookups
- Proper error handling for missing credentials with user-friendly guidance on setup methods
- Reuses existing `_messages_to_gemini()` helper for message format conversion, as Vertex AI's GenerativeModel API is compatible with Gemini's message format
- Maintains backward compatibility with deprecated `gemini-vertex` provider while recommending migration to the new `google` provider

https://claude.ai/code/session_01JB1v6TZ3VWY3FRMeGc6JAn