### PR TITLE
Add local development setup with ngrok tunnel and configurable CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,16 @@ MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 MINIO_PUBLIC_ENDPOINT=localhost:9000
 GROBID_URL=http://localhost:8070
+
+# ── ローカル開発 / ngrok ──────────────────────────────────────────
+# docker-compose.local.yml を使ったローカル開発時のみ必要。
+# ngrok アカウントを作成し、固定ドメインを取得してから設定してください。
+# https://dashboard.ngrok.com/tunnels/agents
+NGROK_AUTHTOKEN=your_ngrok_auth_token
+NGROK_DOMAIN=your-subdomain.ngrok-free.app
+
+# CORS 許可オリジン（カンマ区切り）。
+# ngrok 経由アクセスを許可する場合は固定ドメインを追加してください。
+# デフォルト "*" は全オリジン許可（開発用）。本番環境では明示的に設定すること。
+# 例: CORS_ORIGINS=https://your-subdomain.ngrok-free.app,http://localhost:3000
+CORS_ORIGINS=*

--- a/README.md
+++ b/README.md
@@ -39,22 +39,58 @@ cp .env.example .env
 # .env を編集: LLM_API_KEY (または OPENAI_API_KEY / GEMINI_API_KEY), ADMIN_PASSWORD, JWT_SECRET を必ず設定
 # Gemini を使う場合は LLM_PROVIDER=gemini, LLM_EMBEDDING_DIM=768 なども設定
 
-# 2. 全サービスを起動
+# 2. 全サービスを起動（本番 / CI 用）
 docker compose up -d
 
 # 3. ログ確認（初回はマイグレーション完了を確認）
 docker compose logs -f api-server
 ```
 
-### アクセス先
+> **ネットワーク設計:** 外部に公開されるポートは `frontend:3000` (Nginx) のみです。
+> `api-server` や各種データベースへの直接アクセスは Docker 内部ネットワーク経由のみで行われます。
+
+### アクセス先（本番 / 共通）
 
 | サービス | URL |
 |---|---|
 | 学習UI | http://localhost:3000 |
 | 管理UI | http://localhost:3000/admin.html |
-| API（Swagger） | http://localhost:8001/docs |
+
+### ローカル開発（ngrok + デバッグポート公開）
+
+開発時は `docker-compose.local.yml` を併用することで、DBクライアントや ngrok トンネルが利用できます。
+
+#### 事前準備
+
+1. [ngrok](https://ngrok.com) でアカウント作成・固定ドメインを取得
+2. `.env` に以下を追加:
+
+```
+NGROK_AUTHTOKEN=your_ngrok_auth_token
+NGROK_DOMAIN=your-subdomain.ngrok-free.app
+# ngrok 経由アクセスを CORS で許可（必要な場合）
+CORS_ORIGINS=https://your-subdomain.ngrok-free.app,http://localhost:3000
+```
+
+#### 起動コマンド
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+```
+
+#### アクセス先（ローカル開発時のみ）
+
+| サービス | URL |
+|---|---|
+| 学習UI（ローカル） | http://localhost:3000 |
+| 管理UI（ローカル） | http://localhost:3000/admin.html |
+| 学習UI（ngrok） | https://your-subdomain.ngrok-free.app |
+| ngrok Web UI | http://localhost:4040 |
 | Neo4j Browser | http://localhost:7474 |
 | MinIO コンソール | http://localhost:9001 |
+
+> **セキュリティ注意:** `api-server` のポート（8001）はローカル開発時も直接公開されません。
+> API へのアクセスは必ず Nginx（3000番）経由で行ってください。
 
 ### 初期アカウント
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -302,9 +302,11 @@ async def _lifespan(application: FastAPI):
 # ---------------------------------------------------------------------------
 
 app = FastAPI(title="Episteme Graph API", version="0.1.0", lifespan=_lifespan)
