### PR TITLE
Document LLM multi-provider support and embedding dimension guidelines

### DIFF
--- a/.claude/skills/episteme-graph-dev/SKILL.md
+++ b/.claude/skills/episteme-graph-dev/SKILL.md
@@ -39,13 +39,26 @@ PDF教材からの知識抽出、RAGベースの対話型学習、コース管�
 |---|---|
 | API フレームワーク | FastAPI (ルーター分割済み) |
 | ORM | SQLAlchemy 2.x + pgvector |
-| RDB + ベクトル | PostgreSQL 16 + pgvector (cosine, 3072次元) |
+| RDB + ベクトル | PostgreSQL 16 + pgvector (cosine, 次元数は `LLM_EMBEDDING_DIM` で設定) |
 | グラフDB | Neo4j 5 (Cypher) — レガシー、グラフ走査のみ |
 | ストレージ | MinIO (S3互換) |
-| LLM | OpenAI API (gpt-4o / text-embedding-3-large、Reasoning モデル対応済み) |
+| LLM | **マルチプロバイダ対応** (OpenAI / Gemini)。`LLM_PROVIDER` 環境変数で切替。詳細は下記参照。 |
 | 認証 | JWT (HS256) + bcrypt |
 | 設定管理 | pydantic-settings (core/config.py) |
 | フロントエンド | Vanilla JS SPA + nginx |
+
+### LLM マルチプロバイダ構成
+
+`LLM_PROVIDER` 環境変数で LLM バックエンドを切り替える。
+
+| `LLM_PROVIDER` 値 | バックエンド | 必要な認証 |
+|---|---|---|
+| `openai` (デフォルト) | OpenAI API | `LLM_API_KEY` または `OPENAI_API_KEY` |
+| `gemini` | Google AI Studio (google-generativeai) | `LLM_API_KEY` または `GEMINI_API_KEY` |
+| `google` | Vertex AI (google-cloud-aiplatform) | GCP ADC または `GOOGLE_APPLICATION_CREDENTIALS` |
+| `gemini-vertex` | Vertex AI + generativeai SDK **(廃止予定)** | GCP ADC |
+
+**重要**: `google` / `gemini-vertex` (Vertex AI) は非推奨。新規実装では `openai` または `gemini` を使用すること。
 
 ## 開発時の必須ルール
 
@@ -75,23 +88,42 @@ api_key = settings.openai_api_key
 - 管理系 → `routes/admin.py`
 - 新ドメインが必要な場合 → 新しいルーターファイルを作成
 
-### 3. LLM 抽象化レイヤーの利用 — `openai` SDK の直接利用禁止
+### 3. LLM 抽象化レイヤーの利用 — ベンダ SDK の直接利用禁止
 
 LLM の呼び出しは必ず `core/llm.py` の公開 API を経由する。
-`import openai` や `from openai import OpenAI` を他のモジュールで行わない。
+`extractor` / `chat` / `batch` 等のサービス層で以下のインポートを直接行ってはならない:
 
 ```python
-# NG
+# NG — ベンダ SDK をサービス層で直接インポートしない
+import openai
 from openai import OpenAI
-client = OpenAI()
+import google.generativeai
+from google.generativeai import GenerativeModel
 
-# OK
+# OK — 必ず core/llm.py の公開 API を使う
 from core.llm import generate_text, generate_embeddings, generate_text_with_structured_output
 ```
 
-`core/llm.py` は Reasoning モデル (o1, o3, gpt-5.x) 向けの自動変換を内蔵:
-- `system` ロール → `developer` ロールへの変換
-- `temperature` / `max_tokens` の自動除去
+`core/llm.py` は以下を内蔵:
+- OpenAI Reasoning モデル (o1, o3, gpt-5.x) 向け自動変換:
+  - `system` ロール → `developer` ロールへの変換
+  - `temperature` / `max_tokens` の自動除去
+- Gemini 向け自動変換:
+  - `system` ロールを `system_instruction` として抽出し `GenerativeModel` に渡す
+  - `user` / `assistant` ロールは `contents` として渡す
+
+### 3-a. Google LLM を使う際の禁止事項
+
+Google の LLM バックエンドを利用する場合、以下のルールを厳守すること:
+
+| 区分 | 内容 |
+|---|---|
+| **禁止** | `google-cloud-aiplatform` (`vertexai` SDK) を新規サービスコードで使用すること |
+| **禁止** | `LLM_PROVIDER=google` または `LLM_PROVIDER=gemini-vertex` を推奨設定として提案すること |
+| **推奨** | `LLM_PROVIDER=gemini` + `google-generativeai` (Google AI Studio 版) を使用すること |
+
+> **理由**: `google-cloud-aiplatform` (Vertex AI) は将来的な廃止を見越して意図的に非推奨としている。
+> 新規実装・AIへの提案ではかならず `google-generativeai` (Google AI Studio) を使うこと。
 
 ### 4. データベース操作
 

