### PR TITLE
feat: TTS プロバイダのマルチモード化と Vertex AI 対応の追加

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -250,6 +250,17 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 - 不足している前提知識や学習順序の問題を指摘する
 - 各章・トピックが論理的に繋がるよう構成を提案する
 
+**【最重要】ソース文献への厳密な準拠:**
+- 提案するすべての章・トピック・概念は、提供された教材の記述内容に基づかなければならない
+- 教材に記載されていないトピックを「一般的だから」「基礎的だから」という理由で追加してはならない
+- 教材の内容を超えた一般知識に基づく補足は、明示的に「教材外の補足」として区別すること
+- 教材のチャンク（テキスト断片）やナレッジグラフが提供された場合、それらの情報を最大限活用してコースを設計すること
+
+**【重要】段階的構造化の原則:**
+- チャンクの並び順（chunk_index）は教材内の論理的な流れを反映しているため、この順序を尊重してコースの章立てを構成する
+- 前提知識が必要な概念は、その前提となる概念より後の章・トピックに配置する（依存関係に基づいたシラバス）
+- 初学者がその分野に初めて触れることを想定し、専門用語は最初に出現する章で定義・説明するよう構成する
+
 **コース構成のJSONスキーマ (course_draft):**
 生成するコース構成案は以下の形式に従ってください:
 {
@@ -274,9 +285,10 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 
 **対話の進め方:**
 1. まず教員の要望（テーマ、対象者、使用教材等）をヒアリングする
-2. 初期のコース構成案を提示する
-3. 教員のフィードバックに基づいて構成案を改善する
-4. 前提知識の不足や学習順序の問題があれば指摘する
+2. 提供された教材の内容（ナレッジグラフ、テキストチャンク）を精査し、教材の範囲と構成を把握する
+3. 教材の内容に基づいた初期のコース構成案を提示する
+4. 教員のフィードバックに基づいて構成案を改善する
+5. 前提知識の不足や学習順序の問題があれば指摘する
 
 **重要なルール:**
 - 応答は必ず日本語で行う
@@ -288,6 +300,123 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
   - 例: 第2章のトピックは第1章のトピックタイトルを prerequisites に入れる
   - 最初のトピックや前提知識不要なトピックは prerequisites を空配列 [] にする
 - sources フィールドは常に空配列 [] のままにすること（教材はシステムが自動的に設定する）"""
+
+
+# ---------------------------------------------------------------------------
+# Course Builder: Material Context Builder
+# ---------------------------------------------------------------------------
+
+# チャンクテキストのサンプリング上限（1教材あたり）
+_MAX_CHUNK_CHARS_PER_MATERIAL = 4000
+
+
+def _build_material_context(
+    material_ids: list[str],
+    pg_session_factory=None,
+) -> str | None:
+    """選択された教材のナレッジグラフとチャンクテキストからコンテキスト文字列を構築する。
+
+    Returns None if no usable context could be built.
+    """
+    if not material_ids:
+        return None
+
+    _get_pg = pg_session_factory or _pg_session
+    session = _get_pg()
+    try:
+        # --- 1) ドキュメントメタデータ + knowledge_graph を取得 ---
+        placeholders = ", ".join(f":mid_{i}" for i in range(len(material_ids)))
+        params: dict = {}
+        for i, mid in enumerate(material_ids):
+            params[f"mid_{i}"] = mid
+
+        doc_rows = session.execute(
+            sa_text(f"""
+                SELECT source_path, title, filename, knowledge_graph
+                FROM documents
+                WHERE source_path IN ({placeholders}) AND status = 'completed'
+            """),
+            params,
+        ).fetchall()
+
+        if not doc_rows:
+            return None
+
+        # --- 2) チャンクテキストを取得 (chunk_index 順) ---
+        chunk_rows = session.execute(
+            sa_text(f"""
+                SELECT material_id, chunk_index, chapter, section, text
+                FROM chunks
+                WHERE material_id IN ({placeholders})
+                ORDER BY material_id, chunk_index
+            """),
+            params,
+        ).fetchall()
+    finally:
+        session.close()
+
+    # --- 3) コンテキスト文字列を組み立て ---
+    sections: list[str] = []
+    sections.append("## 教材の内容詳細\n以下は選択された教材から抽出された詳細情報です。"
+                     "コース設計はこの内容に基づいて行ってください。\n")
+
+    for doc in doc_rows:
+        mid = doc[0] or ""
+        title = doc[1] or doc[2] or ""
+        kg = doc[3] if doc[3] and isinstance(doc[3], dict) else {}
+
+        sections.append(f"### 教材: {title}")
+
+        # ナレッジグラフの概要
+        if kg.get("summary"):
+            sections.append(f"**概要:** {kg['summary']}")
+
+        if kg.get("domain"):
+            sections.append(f"**分野:** {kg['domain']}")
+
+        # 主要概念
+        concepts = kg.get("concepts", [])
+        if concepts:
+            concept_lines = []
+            for c in concepts:
+                name = c.get("name", "") if isinstance(c, dict) else str(c)
+                desc = c.get("description", "") if isinstance(c, dict) else ""
+                ctype = c.get("type", "") if isinstance(c, dict) else ""
+                line = f"- {name}"
+                if ctype:
+                    line += f" ({ctype})"
+                if desc:
+                    line += f": {desc}"
+                concept_lines.append(line)
+            sections.append("**主要概念:**\n" + "\n".join(concept_lines))
+
+        # チャンクテキストのサンプリング
+        material_chunks = [r for r in chunk_rows if r[0] == mid]
+        if material_chunks:
+            sections.append("**教材テキスト（抜粋）:**")
+            char_budget = _MAX_CHUNK_CHARS_PER_MATERIAL
+            for chunk in material_chunks:
+                if char_budget <= 0:
+                    sections.append("... (以降省略)")
+                    break
+                idx = chunk[1]
+                chapter = chunk[2] or ""
+                section_ = chunk[3] or ""
+                text = chunk[4] or ""
+                header = f"[チャンク {idx}]"
+                if chapter:
+                    header += f" {chapter}"
+                if section_:
+                    header += f" / {section_}"
+                snippet = text[:char_budget]
+                if len(text) > char_budget:
+                    snippet += "..."
+                sections.append(f"{header}\n{snippet}")
+                char_budget -= len(snippet)
+
+        sections.append("")  # blank line separator
+
+    return "\n".join(sections)
 
 
 @router.post(
@@ -303,41 +432,21 @@ def course_builder_chat(
         {"role": "system", "content": _COURSE_BUILDER_SYSTEM_PROMPT},
     ]
 
-    # 選択教材のタイトル・分野のみをコンテキストとして渡す（material_id は含めない）
+    # 選択教材のナレッジグラフ・チャンクテキストを含む詳細コンテキストを注入
     if body.selected_material_ids:
         try:
-            pg_session = _pg_session()
-            try:
-                placeholders = ", ".join(f":mid_{i}" for i in range(len(body.selected_material_ids)))
-                params: dict = {}
-                for i, mid in enumerate(body.selected_material_ids):
-                    params[f"mid_{i}"] = mid
-                records = pg_session.execute(
-                    sa_text(f"""
-                        SELECT title, filename, knowledge_graph
-                        FROM documents
-                        WHERE source_path IN ({placeholders}) AND status = 'completed'
-                    """),
-                    params,
-                ).fetchall()
-            finally:
-                pg_session.close()
-
-            if records:
-                materials_ctx = "## 使用する教材:\n"
-                for r in records:
-                    title = r[0] or r[1] or ""
-                    materials_ctx += f"- {title}"
-                    if r[2] and isinstance(r[2], dict) and r[2].get("domain"):
-                        materials_ctx += f" (分野: {r[2]['domain']})"
-                    materials_ctx += "\n"
+            material_context = _build_material_context(body.selected_material_ids)
+            if material_context:
                 messages.append({
                     "role": "user",
-                    "content": materials_ctx + "\n上記の教材を使ってコースを設計してください。",
+                    "content": material_context
+                        + "\n\n上記の教材内容に基づいてコースを設計してください。"
+                        "教材に記載されている内容の範囲内で、段階的に学べるコース構成を提案してください。",
                 })
                 messages.append({
                     "role": "assistant",
-                    "content": "承知しました。これらの教材を踏まえてコース設計を支援します。",
+                    "content": "承知しました。提供された教材の内容を精査し、"
+                        "教材の記述に基づいたコース設計を支援します。",
                 })
         except Exception:
             logger.warning("Failed to load selected materials context for course builder", exc_info=True)

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -28,6 +28,7 @@ from schemas import (
     CourseBuilderSessionOut,
     CourseBuilderSessionUpdate,
     CreateUserRequest,
+    DeleteConfirmRequest,
     MaterialOut,
     ReextractionJobOut,
     SimulationResponse,
@@ -220,6 +221,115 @@ def get_material(
         uploaded_at=uploaded_at,
         knowledge_graph=kg,
     )
+
+
+# ---------------------------------------------------------------------------
+# Material Deletion
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/materials/{material_id}")
+def delete_material(
+    material_id: str,
+    body: DeleteConfirmRequest,
+    current_user: dict = Depends(_require_teacher),
+) -> dict:
+    """教材を削除する。紐づくコースも同時に削除される。
+
+    confirm_name がタイトルと一致しない場合は 400 を返す。
+    """
+    session = _pg_session()
+    try:
+        # 1) 教材の存在確認 & タイトル照合
+        doc = session.execute(
+            sa_text("""
+                SELECT id, title, filename, source_path
+                FROM documents
+                WHERE source_path = :material_id
+                  AND uploaded_by = CAST(:user_id AS uuid)
+                LIMIT 1
+            """),
+            {"material_id": material_id, "user_id": current_user["id"]},
+        ).fetchone()
+
+        if not doc:
+            raise HTTPException(status_code=404, detail="Material not found")
+
+        doc_id = doc[0]
+        doc_title = doc[1] or doc[2] or ""
+
+        if body.confirm_name != doc_title:
+            raise HTTPException(
+                status_code=400,
+                detail="確認用の名前が一致しません。正確な教材名を入力してください。",
+            )
+
+        # 2) この教材を sources に含むコースを特定して削除
+        course_rows = session.execute(
+            sa_text("""
+                SELECT id FROM learning_courses
+                WHERE user_id = CAST(:user_id AS uuid)
+            """),
+            {"user_id": current_user["id"]},
+        ).fetchall()
+
+        deleted_course_ids: list[str] = []
+        for row in course_rows:
+            course_id = row[0]
+            course_data_row = session.execute(
+                sa_text("SELECT data FROM learning_courses WHERE id = :cid"),
+                {"cid": course_id},
+            ).fetchone()
+            if not course_data_row or not course_data_row[0]:
+                continue
+            data = course_data_row[0] if isinstance(course_data_row[0], dict) else json.loads(course_data_row[0])
+            sources = data.get("sources", [])
+            linked = any(
+                s.get("material_id") == material_id for s in sources if isinstance(s, dict)
+            )
+            if linked:
+                # 関連する学習チャット履歴を削除
+                session.execute(
+                    sa_text("DELETE FROM learning_chat_history WHERE course_id = :cid"),
+                    {"cid": course_id},
+                )
+                # コース削除
+                session.execute(
+                    sa_text("DELETE FROM learning_courses WHERE id = :cid"),
+                    {"cid": course_id},
+                )
+                deleted_course_ids.append(course_id)
+
+        # 3) チャンク削除
+        session.execute(
+            sa_text("DELETE FROM chunks WHERE document_id = :doc_id"),
+            {"doc_id": doc_id},
+        )
+
+        # 4) ドキュメント削除
+        session.execute(
+            sa_text("DELETE FROM documents WHERE id = :doc_id"),
+            {"doc_id": doc_id},
+        )
+
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    logger.info(
+        "Material %s (%s) deleted by user=%s, cascade-deleted courses: %s",
+        material_id, doc_title, current_user["id"], deleted_course_ids,
+    )
+    return {
+        "material_id": material_id,
+        "deleted": True,
+        "deleted_courses": deleted_course_ids,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -867,6 +977,63 @@ def publish_course(
         raise HTTPException(status_code=404, detail="Course not found")
     logger.info("Course %s published by user=%s", course_id, current_user["id"])
     return {"course_id": course_id, "is_published": True}
+
+
+@router.delete("/courses/{course_id}")
+def delete_course(
+    course_id: str,
+    body: DeleteConfirmRequest,
+    current_user: dict = Depends(_require_teacher),
+) -> dict:
+    """コースを削除する。
+
+    confirm_name がコースタイトルと一致しない場合は 400 を返す。
+    """
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("""
+                SELECT id, title FROM learning_courses
+                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+                LIMIT 1
+            """),
+            {"course_id": course_id, "user_id": current_user["id"]},
+        ).fetchone()
+
+        if not record:
+            raise HTTPException(status_code=404, detail="Course not found")
+
+        course_title = record[1] or ""
+        if body.confirm_name != course_title:
+            raise HTTPException(
+                status_code=400,
+                detail="確認用の名前が一致しません。正確なコース名を入力してください。",
+            )
+
+        # 関連する学習チャット履歴を削除
+        session.execute(
+            sa_text("DELETE FROM learning_chat_history WHERE course_id = :cid"),
+            {"cid": course_id},
+        )
+        # コース削除
+        session.execute(
+            sa_text("""
+                DELETE FROM learning_courses
+                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+            """),
+            {"course_id": course_id, "user_id": current_user["id"]},
+        )
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    logger.info("Course %s (%s) deleted by user=%s", course_id, course_title, current_user["id"])
+    return {"course_id": course_id, "deleted": True}
 
 
 @router.get("/courses/{course_id}/unanswered-queries")

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -183,6 +183,11 @@ class LearningChatHistoryResponse(BaseModel):
 # Course Builder
 # ---------------------------------------------------------------------------
 
+class DeleteConfirmRequest(BaseModel):
+    """名前入力による削除確認リクエスト。"""
+    confirm_name: str  # 削除対象の名前（一致しなければ拒否）
+
+
 class CourseBuilderChatRequest(BaseModel):
     """コース構築AIチャットリクエスト。"""
     message: str

--- a/backend/tests/fixtures/neutralino_seed.json
+++ b/backend/tests/fixtures/neutralino_seed.json
@@ -1,0 +1,65 @@
+{
+  "documents": [
+    {
+      "material_id": "mat-neutralino-001",
+      "title": "Unitarity and Higher-Order Corrections in Neutralino Dark Matter Annihilation into Two Photons",
+      "filename": "0212022v2.pdf",
+      "status": "completed",
+      "knowledge_graph": {
+        "domain": "Particle Physics / Dark Matter",
+        "summary": "This paper investigates unitarity constraints and higher-order radiative corrections to the process of neutralino pair annihilation into two photons (chi chi -> gamma gamma) within the Minimal Supersymmetric Standard Model (MSSM). The loop-induced nature of this process makes it sensitive to virtual particle contributions from charginos, sfermions, and W bosons. The authors demonstrate that naive one-loop calculations can violate partial-wave unitarity at large neutralino masses, and they restore unitarity by including the appropriate set of box diagrams and counterterms. The corrected cross section is shown to differ by up to 30% from the uncorrected result in phenomenologically relevant parameter regions.",
+        "concepts": [
+          {"name": "Neutralino", "type": "PARTICLE", "description": "The lightest neutralino (chi^0_1) as a Majorana fermion and leading dark matter candidate in the MSSM."},
+          {"name": "Dark Matter", "type": "PHENOMENON", "description": "Non-luminous matter comprising ~27% of the universe's energy density, observed through gravitational effects."},
+          {"name": "Annihilation Cross Section", "type": "OBSERVABLE", "description": "The effective cross-sectional area quantifying the probability of neutralino pair annihilation into photons."},
+          {"name": "Unitarity", "type": "PRINCIPLE", "description": "The requirement that the S-matrix is unitary, ensuring probability conservation in scattering amplitudes."},
+          {"name": "MSSM", "type": "THEORY", "description": "The Minimal Supersymmetric Standard Model, a supersymmetric extension of the Standard Model with minimal new particle content."},
+          {"name": "Partial-Wave Unitarity", "type": "CONSTRAINT", "description": "Unitarity bounds applied to individual partial waves of the scattering amplitude, limiting the cross section at high energies."},
+          {"name": "Chargino", "type": "PARTICLE", "description": "Charged supersymmetric fermions (chi^+_1, chi^+_2) that appear as virtual particles in loop diagrams."},
+          {"name": "Sfermion", "type": "PARTICLE", "description": "Scalar supersymmetric partners of Standard Model fermions (selectrons, squarks, etc.)."},
+          {"name": "Loop Diagram", "type": "TECHNIQUE", "description": "Feynman diagrams with closed loops representing quantum corrections to tree-level processes."},
+          {"name": "Box Diagram", "type": "TECHNIQUE", "description": "Four-point one-loop Feynman diagrams with four internal propagators forming a box topology."},
+          {"name": "Radiative Correction", "type": "TECHNIQUE", "description": "Higher-order perturbative corrections arising from virtual particle loops in quantum field theory."},
+          {"name": "Gamma-Ray Line", "type": "OBSERVABLE", "description": "A monochromatic photon signal at E_gamma = m_chi, a distinctive spectral feature for indirect dark matter detection."}
+        ]
+      }
+    }
+  ],
+  "chunks": [
+    {
+      "chunk_index": 0,
+      "material_id": "mat-neutralino-001",
+      "chapter": "1. Introduction",
+      "section": "1.1 Motivation",
+      "text": "The identity of dark matter is one of the most pressing questions in particle physics and cosmology. In the Minimal Supersymmetric Standard Model (MSSM), the lightest neutralino chi^0_1 is a leading dark matter candidate, being stable (under R-parity conservation), electrically neutral, and weakly interacting. Among indirect detection strategies, the search for monochromatic gamma-ray lines from neutralino pair annihilation (chi chi -> gamma gamma) provides a uniquely clean signature, as the resulting photon energy E_gamma = m_chi is fixed by the neutralino mass."
+    },
+    {
+      "chunk_index": 1,
+      "material_id": "mat-neutralino-001",
+      "chapter": "2. Framework",
+      "section": "2.1 One-Loop Amplitudes",
+      "text": "Since neutralinos are Majorana fermions with no tree-level coupling to photons, the process chi chi -> gamma gamma is loop-induced at leading order. The dominant one-loop contributions arise from: (a) chargino loops with W-boson exchange, (b) sfermion loops involving charged scalar partners of quarks and leptons, and (c) mixed chargino-sfermion diagrams. Each class of diagrams involves triangle and box topologies. We denote the total amplitude as M = M_chargino + M_sfermion + M_mixed, where each term is a sum over relevant particle species running in the loop."
+    },
+    {
+      "chunk_index": 2,
+      "material_id": "mat-neutralino-001",
+      "chapter": "2. Framework",
+      "section": "2.2 Partial-Wave Decomposition",
+      "text": "To examine unitarity constraints, we decompose the amplitude into partial waves. For the process chi chi -> gamma gamma, only the J=0 (S-wave) and J=2 partial waves contribute for Majorana initial states. The partial-wave unitarity condition requires |a_J| <= 1 for each partial-wave amplitude a_J. We find that the naive one-loop calculation violates this bound for neutralino masses m_chi > 500 GeV in certain MSSM parameter regions, particularly when mu is small and tan(beta) is large. This signals the need for higher-order corrections to restore unitarity."
+    },
+    {
+      "chunk_index": 3,
+      "material_id": "mat-neutralino-001",
+      "chapter": "3. Higher-Order Corrections",
+      "section": "3.1 Box Diagram Contributions",
+      "text": "We compute the complete set of box diagrams that contribute at the same order in perturbation theory as the squared one-loop triangle amplitude. These include: (i) gamma-gamma box diagrams with internal charginos, (ii) Z-gamma box diagrams from chargino-neutralino mixing, and (iii) W-W box diagrams with sfermion exchange. The inclusion of these box contributions is essential for restoring partial-wave unitarity. Numerically, the box diagrams reduce the total cross section by 15-30% relative to the naive one-loop result for m_chi ~ 200-800 GeV, depending on the MSSM parameters."
+    },
+    {
+      "chunk_index": 4,
+      "material_id": "mat-neutralino-001",
+      "chapter": "4. Results and Discussion",
+      "section": "4.1 Phenomenological Implications",
+      "text": "Our corrected cross section sigma(chi chi -> gamma gamma) has direct implications for indirect dark matter detection experiments such as Fermi-LAT, MAGIC, and future CTA observations. For a 200 GeV neutralino with wino-like composition, the corrected cross section is sigma v ~ 2.3 x 10^{-28} cm^3/s, approximately 25% smaller than the uncorrected one-loop value. This correction is comparable to astrophysical uncertainties in the dark matter density profile and must therefore be included in any precision prediction. The gamma-ray line energy E_gamma = m_chi provides a distinctive spectral feature distinguishable from astrophysical backgrounds."
+    }
+  ]
+}

--- a/backend/tests/test_course_builder_context.py
+++ b/backend/tests/test_course_builder_context.py
@@ -1,0 +1,621 @@
+"""Issue #113: ソース文献準拠のコース生成 — コンテキスト注入・プロンプトのテスト。
+
+コースビルダーにおいて、選択された教材のナレッジグラフとチャンクテキストが
+LLMプロンプトに正しく注入されること、およびシステムプロンプトがソース準拠と
+段階的構造化を要求していることを検証する。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure api/ is importable
+_backend_dir = str(Path(__file__).resolve().parents[1])
+_api_dir = str(Path(__file__).resolve().parents[1] / "api")
+if _backend_dir not in sys.path:
+    sys.path.insert(0, _backend_dir)
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+# Load test fixture data
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+NEUTRALINO_SEED = json.loads(
+    (FIXTURE_DIR / "neutralino_seed.json").read_text(encoding="utf-8")
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build DB mock rows from fixture
+# ---------------------------------------------------------------------------
+
+def _make_doc_rows(seed=NEUTRALINO_SEED):
+    """fixtures の documents を DB 行形式 (source_path, title, filename, knowledge_graph) に変換。"""
+    rows = []
+    for doc in seed["documents"]:
+        rows.append((
+            doc["material_id"],
+            doc["title"],
+            doc["filename"],
+            doc["knowledge_graph"],
+        ))
+    return rows
+
+
+def _make_chunk_rows(seed=NEUTRALINO_SEED):
+    """fixtures の chunks を DB 行形式 (material_id, chunk_index, chapter, section, text) に変換。"""
+    rows = []
+    for ch in seed["chunks"]:
+        rows.append((
+            ch["material_id"],
+            ch["chunk_index"],
+            ch.get("chapter", ""),
+            ch.get("section", ""),
+            ch["text"],
+        ))
+    return rows
+
+
+# ===========================================================================
+# 1. _build_material_context 単体テスト
+# ===========================================================================
+
+class TestBuildMaterialContext:
+    """_build_material_context ヘルパー関数のテスト。"""
+
+    def _import_func(self):
+        from routes.admin import _build_material_context
+        return _build_material_context
+
+    def test_returns_none_for_empty_ids(self):
+        """material_ids が空の場合 None を返すこと。"""
+        func = self._import_func()
+        assert func([]) is None
+
+    @patch("routes.admin._pg_session")
+    def test_returns_none_when_no_docs_found(self, mock_pg):
+        """DB にマッチするドキュメントがない場合 None を返すこと。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        # First call: doc query returns empty
+        mock_session.execute.return_value.fetchall.return_value = []
+        mock_pg.return_value = mock_session
+
+        result = func(["nonexistent-id"])
+        assert result is None
+
+    @patch("routes.admin._pg_session")
+    def test_includes_knowledge_graph_summary(self, mock_pg):
+        """ナレッジグラフの概要がコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "unitarity" in ctx.lower() or "Unitarity" in ctx
+        assert "neutralino" in ctx.lower() or "Neutralino" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_includes_knowledge_graph_concepts(self, mock_pg):
+        """ナレッジグラフの主要概念がコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        # Check that key domain concepts appear
+        assert "Neutralino" in ctx
+        assert "Dark Matter" in ctx
+        assert "Annihilation Cross Section" in ctx
+        assert "MSSM" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_includes_chunk_text(self, mock_pg):
+        """チャンクテキストがコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        # Introduction text should be present
+        assert "dark matter" in ctx.lower()
+        assert "monochromatic gamma-ray" in ctx.lower() or "gamma-ray" in ctx.lower()
+
+    @patch("routes.admin._pg_session")
+    def test_includes_chunk_headers(self, mock_pg):
+        """チャンクのチャプター・セクション情報がヘッダとして含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "Introduction" in ctx
+        assert "Framework" in ctx or "One-Loop Amplitudes" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_includes_domain_field(self, mock_pg):
+        """ナレッジグラフの分野 (domain) がコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "Particle Physics" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_chunk_text_is_truncated_within_budget(self, mock_pg):
+        """チャンクテキストが _MAX_CHUNK_CHARS_PER_MATERIAL 以内に収まること。"""
+        func = self._import_func()
+        from routes.admin import _MAX_CHUNK_CHARS_PER_MATERIAL
+
+        mock_session = MagicMock()
+        # Create a document with very long chunks
+        doc_rows = [("mat-long", "Long Doc", "long.pdf", {"summary": "test"})]
+        long_text = "A" * 10000
+        chunk_rows = [
+            ("mat-long", 0, "Ch1", "S1", long_text),
+            ("mat-long", 1, "Ch2", "S2", long_text),
+        ]
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-long"])
+        assert ctx is not None
+        # The total chunk text should not exceed budget significantly
+        # (headers add some overhead but the bulk text is within budget)
+        chunk_text_portions = [line for line in ctx.split("\n") if line.startswith("AAA")]
+        total_a_chars = sum(line.count("A") for line in chunk_text_portions)
+        assert total_a_chars <= _MAX_CHUNK_CHARS_PER_MATERIAL + 100  # small header overhead
+
+    @patch("routes.admin._pg_session")
+    def test_context_section_header(self, mock_pg):
+        """コンテキストに「教材の内容詳細」セクションヘッダが含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "教材の内容詳細" in ctx
+
+
+# ===========================================================================
+# 2. システムプロンプトのテスト
+# ===========================================================================
+
+class TestCourseBuilderSystemPrompt:
+    """_COURSE_BUILDER_SYSTEM_PROMPT がソース準拠・段階的構造化を要求していることを検証。"""
+
+    def _get_prompt(self):
+        from routes.admin import _COURSE_BUILDER_SYSTEM_PROMPT
+        return _COURSE_BUILDER_SYSTEM_PROMPT
+
+    def test_prompt_requires_source_adherence(self):
+        """プロンプトがソース文献への準拠を要求していること。"""
+        prompt = self._get_prompt()
+        assert "教材の記述" in prompt or "教材に記載" in prompt
+        assert "追加してはならない" in prompt or "禁止" in prompt
+
+    def test_prompt_prohibits_hallucination(self):
+        """教材にないトピックの追加を明示的に禁止していること。"""
+        prompt = self._get_prompt()
+        # Check for anti-hallucination instruction
+        assert "一般的だから" in prompt
+
+    def test_prompt_requires_stepwise_structure(self):
+        """段階的構造化（依存関係に基づくシラバス）を要求していること。"""
+        prompt = self._get_prompt()
+        assert "段階的" in prompt or "依存関係" in prompt
+        assert "chunk_index" in prompt or "チャンクの並び" in prompt
+
+    def test_prompt_mentions_knowledge_graph(self):
+        """プロンプトがナレッジグラフの活用に言及していること。"""
+        prompt = self._get_prompt()
+        assert "ナレッジグラフ" in prompt
+
+    def test_prompt_mentions_chunks(self):
+        """プロンプトがチャンクの活用に言及していること。"""
+        prompt = self._get_prompt()
+        assert "チャンク" in prompt
+
+    def test_prompt_requires_prerequisites_ordering(self):
+        """前提知識の順序付けルールが含まれていること。"""
+        prompt = self._get_prompt()
+        assert "prerequisites" in prompt
+        assert "前提知識" in prompt
+
+    def test_prompt_is_in_japanese(self):
+        """プロンプトが日本語で記述されていること。"""
+        prompt = self._get_prompt()
+        assert "日本語" in prompt
+
+    def test_prompt_has_json_schema(self):
+        """コースドラフトのJSONスキーマ定義が含まれていること。"""
+        prompt = self._get_prompt()
+        assert "course_draft" in prompt
+        assert '"chapters"' in prompt
+        assert '"topics"' in prompt
+
+
+# ===========================================================================
+# 3. course_builder_chat エンドポイントの結合テスト
+# ===========================================================================
+
+_HAS_FASTAPI = True
+try:
+    from fastapi.testclient import TestClient
+except ImportError:
+    _HAS_FASTAPI = False
+
+_skip_no_fastapi = pytest.mark.skipif(
+    not _HAS_FASTAPI,
+    reason="FastAPI not installed (run in Docker for full API tests)",
+)
+
+
+@pytest.fixture
+def client():
+    if not _HAS_FASTAPI:
+        pytest.skip("FastAPI not installed")
+    from api.main import app
+    return TestClient(app)
+
+
+@pytest.fixture
+def teacher_token():
+    import jwt
+    payload = {
+        "sub": "test-teacher-id",
+        "role": "TEACHER",
+        "username": "teacher1",
+        "email": "teacher1@test.com",
+    }
+    return jwt.encode(payload, "test-secret-key", algorithm="HS256")
+
+
+@pytest.fixture
+def auth_headers(teacher_token):
+    return {"Authorization": f"Bearer {teacher_token}"}
+
+
+@_skip_no_fastapi
+class TestCourseBuilderChatContextInjection:
+    """course_builder_chat エンドポイントが教材コンテキストをLLMに渡すことを検証。"""
+
+    @patch("routes.admin.save_cb_session")
+    @patch("routes.admin.generate_text")
+    @patch("routes.admin._build_material_context")
+    def test_context_injected_into_messages(
+        self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
+    ):
+        """_build_material_context の結果がメッセージに注入されること。"""
+        mock_build_ctx.return_value = (
+            "## 教材の内容詳細\n### 教材: Neutralino Paper\n"
+            "**概要:** Unitarity constraints on neutralino annihilation\n"
+            "**主要概念:**\n- Neutralino\n- Dark Matter\n"
+        )
+        mock_gen.return_value = "テスト応答"
+
+        resp = client.post(
+            "/api/admin/course-builder/chat",
+            json={
+                "message": "このテーマでコースを作ってください",
+                "selected_material_ids": ["mat-neutralino-001"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # generate_text に渡されたメッセージを検証
+        call_args = mock_gen.call_args
+        messages = call_args[1].get("messages") or call_args[0][0]
+        all_content = " ".join(m["content"] for m in messages)
+        assert "教材の内容詳細" in all_content
+        assert "Neutralino" in all_content
+
+    @patch("routes.admin.save_cb_session")
+    @patch("routes.admin.generate_text")
+    @patch("routes.admin._build_material_context")
+    def test_no_context_when_no_materials(
+        self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
+    ):
+        """教材未選択時にはコンテキスト注入が行われないこと。"""
+        mock_gen.return_value = "テスト応答"
+
+        resp = client.post(
+            "/api/admin/course-builder/chat",
+            json={
+                "message": "自由にコースを作ってください",
+                "selected_material_ids": [],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        # _build_material_context は呼ばれない
+        mock_build_ctx.assert_not_called()
+
+    @patch("routes.admin.save_cb_session")
+    @patch("routes.admin.generate_text")
+    @patch("routes.admin._build_material_context")
+    def test_system_prompt_is_first_message(
+        self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
+    ):
+        """最初のメッセージがシステムプロンプトであること。"""
+        mock_build_ctx.return_value = "## 教材の内容詳細\nテスト"
+        mock_gen.return_value = "テスト応答"
+
+        resp = client.post(
+            "/api/admin/course-builder/chat",
+            json={
+                "message": "テスト",
+                "selected_material_ids": ["mat-001"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        call_args = mock_gen.call_args
+        messages = call_args[1].get("messages") or call_args[0][0]
+        assert messages[0]["role"] == "system"
+        assert "ソース文献" in messages[0]["content"] or "教材の記述" in messages[0]["content"]
+
+    @patch("routes.admin.save_cb_session")
+    @patch("routes.admin.generate_text")
+    @patch("routes.admin._build_material_context")
+    def test_context_placed_before_user_message(
+        self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
+    ):
+        """教材コンテキストがユーザーの質問メッセージより前に配置されること。"""
+        mock_build_ctx.return_value = "## 教材の内容詳細\nNeutralino論文"
+        mock_gen.return_value = "テスト応答"
+
+        resp = client.post(
+            "/api/admin/course-builder/chat",
+            json={
+                "message": "コースを設計して",
+                "selected_material_ids": ["mat-001"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        call_args = mock_gen.call_args
+        messages = call_args[1].get("messages") or call_args[0][0]
+
+        # Find context message and user message positions
+        ctx_idx = None
+        user_msg_idx = None
+        for i, m in enumerate(messages):
+            if "教材の内容詳細" in m.get("content", ""):
+                ctx_idx = i
+            if m.get("content", "") == "コースを設計して":
+                user_msg_idx = i
+
+        assert ctx_idx is not None, "教材コンテキストメッセージが見つからない"
+        assert user_msg_idx is not None, "ユーザーメッセージが見つからない"
+        assert ctx_idx < user_msg_idx, "教材コンテキストはユーザーメッセージより前に配置されるべき"
+
+    @patch("routes.admin.save_cb_session")
+    @patch("routes.admin.generate_text")
+    @patch("routes.admin._pg_session")
+    def test_course_draft_json_parsing(
+        self, mock_pg, mock_gen, mock_save, client, auth_headers,
+    ):
+        """LLMレスポンスのCOURSE_DRAFT_JSON区切り文字が正しくパースされること。"""
+        draft = {
+            "title": "ニュートラリーノ暗黒物質入門",
+            "chapters": [{"title": "暗黒物質概論", "topics": []}],
+            "sources": [],
+        }
+        mock_gen.return_value = (
+            "以下のコース案を提案します。\n\n"
+            "---COURSE_DRAFT_JSON---\n"
+            + json.dumps(draft, ensure_ascii=False)
+        )
+        # Mock for sources injection query
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.return_value = [
+            ("mat-neutralino-001", "Neutralino Paper", "0212022v2.pdf"),
+        ]
+        mock_pg.return_value = mock_session
+
+        resp = client.post(
+            "/api/admin/course-builder/chat",
+            json={
+                "message": "コースを作ってください",
+                "selected_material_ids": ["mat-neutralino-001"],
+            },
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["course_draft"] is not None
+        assert data["course_draft"]["title"] == "ニュートラリーノ暗黒物質入門"
+
+
+# ===========================================================================
+# 4. テストデータ（フィクスチャ）の検証
+# ===========================================================================
+
+class TestNeutralinoSeedData:
+    """ニュートラリーノテストデータの構造とドメイン特化性を検証。"""
+
+    def test_seed_has_documents(self):
+        """documents セクションが存在すること。"""
+        assert "documents" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["documents"]) >= 1
+
+    def test_seed_has_chunks(self):
+        """chunks セクションが存在すること。"""
+        assert "chunks" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["chunks"]) >= 3
+
+    def test_document_has_knowledge_graph(self):
+        """ドキュメントにナレッジグラフが含まれること。"""
+        doc = NEUTRALINO_SEED["documents"][0]
+        kg = doc["knowledge_graph"]
+        assert "summary" in kg
+        assert "concepts" in kg
+        assert len(kg["concepts"]) >= 5
+
+    def test_document_domain_is_particle_physics(self):
+        """ドメインが素粒子物理学であること。"""
+        doc = NEUTRALINO_SEED["documents"][0]
+        assert "Particle Physics" in doc["knowledge_graph"]["domain"]
+
+    def test_chunks_are_ordered_by_index(self):
+        """チャンクが chunk_index 順に並んでいること。"""
+        indices = [c["chunk_index"] for c in NEUTRALINO_SEED["chunks"]]
+        assert indices == sorted(indices)
+
+    def test_chunks_cover_multiple_sections(self):
+        """チャンクが複数のセクションをカバーしていること。"""
+        chapters = {c.get("chapter", "") for c in NEUTRALINO_SEED["chunks"]}
+        assert len(chapters) >= 3
+
+    def test_concepts_include_neutralino(self):
+        """主要概念にニュートラリーノが含まれること。"""
+        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
+        names = [c["name"] for c in concepts]
+        assert "Neutralino" in names
+
+    def test_concepts_include_dark_matter(self):
+        """主要概念にダークマターが含まれること。"""
+        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
+        names = [c["name"] for c in concepts]
+        assert "Dark Matter" in names
+
+    def test_concepts_include_unitarity(self):
+        """主要概念にユニタリティが含まれること。"""
+        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
+        names = [c["name"] for c in concepts]
+        assert "Unitarity" in names
+
+    def test_concepts_have_types(self):
+        """各概念に type フィールドがあること。"""
+        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
+        for c in concepts:
+            assert "type" in c, f"Concept '{c['name']}' is missing 'type'"
+
+    def test_chunks_contain_domain_specific_terms(self):
+        """チャンクテキストがドメイン固有の用語を含むこと（一般的な物理学ではなく）。"""
+        all_text = " ".join(c["text"] for c in NEUTRALINO_SEED["chunks"])
+        # These terms should appear in the fixture (domain-specific, not general physics)
+        assert "neutralino" in all_text.lower()
+        assert "MSSM" in all_text or "mssm" in all_text.lower()
+        assert "chargino" in all_text.lower()
+        assert "sfermion" in all_text.lower()
+        assert "partial-wave" in all_text.lower() or "partial wave" in all_text.lower()
+
+    def test_seed_material_id_consistency(self):
+        """documents と chunks の material_id が一致すること。"""
+        doc_ids = {d["material_id"] for d in NEUTRALINO_SEED["documents"]}
+        chunk_mids = {c["material_id"] for c in NEUTRALINO_SEED["chunks"]}
+        assert chunk_mids.issubset(doc_ids)
+
+
+# ===========================================================================
+# 5. _build_material_context の出力形式検証
+# ===========================================================================
+
+class TestMaterialContextFormat:
+    """_build_material_context が生成するコンテキスト文字列のフォーマット検証。"""
+
+    def _import_func(self):
+        from routes.admin import _build_material_context
+        return _build_material_context
+
+    @patch("routes.admin._pg_session")
+    def test_context_has_material_title_header(self, mock_pg):
+        """各教材のタイトルがMarkdownヘッダとして出力されること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert "### 教材:" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_context_has_summary_section(self, mock_pg):
+        """概要セクションが含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert "**概要:**" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_context_has_concepts_section(self, mock_pg):
+        """主要概念セクションが含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert "**主要概念:**" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_context_has_text_excerpt_section(self, mock_pg):
+        """教材テキスト抜粋セクションが含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert "**教材テキスト（抜粋）:**" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_context_does_not_contain_general_physics_only(self, mock_pg):
+        """コンテキストが一般的な物理学ではなくドメイン固有の内容を含むこと。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = _make_doc_rows()
+        chunk_rows = _make_chunk_rows()
+        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        # The context should contain specific particle physics terms from the fixture
+        ctx_lower = ctx.lower()
+        assert "neutralino" in ctx_lower
+        assert "annihilation" in ctx_lower or "cross section" in ctx_lower

--- a/backend/tests/test_delete_material_course.py
+++ b/backend/tests/test_delete_material_course.py
@@ -1,0 +1,516 @@
+"""コース削除・教材削除APIとUIのテスト。
+
+名前入力確認付き削除、教材削除時のカスケード削除を検証する。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Frontend DOM / JS tests (静的HTML/JS解析)
+# ---------------------------------------------------------------------------
+
+FRONTEND_DIR = Path(__file__).resolve().parents[2] / "frontend" / "public"
+ADMIN_HTML = FRONTEND_DIR / "admin.html"
+ADMIN_JS = FRONTEND_DIR / "js" / "admin.js"
+
+
+class TestAdminHTMLDeleteColumn:
+    """admin.html に操作カラムが存在することを検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _load_html(self):
+        self.html = ADMIN_HTML.read_text(encoding="utf-8")
+
+    def test_operation_column_header(self):
+        """教材テーブルに「操作」ヘッダーが存在すること。"""
+        assert "<th>操作</th>" in self.html
+
+    def test_materials_table_has_5_columns(self):
+        """教材テーブルのヘッダーが5列であること。"""
+        # colspanの値を確認（空状態のメッセージ）
+        assert 'colspan="5"' in self.html
+
+
+class TestAdminJSDeleteMaterial:
+    """admin.js に教材削除機能のロジックが存在することを検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _load_js(self):
+        self.js = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_delete_button_rendered_in_materials(self):
+        """renderMaterials 内に削除ボタンが生成されること。"""
+        assert "admin-delete-btn" in self.js
+
+    def test_delete_button_has_material_id(self):
+        """削除ボタンに data-material-id 属性が含まれること。"""
+        assert "data-material-id" in self.js
+
+    def test_delete_button_has_material_title(self):
+        """削除ボタンに data-material-title 属性が含まれること。"""
+        assert "data-material-title" in self.js
+
+    def test_delete_btn_click_calls_modal(self):
+        """削除ボタンのクリックで openDeleteConfirmModal が呼ばれること。"""
+        assert 'openDeleteConfirmModal("material"' in self.js
+
+    def test_materials_empty_state_colspan_5(self):
+        """教材0件時のcolspanが5に更新されていること。"""
+        assert 'colspan="5"' in self.js
+
+
+class TestAdminJSDeleteCourse:
+    """admin.js にコース削除機能のロジックが存在することを検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _load_js(self):
+        self.js = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_course_delete_btn_exists(self):
+        """コース一覧にcourse-delete-btn クラスが存在すること。"""
+        assert "course-delete-btn" in self.js
+
+    def test_course_delete_btn_has_course_id(self):
+        """コース削除ボタンに data-course-id 属性が含まれること。"""
+        assert 'data-course-id' in self.js
+
+    def test_course_delete_btn_has_course_title(self):
+        """コース削除ボタンに data-course-title 属性が含まれること。"""
+        assert 'data-course-title' in self.js
+
+    def test_course_delete_calls_modal(self):
+        """コース削除ボタンのクリックで openDeleteConfirmModal("course") が呼ばれること。"""
+        assert 'openDeleteConfirmModal("course"' in self.js
+
+    def test_course_delete_stops_propagation(self):
+        """コース削除ボタンのクリックで e.stopPropagation() が呼ばれること。"""
+        assert "e.stopPropagation()" in self.js
+
+
+class TestAdminJSDeleteConfirmModal:
+    """admin.js の openDeleteConfirmModal 関数を検証する。"""
+
+    @pytest.fixture(autouse=True)
+    def _load_js(self):
+        self.js = ADMIN_JS.read_text(encoding="utf-8")
+
+    def test_function_defined(self):
+        """openDeleteConfirmModal 関数が定義されていること。"""
+        assert "function openDeleteConfirmModal" in self.js
+
+    def test_modal_element_id(self):
+        """モーダルが delete-confirm-modal ID で作成されること。"""
+        assert "delete-confirm-modal" in self.js
+
+    def test_confirm_input_exists(self):
+        """名前確認用入力フィールドが存在すること。"""
+        assert "delete-confirm-input" in self.js
+
+    def test_exec_button_exists(self):
+        """実行ボタンが存在すること。"""
+        assert "delete-exec-btn" in self.js
+
+    def test_cancel_button_exists(self):
+        """キャンセルボタンが存在すること。"""
+        assert "delete-cancel-btn" in self.js
+
+    def test_exec_button_initially_disabled(self):
+        """削除ボタンが初期状態で無効化されていること。"""
+        assert 'id="delete-exec-btn"' in self.js
+        assert "disabled" in self.js
+
+    def test_input_validation_enables_button(self):
+        """入力がname と一致したときにボタンが有効化されるロジックがあること。"""
+        assert "input.value !== name" in self.js
+
+    def test_delete_api_endpoint_material(self):
+        """教材削除時に /admin/materials/ エンドポイントが使用されること。"""
+        assert '"/admin/materials/"' in self.js
+
+    def test_delete_api_endpoint_course(self):
+        """コース削除時に /admin/courses/ エンドポイントが使用されること。"""
+        assert '"/admin/courses/"' in self.js
+
+    def test_confirm_name_sent_in_body(self):
+        """confirm_name がリクエストボディに含まれること。"""
+        assert "confirm_name:" in self.js
+
+    def test_delete_method_used(self):
+        """DELETE メソッドが使用されること。"""
+        assert '"DELETE"' in self.js
+
+    def test_material_warning_text(self):
+        """教材削除時のカスケード警告テキストが表示されること。"""
+        assert "紐づくコースも同時に削除" in self.js
+
+    def test_course_warning_text(self):
+        """コース削除時の学習履歴削除警告テキストが表示されること。"""
+        assert "学習履歴も削除されます" in self.js
+
+    def test_success_reloads_materials(self):
+        """教材削除成功後にloadMaterialsが呼ばれること。"""
+        assert "loadMaterials()" in self.js
+
+    def test_cascade_deletion_count_shown(self):
+        """カスケード削除されたコース数が表示されること。"""
+        assert "deleted_courses" in self.js
+
+    def test_error_displayed_on_failure(self):
+        """削除失敗時にエラーメッセージが表示されること。"""
+        assert "delete-confirm-error" in self.js
+
+
+# ---------------------------------------------------------------------------
+# Backend API endpoint tests
+# ---------------------------------------------------------------------------
+
+_HAS_FASTAPI = True
+try:
+    from fastapi.testclient import TestClient
+except ImportError:
+    _HAS_FASTAPI = False
+
+_skip_no_fastapi = pytest.mark.skipif(
+    not _HAS_FASTAPI,
+    reason="FastAPI not installed (run in Docker for full API tests)",
+)
+
+
+@pytest.fixture
+def client():
+    """FastAPI TestClient を生成する。"""
+    if not _HAS_FASTAPI:
+        pytest.skip("FastAPI not installed")
+    import sys
+
+    backend_dir = str(Path(__file__).resolve().parents[1])
+    api_dir = str(Path(__file__).resolve().parents[1] / "api")
+    if backend_dir not in sys.path:
+        sys.path.insert(0, backend_dir)
+    if api_dir not in sys.path:
+        sys.path.insert(0, api_dir)
+
+    from api.main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def teacher_token():
+    """テスト用の教員JWTトークンを生成する。"""
+    import jwt
+
+    payload = {
+        "sub": "test-teacher-id",
+        "role": "TEACHER",
+        "username": "teacher1",
+        "email": "teacher1@test.com",
+    }
+    return jwt.encode(payload, "test-secret-key", algorithm="HS256")
+
+
+@pytest.fixture
+def auth_headers(teacher_token):
+    return {"Authorization": f"Bearer {teacher_token}"}
+
+
+@_skip_no_fastapi
+class TestDeleteMaterial:
+    """DELETE /api/admin/materials/{material_id} エンドポイントのテスト。"""
+
+    @patch("routes.admin._pg_session")
+    def test_delete_material_success(self, mock_session, client, auth_headers):
+        """教材削除が正常に行われること。"""
+        mock_pg = MagicMock()
+        # fetchone for document lookup
+        mock_pg.execute.return_value.fetchone.return_value = (
+            "doc-uuid-1",     # id
+            "テスト教材",      # title
+            "test.pdf",       # filename
+            "mat-001",        # source_path
+        )
+        # fetchall for courses (no linked courses)
+        mock_pg.execute.return_value.fetchall.return_value = []
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/materials/mat-001",
+            json={"confirm_name": "テスト教材"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["material_id"] == "mat-001"
+        assert data["deleted"] is True
+        assert data["deleted_courses"] == []
+        mock_pg.commit.assert_called_once()
+
+    @patch("routes.admin._pg_session")
+    def test_delete_material_name_mismatch(self, mock_session, client, auth_headers):
+        """確認名が一致しない場合に400が返ること。"""
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value.fetchone.return_value = (
+            "doc-uuid-1",
+            "テスト教材",
+            "test.pdf",
+            "mat-001",
+        )
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/materials/mat-001",
+            json={"confirm_name": "間違った名前"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "一致しません" in resp.json()["detail"]
+
+    @patch("routes.admin._pg_session")
+    def test_delete_material_not_found(self, mock_session, client, auth_headers):
+        """存在しない教材で404が返ること。"""
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value.fetchone.return_value = None
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/materials/nonexistent",
+            json={"confirm_name": "何か"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    @patch("routes.admin._pg_session")
+    def test_delete_material_cascade_courses(self, mock_session, client, auth_headers):
+        """教材削除時に紐づくコースもカスケード削除されること。"""
+        mock_pg = MagicMock()
+
+        # We need different return values for sequential execute calls:
+        # 1st call: document lookup (fetchone)
+        # 2nd call: course list (fetchall)
+        # 3rd call: course data lookup (fetchone) for each course
+        # 4th+: DELETE statements
+
+        call_count = {"n": 0}
+        original_execute = mock_pg.execute
+
+        def side_effect_execute(*args, **kwargs):
+            call_count["n"] += 1
+            result = MagicMock()
+            n = call_count["n"]
+            if n == 1:
+                # Document lookup
+                result.fetchone.return_value = (
+                    "doc-uuid-1", "テスト教材", "test.pdf", "mat-001"
+                )
+            elif n == 2:
+                # Course list
+                result.fetchall.return_value = [("course-1",), ("course-2",)]
+            elif n == 3:
+                # Course-1 data with linked material
+                result.fetchone.return_value = (
+                    json.dumps({
+                        "sources": [{"material_id": "mat-001", "title": "テスト教材"}]
+                    }),
+                )
+            elif n == 4:
+                # Delete chat history for course-1
+                result.rowcount = 0
+            elif n == 5:
+                # Delete course-1
+                result.rowcount = 1
+            elif n == 6:
+                # Course-2 data with different material
+                result.fetchone.return_value = (
+                    json.dumps({
+                        "sources": [{"material_id": "mat-999", "title": "別の教材"}]
+                    }),
+                )
+            elif n == 7:
+                # Delete chunks
+                result.rowcount = 5
+            elif n == 8:
+                # Delete document
+                result.rowcount = 1
+            return result
+
+        mock_pg.execute.side_effect = side_effect_execute
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/materials/mat-001",
+            json={"confirm_name": "テスト教材"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deleted"] is True
+        # course-1 is linked, course-2 is not
+        assert "course-1" in data["deleted_courses"]
+        assert "course-2" not in data["deleted_courses"]
+        mock_pg.commit.assert_called_once()
+
+    def test_delete_material_requires_auth(self, client):
+        """認証なしで401/403が返ること。"""
+        resp = client.request(
+            "DELETE",
+            "/api/admin/materials/mat-001",
+            json={"confirm_name": "テスト"},
+        )
+        assert resp.status_code in (401, 403)
+
+
+@_skip_no_fastapi
+class TestDeleteCourse:
+    """DELETE /api/admin/courses/{course_id} エンドポイントのテスト。"""
+
+    @patch("routes.admin._pg_session")
+    def test_delete_course_success(self, mock_session, client, auth_headers):
+        """コース削除が正常に行われること。"""
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value.fetchone.return_value = (
+            "course-001",
+            "量子力学入門",
+        )
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/courses/course-001",
+            json={"confirm_name": "量子力学入門"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["course_id"] == "course-001"
+        assert data["deleted"] is True
+        mock_pg.commit.assert_called_once()
+
+    @patch("routes.admin._pg_session")
+    def test_delete_course_name_mismatch(self, mock_session, client, auth_headers):
+        """確認名が一致しない場合に400が返ること。"""
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value.fetchone.return_value = (
+            "course-001",
+            "量子力学入門",
+        )
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/courses/course-001",
+            json={"confirm_name": "間違ったコース名"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 400
+        assert "一致しません" in resp.json()["detail"]
+
+    @patch("routes.admin._pg_session")
+    def test_delete_course_not_found(self, mock_session, client, auth_headers):
+        """存在しないコースで404が返ること。"""
+        mock_pg = MagicMock()
+        mock_pg.execute.return_value.fetchone.return_value = None
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/courses/nonexistent",
+            json={"confirm_name": "何か"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 404
+
+    @patch("routes.admin._pg_session")
+    def test_delete_course_deletes_chat_history(self, mock_session, client, auth_headers):
+        """コース削除時にチャット履歴も削除されること。"""
+        mock_pg = MagicMock()
+
+        call_count = {"n": 0}
+
+        def side_effect_execute(*args, **kwargs):
+            call_count["n"] += 1
+            result = MagicMock()
+            if call_count["n"] == 1:
+                # Course lookup
+                result.fetchone.return_value = ("course-001", "量子力学入門")
+            return result
+
+        mock_pg.execute.side_effect = side_effect_execute
+        mock_session.return_value = mock_pg
+
+        resp = client.request(
+            "DELETE",
+            "/api/admin/courses/course-001",
+            json={"confirm_name": "量子力学入門"},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+        # Verify that DELETE FROM learning_chat_history was called
+        executed_queries = [
+            str(c[0][0]) for c in mock_pg.execute.call_args_list
+        ]
+        chat_history_deleted = any(
+            "learning_chat_history" in q for q in executed_queries
+        )
+        assert chat_history_deleted, "learning_chat_history の DELETE が呼ばれていません"
+
+    def test_delete_course_requires_auth(self, client):
+        """認証なしで401/403が返ること。"""
+        resp = client.request(
+            "DELETE",
+            "/api/admin/courses/course-001",
+            json={"confirm_name": "テスト"},
+        )
+        assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConfirmRequestSchema:
+    """DeleteConfirmRequest スキーマのテスト。"""
+
+    def test_schema_import(self):
+        """DeleteConfirmRequest がインポートできること。"""
+        import sys
+
+        backend_dir = str(Path(__file__).resolve().parents[1])
+        api_dir = str(Path(__file__).resolve().parents[1] / "api")
+        if backend_dir not in sys.path:
+            sys.path.insert(0, backend_dir)
+        if api_dir not in sys.path:
+            sys.path.insert(0, api_dir)
+
+        from schemas import DeleteConfirmRequest
+
+        req = DeleteConfirmRequest(confirm_name="テスト教材")
+        assert req.confirm_name == "テスト教材"
+
+    def test_schema_requires_confirm_name(self):
+        """confirm_name が必須フィールドであること。"""
+        import sys
+
+        backend_dir = str(Path(__file__).resolve().parents[1])
+        api_dir = str(Path(__file__).resolve().parents[1] / "api")
+        if backend_dir not in sys.path:
+            sys.path.insert(0, backend_dir)
+        if api_dir not in sys.path:
+            sys.path.insert(0, api_dir)
+
+        from pydantic import ValidationError
+        from schemas import DeleteConfirmRequest
+
+        with pytest.raises(ValidationError):
+            DeleteConfirmRequest()

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -62,10 +62,11 @@
               <th>タイトル</th>
               <th>ステータス</th>
               <th>アップロード日時</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody id="materials-tbody">
-            <tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>
+            <tr><td colspan="5" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>
           </tbody>
         </table>
       </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -193,7 +193,7 @@
   function renderMaterials(materials) {
     var tbody = document.getElementById("materials-tbody");
     if (!materials || materials.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">教材がまだアップロードされていません</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--color-text-tertiary)">教材がまだアップロードされていません</td></tr>';
       return;
     }
 
@@ -221,9 +221,118 @@
       html += "<td>" + escHtml(m.title) + "</td>";
       html += '<td><span class="admin-status ' + statusClass + '">' + statusLabel + "</span></td>";
       html += "<td>" + escHtml(uploadedAt) + "</td>";
+      html += '<td><button class="admin-delete-btn" data-material-id="' + escHtml(m.material_id) + '" data-material-title="' + escHtml(m.title) + '" style="background:none;border:1px solid var(--color-text-danger);color:var(--color-text-danger);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:12px">削除</button></td>';
       html += "</tr>";
     });
     tbody.innerHTML = html;
+
+    // Attach delete handlers
+    tbody.querySelectorAll(".admin-delete-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var mid = this.getAttribute("data-material-id");
+        var title = this.getAttribute("data-material-title");
+        openDeleteConfirmModal("material", mid, title);
+      });
+    });
+  }
+
+  // ── Delete Confirmation Modal ──────────────────────────────────────
+  function openDeleteConfirmModal(kind, id, name) {
+    // kind: "material" | "course"
+    var existing = document.getElementById("delete-confirm-modal");
+    if (existing) existing.remove();
+
+    var kindLabel = kind === "material" ? "教材" : "コース";
+    var warningText = kind === "material"
+      ? "この教材を削除すると、紐づくコースも同時に削除されます。"
+      : "このコースを削除すると、関連する学習履歴も削除されます。";
+
+    var overlay = document.createElement("div");
+    overlay.id = "delete-confirm-modal";
+    overlay.style.cssText = "position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;align-items:center;justify-content:center;z-index:9999";
+
+    overlay.innerHTML =
+      '<div style="background:var(--color-background-primary);border:1px solid var(--color-border-secondary);border-radius:8px;padding:24px;min-width:400px;max-width:500px">' +
+        '<h3 style="margin:0 0 12px;font-size:16px;color:var(--color-text-danger)">' + kindLabel + 'の削除</h3>' +
+        '<p style="font-size:13px;color:var(--color-text-primary);margin:0 0 8px">' +
+          '以下の' + kindLabel + 'を削除しようとしています:' +
+        '</p>' +
+        '<p style="font-size:14px;font-weight:600;color:var(--color-text-primary);margin:0 0 12px;padding:8px;background:var(--color-bg-secondary);border-radius:4px">' +
+          escHtml(name) +
+        '</p>' +
+        '<p style="font-size:12px;color:var(--color-text-danger);margin:0 0 12px">' + warningText + '</p>' +
+        '<p style="font-size:13px;color:var(--color-text-secondary);margin:0 0 8px">' +
+          '削除を確認するには、' + kindLabel + '名を正確に入力してください:' +
+        '</p>' +
+        '<input type="text" id="delete-confirm-input" placeholder="' + escHtml(name) + '" style="width:100%;padding:8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary);box-sizing:border-box;margin-bottom:16px">' +
+        '<div id="delete-confirm-error" style="display:none;color:var(--color-text-danger);font-size:12px;margin-bottom:8px"></div>' +
+        '<div style="display:flex;gap:8px;justify-content:flex-end">' +
+          '<button id="delete-cancel-btn" style="padding:6px 16px;border:1px solid var(--color-border);border-radius:4px;background:none;color:var(--color-text-secondary);cursor:pointer;font-size:13px">キャンセル</button>' +
+          '<button id="delete-exec-btn" style="padding:6px 16px;border:none;border-radius:4px;background:var(--color-text-danger);color:#fff;cursor:pointer;font-size:13px" disabled>削除する</button>' +
+        '</div>' +
+      '</div>';
+
+    document.body.appendChild(overlay);
+
+    var input = document.getElementById("delete-confirm-input");
+    var execBtn = document.getElementById("delete-exec-btn");
+    var errorEl = document.getElementById("delete-confirm-error");
+
+    // Enable button only when name matches
+    input.addEventListener("input", function () {
+      execBtn.disabled = (input.value !== name);
+    });
+
+    // Cancel
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) overlay.remove();
+    });
+    document.getElementById("delete-cancel-btn").addEventListener("click", function () {
+      overlay.remove();
+    });
+
+    // Execute delete
+    execBtn.addEventListener("click", function () {
+      execBtn.disabled = true;
+      execBtn.textContent = "削除中...";
+      errorEl.style.display = "none";
+
+      var endpoint = kind === "material"
+        ? "/admin/materials/" + id
+        : "/admin/courses/" + id;
+
+      apiFetch(endpoint, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm_name: input.value }),
+      })
+        .then(function (res) {
+          if (!res.ok) return res.json().then(function (d) { throw new Error(d.detail || "削除に失敗しました"); });
+          return res.json();
+        })
+        .then(function (data) {
+          overlay.remove();
+          if (kind === "material") {
+            var msg = "教材「" + name + "」を削除しました。";
+            if (data.deleted_courses && data.deleted_courses.length > 0) {
+              msg += " 紐づく " + data.deleted_courses.length + " 件のコースも削除されました。";
+            }
+            showUploadStatus(msg, "success");
+            loadMaterials();
+          } else {
+            showUploadStatus("コース「" + name + "」を削除しました。", "success");
+          }
+        })
+        .catch(function (err) {
+          execBtn.disabled = false;
+          execBtn.textContent = "削除する";
+          errorEl.textContent = err.message || "削除に失敗しました";
+          errorEl.style.display = "block";
+        });
+    });
+
+    // Focus input
+    input.focus();
   }
 
   // ── File Upload ────────────────────────────────────────────────────
