### PR TITLE
Refresh material selection list after upload completion

### DIFF
--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -393,6 +393,7 @@
           "info"
         );
         loadMaterials();
+        loadMaterialsForSelection();
         if (data.task_id) {
           startTaskPolling(data.task_id, file.name);
         } else {
@@ -437,6 +438,7 @@
             );
             disableUploadUI(false);
             loadMaterials();
+            loadMaterialsForSelection();
           } else if (task.status === "failed") {
             stopTaskPolling(taskId);
             var errMsg = task.error_message || "不明なエラー";


### PR DESCRIPTION
## Summary
Added calls to `loadMaterialsForSelection()` after material uploads complete to ensure the material selection dropdown is updated with newly uploaded materials.

## Key Changes
- Added `loadMaterialsForSelection()` call after successful material upload completion (line 396)
- Added `loadMaterialsForSelection()` call after async task-based upload completes (line 441)

## Implementation Details
The changes ensure that whenever materials are uploaded—whether through direct upload or async task processing—both the main materials list and the materials selection list are refreshed. This prevents users from seeing stale data in the selection dropdown after uploading new materials.

https://claude.ai/code/session_012KhJ9eHcY9V3hUCBrNnhnF