--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -20,11 +20,34 @@ PDF 教材からの知識抽出、グラフ構造の定義、パターンマッ�
 | テーブル | 役割 |
 |---|---|
 | `documents` | 教材メタデータ (タイトル、著者、ステータス、knowledge_graph JSONB) |
-| `chunks` | テキストチャンク + embedding (pgvector 3072次元) + DSL メタデータ |
+| `chunks` | テキストチャンク + embedding (pgvector) + DSL メタデータ |
 
 - ベクトル検索: `chunks.embedding` カラム (pgvector cosine distance)
 - ナレッジグラフ構造: `documents.knowledge_graph` (JSONB)
 - DSL 情報: `chunks.smiles_dsl`, `chunks.variables`, `chunks.ancestors` (JSONB)
+
+### Embedding 次元数に関する注意事項
+
+pgvector の次元数は LLM プロバイダと Embedding モデルによって異なる。
+**次元数は絶対にハードコードしない**。必ず `core/llm.py` の `get_embedding_dim()` または `settings.llm_embedding_dim` を参照すること。
+
+| LLM プロバイダ / モデル | Embedding モデル | 次元数 |
+|---|---|---|
+| OpenAI `text-embedding-3-large` | `LLM_PROVIDER=openai` のデフォルト | **3072** |
+| Gemini `text-embedding-004` | `LLM_PROVIDER=gemini` で典型的に使用 | **768** |
+| Gemini `gemini-embedding-exp-03-07` | 高精度 Gemini Embedding | **3072** |
+
+```python
+# NG — 次元数ハードコード禁止
+ALTER TABLE chunks ADD COLUMN embedding vector(3072);
+pgvector_query = "SELECT * FROM chunks ORDER BY embedding <=> $1::vector(3072)"
+
+# OK — 設定値から取得する
+from core.llm import get_embedding_dim
+dim = get_embedding_dim()  # settings.llm_embedding_dim の値を返す
+```
+
+DBスキーマ変更・マイグレーション作成時は `LLM_EMBEDDING_DIM` の値を確認し、現在の次元数に合わせた SQL を生成すること。
 
 データモデルの最新定義は `backend/core/models.py` の `Document` / `Chunk` クラスを直接読んで確認すること。
 
@@ -89,14 +112,45 @@ CorePredicate の定義は `backend/core/schema.py` を直接読んで最新の�
 
 実装の詳細は `backend/core/batch.py` を直接読んで確認すること。
 