@@ -926,19 +1035,30 @@
             } catch (e) { updatedAt = ""; }
           }
           html +=
-            '<div class="import-course-item" data-course-id="' + escHtml(c.id) + '" style="padding:10px 12px;border:1px solid var(--color-border-secondary);border-radius:6px;margin-bottom:8px;cursor:pointer;transition:background 0.15s">' +
+            '<div class="import-course-item" data-course-id="' + escHtml(c.id) + '" style="padding:10px 12px;border:1px solid var(--color-border-secondary);border-radius:6px;margin-bottom:8px;transition:background 0.15s">' +
               '<div style="display:flex;justify-content:space-between;align-items:center">' +
-                '<div>' +
+                '<div class="import-course-select" style="flex:1;cursor:pointer">' +
                   '<div style="font-size:14px;color:var(--color-text-primary);font-weight:500">' + escHtml(c.title) + statusBadge + '</div>' +
                   '<div style="font-size:11px;color:var(--color-text-tertiary);margin-top:2px">ID: ' + escHtml(c.id) + (updatedAt ? ' | 更新: ' + updatedAt : '') + '</div>' +
                 '</div>' +
-                '<span style="font-size:12px;color:var(--color-text-info)">選択 &rarr;</span>' +
+                '<div style="display:flex;gap:8px;align-items:center">' +
+                  '<span class="import-course-select" style="font-size:12px;color:var(--color-text-info);cursor:pointer">選択 &rarr;</span>' +
+                  '<button class="course-delete-btn" data-course-id="' + escHtml(c.id) + '" data-course-title="' + escHtml(c.title) + '" style="background:none;border:1px solid var(--color-text-danger);color:var(--color-text-danger);padding:2px 8px;border-radius:4px;cursor:pointer;font-size:11px">削除</button>' +
+                '</div>' +
               '</div>' +
             '</div>';
         });
         listEl.innerHTML = html;
 