+_cors_origins_raw = _get_settings().cors_origins
+_cors_origins = _cors_origins_raw.split(",") if _cors_origins_raw != "*" else ["*"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -94,6 +94,14 @@ class Settings(BaseSettings):
     minio_secret_key: str = "minioadmin"
     minio_public_endpoint: str = "localhost:9000"
 
+    # --- CORS ---
+    # カンマ区切りでオリジンを指定。"*" はワイルドカード（開発用デフォルト）。
+    # 例: CORS_ORIGINS=https://your-subdomain.ngrok-free.app,http://localhost:3000
+    cors_origins: str = Field(
+        default="*",
+        validation_alias=AliasChoices("CORS_ORIGINS"),
+    )
+
     # --- GROBID ---
     grobid_url: str = "http://localhost:8070"
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,48 @@
+version: "3.9"
+
+# ローカル開発用オーバーライドファイル
+# 使用方法: docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+#
+# このファイルは本番用の docker-compose.yml を「上書き」する形で機能します。
+# 開発時のみ必要なポート公開や ngrok トンネルをここで定義します。
+#
+# ※ api-server のポートはここでも開放しません。
+#   すべての API アクセスは必ず Nginx (frontend:3000) 経由にしてください。
+
+services:
+  # ── 開発用ポート公開 ─────────────────────────────────────────────
+  neo4j:
+    ports:
+      - "7474:7474"   # Neo4j Browser
+      - "7687:7687"   # Bolt プロトコル (DB クライアント用)
+
+  postgres:
+    ports:
+      - "5432:5432"   # PostgreSQL クライアント (psql / TablePlus など)
+
+  minio:
+    ports:
+      - "9000:9000"   # MinIO S3 API
+      - "9001:9001"   # MinIO コンソール
+
+  # ── ngrok トンネル ───────────────────────────────────────────────
+  # 固定ドメインを使ったローカル→外部公開トンネル。
+  # frontend コンテナの 3000 番ポート（Nginx）にトラフィックを転送します。
+  #
+  # 事前準備:
+  #   1. https://ngrok.com でアカウント作成・固定ドメインを取得
+  #   2. .env に NGROK_AUTHTOKEN と NGROK_DOMAIN を設定
+  #      例: NGROK_AUTHTOKEN=your_auth_token
+  #          NGROK_DOMAIN=your-subdomain.ngrok-free.app
+  ngrok:
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    command: http --domain=${NGROK_DOMAIN} frontend:3000
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
+    depends_on:
+      - frontend
+    networks:
+      - episteme
+    ports:
+      - "4040:4040"   # ngrok Web UI (トンネル状態確認)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
   # ── Infrastructure ────────────────────────────────────────────────
   neo4j:
     image: neo4j:5-community
-    ports:
-      - "7474:7474"
-      - "7687:7687"
     environment:
       NEO4J_AUTH: neo4j/episteme
     volumes:
@@ -16,8 +13,6 @@ services:
 
   postgres:
     image: pgvector/pgvector:pg16
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_DB: episteme
       POSTGRES_USER: episteme
@@ -38,9 +33,6 @@ services:
   minio:
     image: minio/minio:latest
     command: server /data --console-address ":9001"
-    ports:
-      - "9000:9000"
-      - "9001:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -54,8 +46,6 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    ports:
-      - "8001:8001"
     environment:
       JWT_SECRET: ${JWT_SECRET:-episteme-dev-secret-change-in-prod}
       LLM_PROVIDER: ${LLM_PROVIDER:-openai}
@@ -79,6 +69,7 @@ services:
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      CORS_ORIGINS: ${CORS_ORIGINS:-*}
     # ローカルの .gcp/ をコンテナに読み取り専用でマウントする。
     # ファイルが存在しない場合は空ディレクトリとしてマウントされる（エラーにはならない）。
     # サービスアカウントキーを使う場合: .gcp/credentials.json に配置する。


### PR DESCRIPTION
## Summary

This PR introduces a local development configuration that enables external access to the application via ngrok tunnels while maintaining security by keeping internal services (databases, API server) unexposed by default. It also adds configurable CORS origins to support multiple deployment scenarios.

## Key Changes

- **New `docker-compose.local.yml`**: Override file for local development that exposes debug ports (Neo4j, PostgreSQL, MinIO) and sets up an ngrok tunnel to the frontend service
- **Removed hardcoded port exposures from `docker-compose.yml`**: Only the frontend (Nginx on port 3000) is exposed in production; databases and API server are now internal-only
- **Configurable CORS origins**: Added `CORS_ORIGINS` environment variable to `backend/core/config.py` and integrated it into FastAPI's CORS middleware, replacing the hardcoded wildcard policy
- **Updated documentation**: Enhanced README with separate sections for production and local development setups, including ngrok prerequisites and access URLs
- **Environment configuration**: Added ngrok and CORS settings to `.env.example` with clear instructions

## Implementation Details

- The ngrok service in `docker-compose.local.yml` tunnels traffic to `frontend:3000` (Nginx) using a fixed domain from environment variables
- CORS origins are parsed from a comma-separated string, with `"*"` as a special case for wildcard (development default)
- All database and API ports are removed from the base `docker-compose.yml`, enforcing the architectural principle that external access flows only through Nginx
- Security note: The API server port (8001) remains unexposed even in local development, requiring all API calls to route through the Nginx reverse proxy

https://claude.ai/code/session_01P12uveNT4PRUNoaLeGMdY3