+## LLM プロバイダ環境変数仕様
+
+ナレッジグラフ・パイプライン実装時に参照が必要な主要環境変数:
+
+| 環境変数 | 説明 | デフォルト値 |
+|---|---|---|
+| `LLM_PROVIDER` | LLM バックエンド (`openai` / `gemini`) | `openai` |
+| `LLM_API_KEY` | API キー（`OPENAI_API_KEY` / `GEMINI_API_KEY` も可） | — |
+| `LLM_ANALYSIS_MODEL` | テキスト生成に使用するモデル名 | `o3-mini` |
+| `LLM_EMBEDDING_MODEL` | Embedding に使用するモデル名 | `text-embedding-3-large` |
+| `LLM_EMBEDDING_DIM` | Embedding ベクトル次元数（pgvector スキーマと一致が必要） | `3072` |
+
+> **禁止**: `google-cloud-aiplatform` (Vertex AI) を新規パイプラインコードで使用すること。
+> Google の LLM を使う場合は必ず `LLM_PROVIDER=gemini` (`google-generativeai`) を指定すること。
+
+### OpenAI → Gemini のロールマッピング
+
+`core/llm.py` はプロバイダ間のロール変換を内部で自動処理する。
+パイプライン実装時は OpenAI 形式のメッセージリストをそのまま渡してよい。
+
+```
+OpenAI 形式                      → Gemini への変換
+─────────────────────────────────────────────────────
+{"role": "system",  "content": "..."} → GenerativeModel(system_instruction="...")
+{"role": "user",    "content": "..."} → contents[{"role": "user",  "parts": [...]}]
+{"role": "assistant","content": "..."} → contents[{"role": "model", "parts": [...]}]
+```
+
+この変換は `core/llm.py` 内部で行われるため、`extractor.py` / `chat.py` / `batch.py` 側での分岐は不要。
+
 ## 開発ガイドライン
 
 1. **スキーマ変更**: `backend/core/schema.py` の Pydantic モデルを先に更新し、`backend/core/models.py` の ORM モデルも同期する
 2. **新しい関係型**: `CorePredicate` 列挙型に追加し、既存コードへの影響を確認
 3. **抽出精度向上**: `backend/core/extractor.py` のプロンプトを調整
 4. **検索精度向上**: `backend/core/embedder.py` のチャンク戦略・クエリ戦略を調整
-5. **LLM 呼び出し**: 必ず `core/llm.py` の公開 API (`generate_text`, `generate_embeddings`, `generate_text_with_structured_output`) を経由する。`openai` SDK を直接使用しない
+5. **LLM 呼び出し**: 必ず `core/llm.py` の公開 API (`generate_text`, `generate_embeddings`, `generate_text_with_structured_output`) を経由する。`openai` / `google.generativeai` SDK を直接使用しない
 6. **設定値**: `core/config.py` の `get_settings()` を経由する。`os.environ` を直接使用しない
+7. **Embedding 次元数**: `get_embedding_dim()` または `settings.llm_embedding_dim` を使用し、絶対にハードコードしない
 
 ## CI テストパターンの更新（必須）
 


### PR DESCRIPTION
## Summary

Updated skill documentation to reflect the multi-provider LLM architecture and establish clear guidelines for handling embedding dimensions across different LLM providers (OpenAI and Gemini).

## Key Changes

- **Embedding dimension handling**: Removed hardcoded 3072 dimension reference and added comprehensive guidance to always use `get_embedding_dim()` or `settings.llm_embedding_dim` instead of hardcoding values
  - Added table documenting dimension differences across providers (OpenAI: 3072, Gemini: 768/3072)
  - Included code examples showing correct vs incorrect patterns
  - Added migration guidance for DB schema changes

- **LLM provider environment variables**: Documented the complete set of environment variables for multi-provider support
  - `LLM_PROVIDER` (openai/gemini)
  - `LLM_ANALYSIS_MODEL` and `LLM_EMBEDDING_MODEL`
  - `LLM_EMBEDDING_DIM` for pgvector schema alignment

- **Provider-specific role mapping**: Clarified how `core/llm.py` automatically handles OpenAI-to-Gemini message format conversion
  - System role handling
  - User/assistant role transformation
  - No branching needed in service layer code

- **Deprecated Vertex AI guidance**: Explicitly marked `google-cloud-aiplatform` (Vertex AI) as non-recommended for new implementations
  - Established `LLM_PROVIDER=gemini` (google-generativeai) as the preferred Google backend
  - Documented the deprecation rationale

- **Updated development guidelines**: 
  - Clarified that vendor SDKs (openai, google.generativeai) should not be imported directly in service layers
  - Added embedding dimension as a new guideline item
  - Updated LLM abstraction layer documentation to cover both OpenAI and Gemini transformations

- **Architecture documentation**: Updated tech stack descriptions to reflect multi-provider support instead of OpenAI-only references

## Implementation Details

All changes are documentation-only, establishing best practices and constraints for the existing multi-provider LLM architecture. No code logic changes are included.

https://claude.ai/code/session_01XHAhBxwjKDN7iRw7utZQTU