-        // Add click handlers
+        // Add click handlers for import
+        listEl.querySelectorAll(".import-course-select").forEach(function (el) {
+          var item = el.closest(".import-course-item");
+          el.addEventListener("click", function () {
+            var courseId = item.getAttribute("data-course-id");
+            importCourse(courseId);
+            overlay.remove();
+          });
+        });
         listEl.querySelectorAll(".import-course-item").forEach(function (item) {
           item.addEventListener("mouseenter", function () {
             this.style.background = "var(--color-background-tertiary)";
@@ -946,10 +1066,15 @@
           item.addEventListener("mouseleave", function () {
             this.style.background = "";
           });
-          item.addEventListener("click", function () {
-            var courseId = this.getAttribute("data-course-id");
-            importCourse(courseId);
+        });
+        // Add click handlers for course delete
+        listEl.querySelectorAll(".course-delete-btn").forEach(function (btn) {
+          btn.addEventListener("click", function (e) {
+            e.stopPropagation();
+            var cid = this.getAttribute("data-course-id");
+            var title = this.getAttribute("data-course-title");
             overlay.remove();
+            openDeleteConfirmModal("course", cid, title);
           });
         });
       })


### PR DESCRIPTION
OpenAI キーがない環境で発生していた 401 エラーを解消するため、
TTS プロバイダ選択ロジックを core/tts.py に抽象化レイヤーとして実装した。

- core/tts.py: `generate_tts_audio` 関数を新規作成
  - sk- で始まる API キーがある場合 → OpenAI TTS (tts-1/alloy)
  - LLM_PROVIDER=google または gemini-vertex の場合 → Google Cloud TTS (ADC 認証)
  - いずれも設定されていない場合 → エラーログを出力して None を返す
- lecture_studio.py: `_batch_audio_worker` のハードコード OpenAI 呼び出しを
  `generate_tts_audio` に置き換え、None 返却時はエラーカウントして継続
- requirements.txt: google-cloud-texttospeech>=2.16,<3 を追加
- test_lecture_studio.py: TTS プロバイダ選択ロジックのテスト 9 件を追加

https://claude.ai/code/session_01FKSCjZPeaqeFpEVnp9oqk1