### PR TITLE
Issue #121: Add group management and access control for materials

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -28,6 +28,13 @@ POST /api/admin/course-builder/chat                             コース構築A
 PUT  /api/admin/courses/{course_id}/publish                     コースを学生に公開
 POST /api/admin/users/student                                   学生アカウント作成 (TEACHER)
 POST /api/admin/users/teacher                                   教員アカウント作成 (SYSTEM_ADMIN)
+POST /api/groups                                                グループ作成
+GET  /api/groups                                                自グループ一覧
+GET  /api/groups/{group_id}                                     グループ詳細
+POST /api/groups/{group_id}/members                             ユーザーを直接招待
+POST /api/groups/join-by-code                                   招待コードで参加
+GET  /api/me/invitations                                        自分宛ての招待一覧
+POST /api/me/invitations/{inv}/accept                           招待を承諾
 GET  /healthz                                                   ヘルスチェック
 """
 
@@ -44,7 +51,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text as sa_text
 
 from dependencies import _hash_password
-from routes import auth, learning, admin, lecture
+from routes import auth, learning, admin, lecture, groups
 from core.config import get_settings as _get_settings
 from core.postgres import get_session as _pg_session, check_connection as _pg_check
 
@@ -232,8 +239,80 @@ def _run_migrations() -> None:
         session.execute(sa_text("DROP INDEX IF EXISTS idx_chunks_arxiv"))
         session.execute(sa_text("ALTER TABLE chunks DROP COLUMN IF EXISTS arxiv_id"))
 
+        # Migration 009: グループ + 資料開示範囲 (Issue #121)
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS groups (
+                id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                name         TEXT NOT NULL,
+                description  TEXT NOT NULL DEFAULT '',
+                invite_code  TEXT UNIQUE,
+                created_by   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_groups_created_by ON groups(created_by)"
+        ))
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS group_members (
+                id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                group_id   UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                role       TEXT NOT NULL DEFAULT 'member'
+                              CHECK (role IN ('admin', 'member')),
+                joined_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE(group_id, user_id)
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_group_members_user ON group_members(user_id)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_group_members_group ON group_members(group_id)"
+        ))
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS group_invitations (
+                id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                group_id         UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                invitee_user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                inviter_user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                status           TEXT NOT NULL DEFAULT 'pending'
+                                    CHECK (status IN ('pending', 'accepted', 'declined', 'revoked')),
+                created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+                responded_at     TIMESTAMPTZ,
+                UNIQUE(group_id, invitee_user_id, status)
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_invitations_invitee ON group_invitations(invitee_user_id, status)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_invitations_group ON group_invitations(group_id)"
+        ))
+        for ddl in [
+            "ALTER TABLE documents ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'",
+            "ALTER TABLE documents ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE SET NULL",
+            "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'",
+            "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE SET NULL",
+            "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT ''",
+        ]:
+            session.execute(sa_text(ddl))
+        # 既存の公開テンプレートを 'public' 扱いに移行（後方互換）
+        session.execute(sa_text("""
+            UPDATE learning_courses
+                SET visibility = 'public'
+                WHERE is_published = true AND is_template = true AND visibility = 'private'
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_documents_visibility ON documents(visibility)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_courses_visibility ON learning_courses(visibility)"
+        ))
+
         session.commit()
-        logger.info("Migrations (002-007) applied successfully.")
+        logger.info("Migrations (002-009) applied successfully.")
 
         # Seed builtin schema types/predicates
         from core.schema_registry import seed_builtin_schema
@@ -316,6 +395,7 @@ app.include_router(auth.router)
 app.include_router(learning.router)
 app.include_router(admin.router)
 app.include_router(lecture.router)
+app.include_router(groups.router)
 
 
 @app.get("/healthz")

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -36,6 +36,7 @@ from schemas import (
     SchemaTypeCreateRequest,
     SchemaTypeOut,
     UserOut,
+    VisibilityUpdateRequest,
 )
 from services import (
     _material_lock,
@@ -44,6 +45,7 @@ from services import (
     get_background_task,
     process_material_background,
     save_cb_session,
+    user_can_access_group,
 )
 from core.llm import generate_text
 from core.meta_analyzer import (
@@ -149,7 +151,8 @@ def list_materials(
     try:
         records = session.execute(
             sa_text("""
-                SELECT source_path, filename, title, status, created_at, knowledge_graph
+                SELECT source_path, filename, title, status, created_at, knowledge_graph,
+                       COALESCE(visibility, 'private'), group_id
                 FROM documents
                 WHERE uploaded_by = CAST(:user_id AS uuid) AND filename IS NOT NULL
                 ORDER BY created_at DESC
@@ -177,6 +180,8 @@ def list_materials(
             status=status,
             uploaded_at=uploaded_at,
             knowledge_graph=kg,
+            visibility=r[6] or "private",
+            group_id=str(r[7]) if r[7] else None,
         ))
 
     return materials
@@ -192,7 +197,8 @@ def get_material(
     try:
         record = session.execute(
             sa_text("""
-                SELECT source_path, filename, title, status, created_at, knowledge_graph
+                SELECT source_path, filename, title, status, created_at, knowledge_graph,
+                       COALESCE(visibility, 'private'), group_id
                 FROM documents
                 WHERE uploaded_by = CAST(:user_id AS uuid) AND source_path = :material_id
                 LIMIT 1
@@ -220,7 +226,118 @@ def get_material(
         status=status,
         uploaded_at=uploaded_at,
         knowledge_graph=kg,
+        visibility=record[6] or "private",
+        group_id=str(record[7]) if record[7] else None,
     )
+
+
+@router.put("/materials/{material_id}/visibility")
+def update_material_visibility(
+    material_id: str,
+    body: VisibilityUpdateRequest,
+    current_user: dict = Depends(_require_teacher),
+) -> dict:
+    """教材の開示範囲を更新する。"""
+    if body.visibility not in ("public", "group", "private"):
+        raise HTTPException(status_code=400, detail=f"Invalid visibility: {body.visibility}")
+    if body.visibility == "group":
+        if not body.group_id:
+            raise HTTPException(status_code=400, detail="visibility='group' requires group_id")
+        if not user_can_access_group(current_user["id"], body.group_id):
+            raise HTTPException(status_code=403, detail="指定されたグループに参加していません")
+
+    session = _pg_session()
+    try:
+        result = session.execute(
+            sa_text("""
+                UPDATE documents
+                SET visibility = :visibility,
+                    group_id = CAST(:group_id AS uuid),
+                    updated_at = now()
+                WHERE source_path = :material_id
+                  AND uploaded_by = CAST(:user_id AS uuid)
+                RETURNING id
+            """),
+            {
+                "visibility": body.visibility,
+                "group_id": body.group_id if body.visibility == "group" else None,
+                "material_id": material_id,
+                "user_id": current_user["id"],
+            },
+        ).fetchone()
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    if not result:
+        raise HTTPException(status_code=404, detail="Material not found")
+    logger.info(
+        "Material %s visibility=%s group=%s by user=%s",
+        material_id, body.visibility, body.group_id, current_user["id"],
+    )
+    return {
+        "material_id": material_id,
+        "visibility": body.visibility,
+        "group_id": body.group_id if body.visibility == "group" else None,
+    }
+
+
+@router.put("/courses/{course_id}/visibility")
+def update_course_visibility(
+    course_id: str,
+    body: VisibilityUpdateRequest,
+    current_user: dict = Depends(_require_teacher),
+) -> dict:
+    """コースの開示範囲を更新する。"""
+    if body.visibility not in ("public", "group", "private"):
+        raise HTTPException(status_code=400, detail=f"Invalid visibility: {body.visibility}")
+    if body.visibility == "group":
+        if not body.group_id:
+            raise HTTPException(status_code=400, detail="visibility='group' requires group_id")
+        if not user_can_access_group(current_user["id"], body.group_id):
+            raise HTTPException(status_code=403, detail="指定されたグループに参加していません")
+
+    session = _pg_session()
+    try:
+        result = session.execute(
+            sa_text("""
+                UPDATE learning_courses
+                SET visibility = :visibility,
+                    group_id = CAST(:group_id AS uuid),
+                    is_published = CASE WHEN :visibility = 'public' THEN true ELSE is_published END,
+                    is_template = CASE WHEN :visibility = 'public' THEN true ELSE is_template END,
+                    updated_at = now()
+                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+                RETURNING id
+            """),
+            {
+                "visibility": body.visibility,
+                "group_id": body.group_id if body.visibility == "group" else None,
+                "course_id": course_id,
+                "user_id": current_user["id"],
+            },
+        ).fetchone()
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    if not result:
+        raise HTTPException(status_code=404, detail="Course not found")
+    logger.info(
+        "Course %s visibility=%s group=%s by user=%s",
+        course_id, body.visibility, body.group_id, current_user["id"],
+    )
+    return {
+        "course_id": course_id,
+        "visibility": body.visibility,
+        "group_id": body.group_id if body.visibility == "group" else None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/routes/groups.py
+++ b/backend/api/routes/groups.py
@@ -1,0 +1,775 @@
+"""Episteme Graph — グループ管理エンドポイント (/api/groups, /api/me/invitations)。
+
+Issue #121: 資料のアクセス制御およびグループ招待機能。
+
+Endpoints
+---------
+POST   /api/groups                                    グループを作成
+GET    /api/groups                                    自分が参加するグループ一覧
+GET    /api/groups/{group_id}                         グループ詳細 + メンバー一覧
+PUT    /api/groups/{group_id}                         グループ更新 (admin)
+DELETE /api/groups/{group_id}                         グループ削除 (admin)
+POST   /api/groups/{group_id}/members                 ユーザーを直接招待 (admin)
+DELETE /api/groups/{group_id}/members/{user_id}       メンバー退会/除名 (admin or self)
+POST   /api/groups/{group_id}/invite-code/rotate      招待コードを再発行 (admin)
+POST   /api/groups/join-by-code                       招待コードで参加
+GET    /api/groups/{group_id}/invitations             直接招待の一覧 (admin)
+GET    /api/me/invitations                            自分への未承諾の招待一覧
+POST   /api/me/invitations/{invitation_id}/accept     招待を承諾
+POST   /api/me/invitations/{invitation_id}/decline    招待を辞退
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text as sa_text
+
+from dependencies import _get_current_user
+from schemas import (
+    GroupCreateRequest,
+    GroupDetailOut,
+    GroupInvitationOut,
+    GroupInviteByCodeRequest,
+    GroupInviteByUserRequest,
+    GroupMemberOut,
+    GroupOut,
+    GroupUpdateRequest,
+)
+from core.postgres import get_session as _pg_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Groups"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_invite_code() -> str:
+    """URL-safe な 12 文字の招待コードを生成する。"""
+    return secrets.token_urlsafe(9)[:12]
+
+
+def _require_member(session, group_id: str, user_id: str) -> str:
+    """ユーザーがグループのメンバーであることを確認し、ロールを返す。"""
+    row = session.execute(
+        sa_text("""
+            SELECT role FROM group_members
+            WHERE group_id = CAST(:gid AS uuid) AND user_id = CAST(:uid AS uuid)
+            LIMIT 1
+        """),
+        {"gid": group_id, "uid": user_id},
+    ).fetchone()
+    if not row:
+        raise HTTPException(status_code=403, detail="You are not a member of this group")
+    return row[0]
+
+
+def _require_admin(session, group_id: str, user_id: str) -> None:
+    """ユーザーがグループの admin であることを確認する。"""
+    role = _require_member(session, group_id, user_id)
+    if role != "admin":
+        raise HTTPException(status_code=403, detail="Group admin role required")
+
+
+def _group_row_to_out(row, my_role: str, member_count: int, show_invite_code: bool) -> GroupOut:
+    return GroupOut(
+        id=str(row[0]),
+        name=row[1] or "",
+        description=row[2] or "",
+        invite_code=(row[3] or None) if show_invite_code else None,
+        created_by=str(row[4]),
+        my_role=my_role,
+        member_count=member_count,
+        created_at=row[5].isoformat() if row[5] else "",
+        updated_at=row[6].isoformat() if row[6] else "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Groups CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/groups", response_model=GroupOut, status_code=201)
+def create_group(
+    body: GroupCreateRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupOut:
+    """グループを作成する。作成者は自動的に admin として参加する。"""
+    if not body.name.strip():
+        raise HTTPException(status_code=400, detail="Group name is required")
+
+    group_id = uuid.uuid4()
+    invite_code = _generate_invite_code()
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO groups (id, name, description, invite_code, created_by)
+                VALUES (:id, :name, :description, :invite_code, CAST(:created_by AS uuid))
+            """),
+            {
+                "id": group_id,
+                "name": body.name.strip(),
+                "description": body.description or "",
+                "invite_code": invite_code,
+                "created_by": current_user["id"],
+            },
+        )
+        session.execute(
+            sa_text("""
+                INSERT INTO group_members (group_id, user_id, role)
+                VALUES (:gid, CAST(:uid AS uuid), 'admin')
+            """),
+            {"gid": group_id, "uid": current_user["id"]},
+        )
+        row = session.execute(
+            sa_text("""
+                SELECT id, name, description, invite_code, created_by, created_at, updated_at
+                FROM groups WHERE id = :id
+            """),
+            {"id": group_id},
+        ).fetchone()
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    logger.info("Group '%s' (id=%s) created by user=%s", body.name, group_id, current_user["id"])
+    return _group_row_to_out(row, my_role="admin", member_count=1, show_invite_code=True)
+
+
+@router.get("/api/groups", response_model=list[GroupOut])
+def list_my_groups(
+    current_user: dict = Depends(_get_current_user),
+) -> list[GroupOut]:
+    """自分が所属しているグループ一覧を返す。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                SELECT g.id, g.name, g.description, g.invite_code, g.created_by,
+                       g.created_at, g.updated_at, gm.role,
+                       (SELECT COUNT(*) FROM group_members gm2 WHERE gm2.group_id = g.id) AS member_count
+                FROM groups g
+                JOIN group_members gm ON gm.group_id = g.id
+                WHERE gm.user_id = CAST(:uid AS uuid)
+                ORDER BY g.updated_at DESC
+            """),
+            {"uid": current_user["id"]},
+        ).fetchall()
+    finally:
+        session.close()
+
+    return [
+        _group_row_to_out(
+            r[:7],
+            my_role=r[7],
+            member_count=int(r[8] or 0),
+            show_invite_code=(r[7] == "admin"),
+        )
+        for r in rows
+    ]
+
+
+@router.get("/api/groups/{group_id}", response_model=GroupDetailOut)
+def get_group_detail(
+    group_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupDetailOut:
+    """グループ詳細（メンバーリスト付き）を返す。メンバーのみアクセス可能。"""
+    session = _pg_session()
+    try:
+        my_role = _require_member(session, group_id, current_user["id"])
+
+        group_row = session.execute(
+            sa_text("""
+                SELECT id, name, description, invite_code, created_by, created_at, updated_at
+                FROM groups WHERE id = CAST(:id AS uuid)
+            """),
+            {"id": group_id},
+        ).fetchone()
+        if not group_row:
+            raise HTTPException(status_code=404, detail="Group not found")
+
+        member_rows = session.execute(
+            sa_text("""
+                SELECT u.id, u.display_name, u.email, gm.role, gm.joined_at
+                FROM group_members gm
+                JOIN users u ON u.id = gm.user_id
+                WHERE gm.group_id = CAST(:gid AS uuid)
+                ORDER BY gm.joined_at ASC
+            """),
+            {"gid": group_id},
+        ).fetchall()
+    finally:
+        session.close()
+
+    members = [
+        GroupMemberOut(
+            user_id=str(mr[0]),
+            username=mr[1] or "",
+            email=mr[2] or "",
+            role=mr[3],
+            joined_at=mr[4].isoformat() if mr[4] else "",
+        )
+        for mr in member_rows
+    ]
+
+    base = _group_row_to_out(
+        group_row,
+        my_role=my_role,
+        member_count=len(members),
+        show_invite_code=(my_role == "admin"),
+    )
+    return GroupDetailOut(**base.model_dump(), members=members)
+
+
+@router.put("/api/groups/{group_id}", response_model=GroupOut)
+def update_group(
+    group_id: str,
+    body: GroupUpdateRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupOut:
+    """グループの名前・説明を更新する（admin のみ）。"""
+    session = _pg_session()
+    try:
+        _require_admin(session, group_id, current_user["id"])
+
+        updates: list[str] = []
+        params: dict = {"id": group_id}
+        if body.name is not None:
+            if not body.name.strip():
+                raise HTTPException(status_code=400, detail="Group name cannot be empty")
+            updates.append("name = :name")
+            params["name"] = body.name.strip()
+        if body.description is not None:
+            updates.append("description = :description")
+            params["description"] = body.description
+
+        if updates:
+            updates.append("updated_at = now()")
+            session.execute(
+                sa_text(f"UPDATE groups SET {', '.join(updates)} WHERE id = CAST(:id AS uuid)"),
+                params,
+            )
+
+        row = session.execute(
+            sa_text("""
+                SELECT id, name, description, invite_code, created_by, created_at, updated_at
+                FROM groups WHERE id = CAST(:id AS uuid)
+            """),
+            {"id": group_id},
+        ).fetchone()
+        member_count = session.execute(
+            sa_text("SELECT COUNT(*) FROM group_members WHERE group_id = CAST(:gid AS uuid)"),
+            {"gid": group_id},
+        ).scalar() or 0
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    return _group_row_to_out(row, my_role="admin", member_count=int(member_count), show_invite_code=True)
+
+
+@router.delete("/api/groups/{group_id}")
+def delete_group(
+    group_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> dict:
+    """グループを削除する（admin のみ）。
+
+    CASCADE により group_members / group_invitations も削除される。
+    関連する Document/LearningCourse の group_id は SET NULL される。
+    """
+    session = _pg_session()
+    try:
+        _require_admin(session, group_id, current_user["id"])
+        session.execute(
+            sa_text("DELETE FROM groups WHERE id = CAST(:id AS uuid)"),
+            {"id": group_id},
+        )
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    logger.info("Group %s deleted by user=%s", group_id, current_user["id"])
+    return {"group_id": group_id, "deleted": True}
+
+
+# ---------------------------------------------------------------------------
+# Invite code rotation
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/groups/{group_id}/invite-code/rotate")
+def rotate_invite_code(
+    group_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> dict:
+    """招待コードを再発行する（admin のみ）。"""
+    new_code = _generate_invite_code()
+    session = _pg_session()
+    try:
+        _require_admin(session, group_id, current_user["id"])
+        session.execute(
+            sa_text("""
+                UPDATE groups SET invite_code = :code, updated_at = now()
+                WHERE id = CAST(:id AS uuid)
+            """),
+            {"code": new_code, "id": group_id},
+        )
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+    return {"group_id": group_id, "invite_code": new_code}
+
+
+# ---------------------------------------------------------------------------
+# Direct invitation by user (admin)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/groups/{group_id}/members", response_model=GroupInvitationOut, status_code=201)
+def invite_user(
+    group_id: str,
+    body: GroupInviteByUserRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupInvitationOut:
+    """特定のユーザー（username または email）をグループへ直接招待する（admin のみ）。"""
+    if not body.username and not body.email:
+        raise HTTPException(status_code=400, detail="username または email のいずれかを指定してください")
+
+    session = _pg_session()
+    try:
+        _require_admin(session, group_id, current_user["id"])
+
+        # 招待対象ユーザーを解決
+        if body.username:
+            target = session.execute(
+                sa_text("SELECT id, display_name, email FROM users WHERE display_name = :name LIMIT 1"),
+                {"name": body.username},
+            ).fetchone()
+        else:
+            target = session.execute(
+                sa_text("SELECT id, display_name, email FROM users WHERE email = :email LIMIT 1"),
+                {"email": body.email},
+            ).fetchone()
+
+        if not target:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        target_id = target[0]
+        target_username = target[1] or ""
+
+        # 既にメンバーならエラー
+        already = session.execute(
+            sa_text("""
+                SELECT 1 FROM group_members
+                WHERE group_id = CAST(:gid AS uuid) AND user_id = :uid
+                LIMIT 1
+            """),
+            {"gid": group_id, "uid": target_id},
+        ).fetchone()
+        if already:
+            raise HTTPException(status_code=409, detail="User is already a member")
+
+        # 既存の pending 招待があれば再利用
+        existing = session.execute(
+            sa_text("""
+                SELECT id, created_at FROM group_invitations
+                WHERE group_id = CAST(:gid AS uuid)
+                  AND invitee_user_id = :uid
+                  AND status = 'pending'
+                LIMIT 1
+            """),
+            {"gid": group_id, "uid": target_id},
+        ).fetchone()
+        if existing:
+            inv_id = existing[0]
+            created_at = existing[1]
+        else:
+            inv_id = uuid.uuid4()
+            session.execute(
+                sa_text("""
+                    INSERT INTO group_invitations
+                        (id, group_id, invitee_user_id, inviter_user_id, status)
+                    VALUES (:id, CAST(:gid AS uuid), :uid, CAST(:inviter AS uuid), 'pending')
+                """),
+                {
+                    "id": inv_id,
+                    "gid": group_id,
+                    "uid": target_id,
+                    "inviter": current_user["id"],
+                },
+            )
+            created_at = None
+
+        group_name = session.execute(
+            sa_text("SELECT name FROM groups WHERE id = CAST(:id AS uuid)"),
+            {"id": group_id},
+        ).scalar() or ""
+
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    return GroupInvitationOut(
+        id=str(inv_id),
+        group_id=group_id,
+        group_name=group_name,
+        invitee_user_id=str(target_id),
+        invitee_username=target_username,
+        inviter_user_id=current_user["id"],
+        inviter_username=current_user.get("username", ""),
+        status="pending",
+        created_at=created_at.isoformat() if created_at else "",
+    )
+
+
+@router.delete("/api/groups/{group_id}/members/{user_id}")
+def remove_member(
+    group_id: str,
+    user_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> dict:
+    """メンバーを退会/除名する。admin は任意メンバーを、非 admin は自分自身のみ可能。"""
+    session = _pg_session()
+    try:
+        # 自分自身か admin である必要がある
+        if user_id != current_user["id"]:
+            _require_admin(session, group_id, current_user["id"])
+
+        # 除名対象
+        result = session.execute(
+            sa_text("""
+                DELETE FROM group_members
+                WHERE group_id = CAST(:gid AS uuid) AND user_id = CAST(:uid AS uuid)
+                RETURNING id
+            """),
+            {"gid": group_id, "uid": user_id},
+        ).fetchone()
+
+        if not result:
+            raise HTTPException(status_code=404, detail="Member not found")
+
+        # 最後の admin を削除すると admin-less になるため確認
+        admin_count = session.execute(
+            sa_text("""
+                SELECT COUNT(*) FROM group_members
+                WHERE group_id = CAST(:gid AS uuid) AND role = 'admin'
+            """),
+            {"gid": group_id},
+        ).scalar() or 0
+        if admin_count == 0:
+            session.rollback()
+            raise HTTPException(
+                status_code=400,
+                detail="最後の管理者は削除できません。先に別のメンバーを admin に昇格させてください。",
+            )
+
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    return {"group_id": group_id, "user_id": user_id, "removed": True}
+
+
+# ---------------------------------------------------------------------------
+# Join by invite code
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/groups/join-by-code", response_model=GroupOut)
+def join_by_code(
+    body: GroupInviteByCodeRequest,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupOut:
+    """招待コードを使ってグループに参加する。"""
+    code = (body.invite_code or "").strip()
+    if not code:
+        raise HTTPException(status_code=400, detail="invite_code is required")
+
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT id, name, description, invite_code, created_by, created_at, updated_at
+                FROM groups WHERE invite_code = :code LIMIT 1
+            """),
+            {"code": code},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Invalid invite code")
+
+        group_id = row[0]
+
+        # 既にメンバーなら成功（冪等）
+        existing = session.execute(
+            sa_text("""
+                SELECT role FROM group_members
+                WHERE group_id = :gid AND user_id = CAST(:uid AS uuid)
+                LIMIT 1
+            """),
+            {"gid": group_id, "uid": current_user["id"]},
+        ).fetchone()
+
+        if not existing:
+            session.execute(
+                sa_text("""
+                    INSERT INTO group_members (group_id, user_id, role)
+                    VALUES (:gid, CAST(:uid AS uuid), 'member')
+                """),
+                {"gid": group_id, "uid": current_user["id"]},
+            )
+            # もし自分宛の pending 招待があれば accepted に更新
+            session.execute(
+                sa_text("""
+                    UPDATE group_invitations
+                    SET status = 'accepted', responded_at = now()
+                    WHERE group_id = :gid
+                      AND invitee_user_id = CAST(:uid AS uuid)
+                      AND status = 'pending'
+                """),
+                {"gid": group_id, "uid": current_user["id"]},
+            )
+        my_role = existing[0] if existing else "member"
+
+        member_count = session.execute(
+            sa_text("SELECT COUNT(*) FROM group_members WHERE group_id = :gid"),
+            {"gid": group_id},
+        ).scalar() or 0
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    logger.info("User=%s joined group=%s by invite code", current_user["id"], group_id)
+    return _group_row_to_out(
+        row,
+        my_role=my_role,
+        member_count=int(member_count),
+        show_invite_code=(my_role == "admin"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invitations (group-scoped & user-scoped)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/groups/{group_id}/invitations", response_model=list[GroupInvitationOut])
+def list_group_invitations(
+    group_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> list[GroupInvitationOut]:
+    """グループ管理者向けの招待一覧（pending のみ）。"""
+    session = _pg_session()
+    try:
+        _require_admin(session, group_id, current_user["id"])
+        rows = session.execute(
+            sa_text("""
+                SELECT gi.id, gi.group_id, g.name, gi.invitee_user_id, u.display_name,
+                       gi.inviter_user_id, iu.display_name,
+                       gi.status, gi.created_at, gi.responded_at
+                FROM group_invitations gi
+                JOIN groups g ON g.id = gi.group_id
+                JOIN users u ON u.id = gi.invitee_user_id
+                JOIN users iu ON iu.id = gi.inviter_user_id
+                WHERE gi.group_id = CAST(:gid AS uuid) AND gi.status = 'pending'
+                ORDER BY gi.created_at DESC
+            """),
+            {"gid": group_id},
+        ).fetchall()
+    finally:
+        session.close()
+
+    return [
+        GroupInvitationOut(
+            id=str(r[0]),
+            group_id=str(r[1]),
+            group_name=r[2] or "",
+            invitee_user_id=str(r[3]),
+            invitee_username=r[4] or "",
+            inviter_user_id=str(r[5]),
+            inviter_username=r[6] or "",
+            status=r[7],
+            created_at=r[8].isoformat() if r[8] else "",
+            responded_at=r[9].isoformat() if r[9] else "",
+        )
+        for r in rows
+    ]
+
+
+@router.get("/api/me/invitations", response_model=list[GroupInvitationOut])
+def list_my_invitations(
+    current_user: dict = Depends(_get_current_user),
+) -> list[GroupInvitationOut]:
+    """自分宛ての pending 招待一覧。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                SELECT gi.id, gi.group_id, g.name, gi.invitee_user_id, u.display_name,
+                       gi.inviter_user_id, iu.display_name,
+                       gi.status, gi.created_at, gi.responded_at
+                FROM group_invitations gi
+                JOIN groups g ON g.id = gi.group_id
+                JOIN users u ON u.id = gi.invitee_user_id
+                JOIN users iu ON iu.id = gi.inviter_user_id
+                WHERE gi.invitee_user_id = CAST(:uid AS uuid) AND gi.status = 'pending'
+                ORDER BY gi.created_at DESC
+            """),
+            {"uid": current_user["id"]},
+        ).fetchall()
+    finally:
+        session.close()
+
+    return [
+        GroupInvitationOut(
+            id=str(r[0]),
+            group_id=str(r[1]),
+            group_name=r[2] or "",
+            invitee_user_id=str(r[3]),
+            invitee_username=r[4] or "",
+            inviter_user_id=str(r[5]),
+            inviter_username=r[6] or "",
+            status=r[7],
+            created_at=r[8].isoformat() if r[8] else "",
+            responded_at=r[9].isoformat() if r[9] else "",
+        )
+        for r in rows
+    ]
+
+
+def _respond_invitation(invitation_id: str, user_id: str, accept: bool) -> GroupInvitationOut:
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT gi.id, gi.group_id, gi.invitee_user_id, gi.status
+                FROM group_invitations gi
+                WHERE gi.id = CAST(:id AS uuid)
+                LIMIT 1
+            """),
+            {"id": invitation_id},
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Invitation not found")
+        if str(row[2]) != str(user_id):
+            raise HTTPException(status_code=403, detail="This invitation is not addressed to you")
+        if row[3] != "pending":
+            raise HTTPException(status_code=409, detail=f"Invitation already {row[3]}")
+
+        group_id = row[1]
+        new_status = "accepted" if accept else "declined"
+        session.execute(
+            sa_text("""
+                UPDATE group_invitations
+                SET status = :status, responded_at = now()
+                WHERE id = CAST(:id AS uuid)
+            """),
+            {"status": new_status, "id": invitation_id},
+        )
+        if accept:
+            # 既に他経路で参加済みかもしれないので冪等に扱う
+            session.execute(
+                sa_text("""
+                    INSERT INTO group_members (group_id, user_id, role)
+                    VALUES (:gid, CAST(:uid AS uuid), 'member')
+                    ON CONFLICT (group_id, user_id) DO NOTHING
+                """),
+                {"gid": group_id, "uid": user_id},
+            )
+
+        detail_row = session.execute(
+            sa_text("""
+                SELECT gi.id, gi.group_id, g.name, gi.invitee_user_id, u.display_name,
+                       gi.inviter_user_id, iu.display_name,
+                       gi.status, gi.created_at, gi.responded_at
+                FROM group_invitations gi
+                JOIN groups g ON g.id = gi.group_id
+                JOIN users u ON u.id = gi.invitee_user_id
+                JOIN users iu ON iu.id = gi.inviter_user_id
+                WHERE gi.id = CAST(:id AS uuid)
+                LIMIT 1
+            """),
+            {"id": invitation_id},
+        ).fetchone()
+        session.commit()
+    except HTTPException:
+        raise
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+    return GroupInvitationOut(
+        id=str(detail_row[0]),
+        group_id=str(detail_row[1]),
+        group_name=detail_row[2] or "",
+        invitee_user_id=str(detail_row[3]),
+        invitee_username=detail_row[4] or "",
+        inviter_user_id=str(detail_row[5]),
+        inviter_username=detail_row[6] or "",
+        status=detail_row[7],
+        created_at=detail_row[8].isoformat() if detail_row[8] else "",
+        responded_at=detail_row[9].isoformat() if detail_row[9] else "",
+    )
+
+
+@router.post("/api/me/invitations/{invitation_id}/accept", response_model=GroupInvitationOut)
+def accept_invitation(
+    invitation_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupInvitationOut:
+    """自分宛ての招待を承諾し、グループに参加する。"""
+    return _respond_invitation(invitation_id, current_user["id"], accept=True)
+
+
+@router.post("/api/me/invitations/{invitation_id}/decline", response_model=GroupInvitationOut)
+def decline_invitation(
+    invitation_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> GroupInvitationOut:
+    """自分宛ての招待を辞退する。"""
+    return _respond_invitation(invitation_id, current_user["id"], accept=False)

--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -25,11 +25,13 @@ from services import (
     check_prerequisites,
     detect_and_record_misconception,
     get_course_data,
+    get_user_group_ids,
     log_unanswered_query,
     persist_chat_history,
     save_course_data,
     delete_course_data,
     search_chunks_with_metadata,
+    user_can_access_group,
 )
 from core.llm import generate_text, get_llm_params
 from core.postgres import get_session as _pg_session
@@ -43,12 +45,27 @@ router = APIRouter(prefix="/api/learning", tags=["Learning"])
 # ---------------------------------------------------------------------------
 
 
+def _validate_visibility(visibility: str, group_id: str | None, user_id: str) -> None:
+    """visibility の値と group_id の整合性を検証する。"""
+    if visibility not in ("public", "group", "private"):
+        raise HTTPException(status_code=400, detail=f"Invalid visibility: {visibility}")
+    if visibility == "group":
+        if not group_id:
+            raise HTTPException(status_code=400, detail="visibility='group' requires group_id")
+        if not user_can_access_group(user_id, group_id):
+            raise HTTPException(
+                status_code=403,
+                detail="指定されたグループに参加していません",
+            )
+
+
 @router.post("/courses", response_model=LearningCourseOut, status_code=201)
 def create_course(
     body: CourseCreateRequest,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseOut:
     """新しいコースを作成する。"""
+    _validate_visibility(body.visibility, body.group_id, current_user["id"])
     course_id = str(uuid.uuid4())[:8]
 
     data = {
@@ -61,35 +78,66 @@ def create_course(
         "referenced_sections": [],
     }
 
-    save_course_data(current_user["id"], course_id, data, is_template=body.is_template)
+    save_course_data(
+        current_user["id"],
+        course_id,
+        data,
+        is_template=body.is_template,
+        visibility=body.visibility,
+        group_id=body.group_id if body.visibility == "group" else None,
+        description=body.description,
+    )
 
     logger.info("Created course '%s' (id=%s) for user=%s", body.title, course_id, current_user["id"])
-    return LearningCourseOut(id=course_id, title=body.title, is_template=body.is_template)
+    return LearningCourseOut(
+        id=course_id,
+        title=body.title,
+        is_template=body.is_template,
+        visibility=body.visibility,
+        group_id=body.group_id if body.visibility == "group" else None,
+        description=body.description,
+    )
 
 
 @router.get("/courses", response_model=list[LearningCourseOut])
 def list_courses(
     current_user: dict = Depends(_get_current_user),
 ) -> list[LearningCourseOut]:
-    """ユーザーが登録しているコース一覧を返す。公開テンプレートも含む。"""
+    """ユーザーが登録しているコース一覧を返す。
+
+    以下を返す:
+    - 自分が所有するコース
+    - visibility='public' かつ公開テンプレートのコース（受講可能）
+    - visibility='group' かつ自分が参加するグループのコース（受講可能）
+    """
+    user_groups = get_user_group_ids(current_user["id"])
+
     session = _pg_session()
     try:
         own_records = session.execute(
             sa_text("""
                 SELECT id, title,
                        COALESCE(is_template, false) AS is_template,
-                       COALESCE(is_published, false) AS is_published
+                       COALESCE(is_published, false) AS is_published,
+                       COALESCE(visibility, 'private') AS visibility,
+                       group_id,
+                       COALESCE(description, '') AS description
                 FROM learning_courses
                 WHERE user_id = CAST(:user_id AS uuid)
             """),
             {"user_id": current_user["id"]},
         ).fetchall()
 
-        template_records = session.execute(
+        # 公開テンプレート
+        public_records = session.execute(
             sa_text("""
-                SELECT lc.id, lc.title
+                SELECT lc.id, lc.title,
+                       COALESCE(lc.visibility, 'private'),
+                       lc.group_id,
+                       COALESCE(lc.description, '')
                 FROM learning_courses lc
                 WHERE lc.is_published = true AND lc.is_template = true
+                  AND COALESCE(lc.visibility, 'public') = 'public'
                   AND lc.user_id != CAST(:user_id AS uuid)
                   AND NOT EXISTS (
                       SELECT 1 FROM learning_courses lc2
@@ -99,6 +147,34 @@ def list_courses(
             """),
             {"user_id": current_user["id"]},
         ).fetchall()
+
+        # グループ共有コース（自分が参加するグループ）
+        if user_groups:
+            # UUID リストを展開
+            gph = ", ".join(f"CAST(:g_{i} AS uuid)" for i in range(len(user_groups)))
+            params: dict = {"user_id": current_user["id"]}
+            for i, gid in enumerate(user_groups):
+                params[f"g_{i}"] = gid
+            group_records = session.execute(
+                sa_text(f"""
+                    SELECT lc.id, lc.title,
+                           COALESCE(lc.visibility, 'private'),
+                           lc.group_id,
+                           COALESCE(lc.description, '')
+                    FROM learning_courses lc
+                    WHERE lc.visibility = 'group'
+                      AND lc.group_id IN ({gph})
+                      AND lc.user_id != CAST(:user_id AS uuid)
+                      AND NOT EXISTS (
+                          SELECT 1 FROM learning_courses lc2
+                          WHERE lc2.user_id = CAST(:user_id AS uuid)
+                            AND lc2.cloned_from = lc.id
+                      )
+                """),
+                params,
+            ).fetchall()
+        else:
+            group_records = []
     finally:
         session.close()
 
@@ -109,6 +185,9 @@ def list_courses(
             is_template=bool(r[2]),
             is_published=bool(r[3]),
             is_enrollable=False,
+            visibility=r[4] or "private",
+            group_id=str(r[5]) if r[5] else None,
+            description=r[6] or "",
         )
         for r in own_records
     ]
@@ -119,8 +198,24 @@ def list_courses(
             is_template=True,
             is_published=True,
             is_enrollable=True,
+            visibility=r[2] or "public",
+            group_id=str(r[3]) if r[3] else None,
+            description=r[4] or "",
         )
-        for r in template_records
+        for r in public_records
+    )
+    courses.extend(
+        LearningCourseOut(
+            id=r[0],
+            title=r[1],
+            is_template=False,
+            is_published=False,
+            is_enrollable=True,
+            visibility=r[2] or "group",
+            group_id=str(r[3]) if r[3] else None,
+            description=r[4] or "",
+        )
+        for r in group_records
     )
     return courses
 
@@ -208,13 +303,15 @@ def enroll_course(
     course_id: str,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseOut:
-    """公開テンプレートコースをクローンして自分のコースとして登録する。"""
+    """受講可能なコース（公開/グループ共有）をクローンして自分のコースとして登録する。"""
     session = _pg_session()
     try:
         record = session.execute(
             sa_text("""
-                SELECT data FROM learning_courses
-                WHERE id = :course_id AND is_published = true AND is_template = true
+                SELECT data, COALESCE(visibility, 'private'), group_id,
+                       COALESCE(is_published, false), COALESCE(is_template, false)
+                FROM learning_courses
+                WHERE id = :course_id
                 LIMIT 1
             """),
             {"course_id": course_id},
@@ -223,9 +320,21 @@ def enroll_course(
         session.close()
 
     if not record or not record[0]:
-        raise HTTPException(status_code=404, detail="Published course not found")
+        raise HTTPException(status_code=404, detail="Course not found")
 
-    template_data = record[0] if isinstance(record[0], dict) else json.loads(record[0])
+    data_raw, visibility, group_id, is_published, is_template = record
+    enrollable = False
+    if visibility == "public" and is_published and is_template:
+        enrollable = True
+    elif visibility == "group" and group_id and user_can_access_group(
+        current_user["id"], str(group_id)
+    ):
+        enrollable = True
+
+    if not enrollable:
+        raise HTTPException(status_code=403, detail="このコースを受講する権限がありません")
+
+    template_data = data_raw if isinstance(data_raw, dict) else json.loads(data_raw)
 
     new_course_id = str(uuid.uuid4())[:8]
     cloned_data = dict(template_data)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -53,6 +53,14 @@ class MaterialOut(BaseModel):
     status: str  # uploaded | processing | completed | failed
     uploaded_at: str
     knowledge_graph: dict | None = None
+    visibility: str = "private"  # public | group | private
+    group_id: str | None = None
+
+
+class VisibilityUpdateRequest(BaseModel):
+    """教材/コースの開示範囲を変更するリクエスト。"""
+    visibility: str  # public | group | private
+    group_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +124,9 @@ class CourseCreateRequest(BaseModel):
     concepts: list[LearningConcept] = []
     sources: list[LearningSource] = []
     is_template: bool = False  # Trueの場合、教員作成テンプレートとして扱う
+    visibility: str = "private"  # public | group | private
+    group_id: str | None = None
+    description: str = ""
 
 
 class CourseUpdateRequest(BaseModel):
@@ -126,6 +137,9 @@ class CourseUpdateRequest(BaseModel):
     topics: list[LearningTopic] | None = None
     concepts: list[LearningConcept] | None = None
     sources: list[LearningSource] | None = None
+    visibility: str | None = None
+    group_id: str | None = None
+    description: str | None = None
 
 
 class LearningCourseOut(BaseModel):
@@ -134,6 +148,9 @@ class LearningCourseOut(BaseModel):
     is_template: bool = False
     is_published: bool = False
     is_enrollable: bool = False  # True: 自分未登録の公開テンプレート
+    visibility: str = "private"
+    group_id: str | None = None
+    description: str = ""
 
 
 class LearningCourseDetail(BaseModel):
@@ -477,3 +494,72 @@ class LectureAudioGenerateStartResponse(BaseModel):
     course_id: str
     total_chunks: int = 0
     status: str = "pending"
+
+
+# ---------------------------------------------------------------------------
+# Groups & Visibility (Issue #121)
+# ---------------------------------------------------------------------------
+
+class GroupCreateRequest(BaseModel):
+    """グループ作成リクエスト。"""
+    name: str
+    description: str = ""
+
+
+class GroupUpdateRequest(BaseModel):
+    """グループ更新リクエスト。"""
+    name: str | None = None
+    description: str | None = None
+
+
+class GroupMemberOut(BaseModel):
+    """グループ所属メンバー情報。"""
+    user_id: str
+    username: str
+    email: str = ""
+    role: str = "member"  # admin | member
+    joined_at: str = ""
+
+
+class GroupOut(BaseModel):
+    """グループ情報。"""
+    id: str
+    name: str
+    description: str = ""
+    invite_code: str | None = None  # admin のみ閲覧可能
+    created_by: str
+    my_role: str = "member"  # 現在ユーザーのロール
+    member_count: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class GroupDetailOut(GroupOut):
+    """グループ詳細（メンバーリスト含む）。"""
+    members: list[GroupMemberOut] = []
+
+
+class GroupInviteByUserRequest(BaseModel):
+    """特定ユーザーに対する直接招待リクエスト。"""
+    # username または email のいずれかで識別
+    username: str | None = None
+    email: str | None = None
+
+
+class GroupInviteByCodeRequest(BaseModel):
+    """招待コードによる参加リクエスト。"""
+    invite_code: str
+
+
+class GroupInvitationOut(BaseModel):
+    """招待情報。"""
+    id: str
+    group_id: str
+    group_name: str = ""
+    invitee_user_id: str
+    invitee_username: str = ""
+    inviter_user_id: str
+    inviter_username: str = ""
+    status: str = "pending"  # pending | accepted | declined | revoked
+    created_at: str = ""
+    responded_at: str = ""

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -132,7 +132,7 @@ def get_background_task(task_id: str) -> dict | None:
 
 
 def get_course_data(user_id: str, course_id: str) -> dict | None:
-    """PostgreSQL から LearningCourse データを取得する。"""
+    """PostgreSQL から LearningCourse データを取得する（オーナー限定）。"""
     session = _pg_session()
     try:
         record = session.execute(
@@ -150,13 +150,69 @@ def get_course_data(user_id: str, course_id: str) -> dict | None:
     return None
 
 
-def save_course_data(user_id: str, course_id: str, data: dict, is_template: bool = False) -> None:
+def get_accessible_course_data(user_id: str, course_id: str) -> dict | None:
+    """visibility を考慮して、アクセス可能な LearningCourse データを返す。
+
+    - オーナー本人: 常に可
+    - visibility='public' かつ is_published かつ is_template: 可
+    - visibility='group' かつ自分がそのグループのメンバー: 可
+    """
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("""
+                SELECT data, user_id, COALESCE(visibility, 'private'),
+                       group_id, COALESCE(is_published, false), COALESCE(is_template, false)
+                FROM learning_courses
+                WHERE id = :course_id
+                LIMIT 1
+            """),
+            {"course_id": course_id},
+        ).fetchone()
+        if not record or not record[0]:
+            return None
+
+        data_raw, owner_id, visibility, group_id, is_published, is_template = record
+        data = data_raw if isinstance(data_raw, dict) else json.loads(data_raw)
+
+        if str(owner_id) == str(user_id):
+            return data
+        if visibility == "public" and is_published and is_template:
+            return data
+        if visibility == "group" and group_id:
+            row = session.execute(
+                sa_text("""
+                    SELECT 1 FROM group_members
+                    WHERE group_id = :gid AND user_id = CAST(:uid AS uuid)
+                    LIMIT 1
+                """),
+                {"gid": group_id, "uid": user_id},
+            ).fetchone()
+            if row:
+                return data
+        return None
+    finally:
+        session.close()
+
+
+def save_course_data(
+    user_id: str,
+    course_id: str,
+    data: dict,
+    is_template: bool = False,
+    *,
+    visibility: str = "private",
+    group_id: str | None = None,
+    description: str = "",
+) -> None:
     """LearningCourse データを PostgreSQL に UPSERT する。"""
     session = _pg_session()
     try:
         session.execute(
             sa_text("""
-                INSERT INTO learning_courses (id, user_id, title, data, is_template, is_published, owner_id)
+                INSERT INTO learning_courses
+                    (id, user_id, title, data, is_template, is_published, owner_id,
+                     visibility, group_id, description)
                 VALUES (
                     :course_id,
                     CAST(:user_id AS uuid),
@@ -164,11 +220,17 @@ def save_course_data(user_id: str, course_id: str, data: dict, is_template: bool
                     CAST(:data AS jsonb),
                     :is_template,
                     false,
-                    CAST(:user_id AS uuid)
+                    CAST(:user_id AS uuid),
+                    :visibility,
+                    CAST(:group_id AS uuid),
+                    :description
                 )
                 ON CONFLICT (id) DO UPDATE
                 SET data = CAST(EXCLUDED.data AS jsonb),
                     title = EXCLUDED.title,
+                    visibility = EXCLUDED.visibility,
+                    group_id = EXCLUDED.group_id,
+                    description = EXCLUDED.description,
                     updated_at = now()
             """),
             {
@@ -177,12 +239,53 @@ def save_course_data(user_id: str, course_id: str, data: dict, is_template: bool
                 "title": data.get("title", course_id),
                 "data": json.dumps(data, ensure_ascii=False),
                 "is_template": is_template,
+                "visibility": visibility,
+                "group_id": group_id,
+                "description": description,
             },
         )
         session.commit()
     except Exception:
         session.rollback()
         raise
+    finally:
+        session.close()
+
+
+def get_user_group_ids(user_id: str) -> list[str]:
+    """ユーザーが参加しているグループIDのリストを返す。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                SELECT group_id FROM group_members
+                WHERE user_id = CAST(:uid AS uuid)
+            """),
+            {"uid": user_id},
+        ).fetchall()
+        return [str(r[0]) for r in rows]
+    finally:
+        session.close()
+
+
+def user_can_access_group(user_id: str, group_id: str | None) -> bool:
+    """ユーザーが指定のグループに属しているかを判定する。
+
+    group_id が None/空の場合は False を返す。
+    """
+    if not group_id:
+        return False
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT 1 FROM group_members
+                WHERE user_id = CAST(:uid AS uuid) AND group_id = CAST(:gid AS uuid)
+                LIMIT 1
+            """),
+            {"uid": user_id, "gid": group_id},
+        ).fetchone()
+        return row is not None
     finally:
         session.close()
 

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -95,6 +95,9 @@ class Document(Base):
     text_length = Column(Integer, nullable=True)
     chunk_count = Column(Integer, nullable=True)
     uploaded_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    # Visibility / access control (Issue #121)
+    visibility = Column(Text, nullable=False, default="private")  # public | group | private
+    group_id = Column(UUID(as_uuid=True), ForeignKey("groups.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
 
@@ -231,6 +234,10 @@ class LearningCourse(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     title = Column(Text, nullable=False)
     data = Column(JSONB, nullable=False, default=dict)
+    # Visibility / access control (Issue #121)
+    visibility = Column(Text, nullable=False, default="private")  # public | group | private
+    group_id = Column(UUID(as_uuid=True), ForeignKey("groups.id", ondelete="SET NULL"), nullable=True)
+    description = Column(Text, nullable=False, default="")
     created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
 
@@ -282,3 +289,45 @@ class LearningChatHistory(Base):
     topic_id = Column(Text, nullable=False)
     history = Column(JSONB, nullable=False, default=list)
     updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
+
+
+# ============================================================
+# グループ / 開示範囲（Issue #121）
+# ============================================================
+
+class Group(Base):
+    __tablename__ = "groups"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=_new_uuid)
+    name = Column(Text, nullable=False)
+    description = Column(Text, nullable=False, default="")
+    invite_code = Column(Text, unique=True, nullable=True)
+    created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow, onupdate=_utcnow)
+
+
+class GroupMember(Base):
+    __tablename__ = "group_members"
+    __table_args__ = (UniqueConstraint("group_id", "user_id"),)
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=_new_uuid)
+    group_id = Column(UUID(as_uuid=True), ForeignKey("groups.id", ondelete="CASCADE"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    role = Column(Text, nullable=False, default="member")  # admin | member
+    joined_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+
+
+class GroupInvitation(Base):
+    __tablename__ = "group_invitations"
+    __table_args__ = (
+        UniqueConstraint("group_id", "invitee_user_id", "status"),
+    )
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=_new_uuid)
+    group_id = Column(UUID(as_uuid=True), ForeignKey("groups.id", ondelete="CASCADE"), nullable=False)
+    invitee_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    inviter_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    status = Column(Text, nullable=False, default="pending")  # pending | accepted | declined | revoked
+    created_at = Column(DateTime(timezone=True), nullable=False, default=_utcnow)
+    responded_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/db/009_groups_visibility.sql
+++ b/backend/db/009_groups_visibility.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- Migration 009: グループ機能 + 資料の開示範囲（Issue #121）
+-- ============================================================
+
+-- ============================================================
+-- グループ本体
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS groups (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name         TEXT NOT NULL,
+    description  TEXT NOT NULL DEFAULT '',
+    invite_code  TEXT UNIQUE,
+    created_by   UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_groups_created_by ON groups(created_by);
+
+-- ============================================================
+-- グループ所属
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS group_members (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id   UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role       TEXT NOT NULL DEFAULT 'member'
+                  CHECK (role IN ('admin', 'member')),
+    joined_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_members_user ON group_members(user_id);
+CREATE INDEX IF NOT EXISTS idx_group_members_group ON group_members(group_id);
+
+-- ============================================================
+-- グループ招待（特定ユーザーへの直接招待）
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS group_invitations (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id         UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    invitee_user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    inviter_user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'accepted', 'declined', 'revoked')),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    responded_at     TIMESTAMPTZ,
+    UNIQUE(group_id, invitee_user_id, status)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_invitee ON group_invitations(invitee_user_id, status);
+CREATE INDEX IF NOT EXISTS idx_invitations_group ON group_invitations(group_id);
+
+-- ============================================================
+-- 資料の開示範囲（Visibility）カラム
+-- ============================================================
+
+ALTER TABLE documents
+    ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'
+        CHECK (visibility IN ('public', 'group', 'private')),
+    ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_documents_visibility ON documents(visibility);
+CREATE INDEX IF NOT EXISTS idx_documents_group ON documents(group_id) WHERE group_id IS NOT NULL;
+
+ALTER TABLE learning_courses
+    ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'private'
+        CHECK (visibility IN ('public', 'group', 'private')),
+    ADD COLUMN IF NOT EXISTS group_id UUID REFERENCES groups(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_courses_visibility ON learning_courses(visibility);
+CREATE INDEX IF NOT EXISTS idx_courses_group ON learning_courses(group_id) WHERE group_id IS NOT NULL;
+
+-- 既存の公開テンプレートを 'public' 扱いに移行（後方互換）
+UPDATE learning_courses
+    SET visibility = 'public'
+    WHERE is_published = true AND is_template = true AND visibility = 'private';

--- a/backend/tests/test_groups_visibility.py
+++ b/backend/tests/test_groups_visibility.py
@@ -77,6 +77,12 @@ class _FakeSession:
 
     def __init__(self, store: _Store):
         self.store = store
+        # rollback 用にスナップショットを取る（shallow なリスト/辞書コピー）
+        self._snapshot = {
+            "groups": {k: dict(v) for k, v in store.groups.items()},
+            "members": [dict(m) for m in store.members],
+            "invitations": [dict(i) for i in store.invitations],
+        }
 
     # -- helpers ----------------------------------------------------------
     def _group_row(self, g):
@@ -94,6 +100,39 @@ class _FakeSession:
     def execute(self, query, params=None):
         sql = str(query).strip()
         p = params or {}
+
+        # --- DELETE / UPDATE ブランチは SELECT より先に評価する
+        # (両者が "FROM groups WHERE id = CAST" という部分文字列を共有するため)
+        if sql.startswith("DELETE FROM group_members"):
+            gid = str(p["gid"]); uid = str(p["uid"])
+            before = len(self.store.members)
+            self.store.members = [
+                m for m in self.store.members
+                if not (m["group_id"] == gid and m["user_id"] == uid)
+            ]
+            if len(self.store.members) < before:
+                return _Result([(str(uuid.uuid4()),)])  # RETURNING id dummy
+            return _Result([])
+
+        if sql.startswith("DELETE FROM groups"):
+            gid = str(p["id"])
+            self.store.groups.pop(gid, None)
+            self.store.members = [m for m in self.store.members if m["group_id"] != gid]
+            self.store.invitations = [i for i in self.store.invitations if i["group_id"] != gid]
+            return _Result()
+
+        if sql.startswith("UPDATE groups"):
+            gid = str(p["id"])
+            g = self.store.groups.get(gid)
+            if g:
+                if "name" in p:
+                    g["name"] = p["name"]
+                if "description" in p:
+                    g["description"] = p["description"]
+                if "code" in p:
+                    g["invite_code"] = p["code"]
+                g["updated_at"] = dt.datetime.utcnow()
+            return _Result()
 
         # --- INSERT into groups ---
         if sql.startswith("INSERT INTO groups"):
@@ -312,48 +351,22 @@ class _FakeSession:
                     ))
             return _Result(out)
 
-        # --- DELETE group_members by group+user ---
-        if sql.startswith("DELETE FROM group_members"):
-            gid = str(p["gid"]); uid = str(p["uid"])
-            before = len(self.store.members)
-            self.store.members = [
-                m for m in self.store.members
-                if not (m["group_id"] == gid and m["user_id"] == uid)
-            ]
-            if len(self.store.members) < before:
-                return _Result([(str(uuid.uuid4()),)])  # RETURNING id dummy
-            return _Result([])
-
-        # --- DELETE group ---
-        if sql.startswith("DELETE FROM groups"):
-            gid = str(p["id"])
-            self.store.groups.pop(gid, None)
-            self.store.members = [m for m in self.store.members if m["group_id"] != gid]
-            self.store.invitations = [i for i in self.store.invitations if i["group_id"] != gid]
-            return _Result()
-
-        # --- UPDATE groups ---
-        if sql.startswith("UPDATE groups"):
-            gid = str(p["id"])
-            g = self.store.groups.get(gid)
-            if g:
-                if "name" in p:
-                    g["name"] = p["name"]
-                if "description" in p:
-                    g["description"] = p["description"]
-                if "code" in p:
-                    g["invite_code"] = p["code"]
-                g["updated_at"] = dt.datetime.utcnow()
-            return _Result()
-
         # Default
         return _Result()
 
     def commit(self):
-        pass
+        # スナップショットを現在の状態で更新
+        self._snapshot = {
+            "groups": {k: dict(v) for k, v in self.store.groups.items()},
+            "members": [dict(m) for m in self.store.members],
+            "invitations": [dict(i) for i in self.store.invitations],
+        }
 
     def rollback(self):
-        pass
+        # 直近 commit 時点の状態に戻す
+        self.store.groups = {k: dict(v) for k, v in self._snapshot["groups"].items()}
+        self.store.members = [dict(m) for m in self._snapshot["members"]]
+        self.store.invitations = [dict(i) for i in self._snapshot["invitations"]]
 
     def close(self):
         pass
@@ -577,6 +590,273 @@ class TestInviteCodeGeneration:
         for c in codes:
             assert len(c) == 12
             assert all(ch.isalnum() or ch in "-_" for ch in c)
+
+
+class TestInviteCodeRotation:
+    """招待コード再発行（無効化）フロー。"""
+
+    def test_rotate_invalidates_old_code_and_new_code_works(self, client_and_state):
+        client, current, store = client_and_state
+
+        # Alice がグループ作成
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "RotGrp"}, headers=_h()).json()
+        old_code = grp["invite_code"]
+        gid = grp["id"]
+        assert old_code
+
+        # 招待コード再発行
+        resp = client.post(f"/api/groups/{gid}/invite-code/rotate", headers=_h())
+        assert resp.status_code == 200, resp.text
+        new_code = resp.json()["invite_code"]
+        assert new_code and new_code != old_code
+
+        # Bob が古いコードで参加しようとすると 404
+        current["user"] = USER_BOB
+        old_resp = client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": old_code},
+            headers=_h(),
+        )
+        assert old_resp.status_code == 404
+
+        # Bob が新しいコードで参加すると成功
+        new_resp = client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": new_code},
+            headers=_h(),
+        )
+        assert new_resp.status_code == 200, new_resp.text
+        assert new_resp.json()["id"] == gid
+
+    def test_non_admin_cannot_rotate_invite_code(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "G"}, headers=_h()).json()
+        code = grp["invite_code"]
+
+        # Bob が参加
+        current["user"] = USER_BOB
+        client.post("/api/groups/join-by-code", json={"invite_code": code}, headers=_h())
+
+        # Bob (member) が rotate を叩く → 403
+        resp = client.post(f"/api/groups/{grp['id']}/invite-code/rotate", headers=_h())
+        assert resp.status_code == 403
+
+
+class TestMemberRemoval:
+    """メンバー削除・退会・最後の admin 保護。"""
+
+    def test_admin_can_remove_member(self, client_and_state):
+        client, current, store = client_and_state
+
+        # Alice（admin）がグループ作成、Bob が参加
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "RmGrp"}, headers=_h()).json()
+        current["user"] = USER_BOB
+        client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": grp["invite_code"]},
+            headers=_h(),
+        )
+        assert any(m["user_id"] == USER_BOB["id"] for m in store.members)
+
+        # Alice が Bob を除名
+        current["user"] = USER_ALICE
+        resp = client.delete(
+            f"/api/groups/{grp['id']}/members/{USER_BOB['id']}",
+            headers=_h(),
+        )
+        assert resp.status_code == 200
+        assert not any(
+            m["user_id"] == USER_BOB["id"] and m["group_id"] == grp["id"]
+            for m in store.members
+        )
+
+    def test_member_can_leave_themselves(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "LeaveGrp"}, headers=_h()).json()
+
+        current["user"] = USER_BOB
+        client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": grp["invite_code"]},
+            headers=_h(),
+        )
+        # Bob が自分自身を退会
+        resp = client.delete(
+            f"/api/groups/{grp['id']}/members/{USER_BOB['id']}",
+            headers=_h(),
+        )
+        assert resp.status_code == 200
+        assert not any(m["user_id"] == USER_BOB["id"] for m in store.members)
+
+    def test_non_admin_cannot_remove_others(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "G"}, headers=_h()).json()
+        current["user"] = USER_BOB
+        client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": grp["invite_code"]},
+            headers=_h(),
+        )
+
+        # Bob（member）が Alice（admin）を除名しようとする → 403
+        resp = client.delete(
+            f"/api/groups/{grp['id']}/members/{USER_ALICE['id']}",
+            headers=_h(),
+        )
+        assert resp.status_code == 403
+        # Alice はまだメンバーのまま
+        assert any(m["user_id"] == USER_ALICE["id"] for m in store.members)
+
+    def test_removing_last_admin_is_rejected(self, client_and_state):
+        client, current, store = client_and_state
+
+        # Alice だけのグループを作り、Alice が自分自身を退会しようとする
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "LastAdmin"}, headers=_h()).json()
+
+        resp = client.delete(
+            f"/api/groups/{grp['id']}/members/{USER_ALICE['id']}",
+            headers=_h(),
+        )
+        assert resp.status_code == 400
+        # Alice は残っている（ロールバックされた）
+        assert any(
+            m["user_id"] == USER_ALICE["id"] and m["group_id"] == grp["id"]
+            for m in store.members
+        )
+
+    def test_remove_nonexistent_member_returns_404(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "G"}, headers=_h()).json()
+
+        # Bob は未参加
+        resp = client.delete(
+            f"/api/groups/{grp['id']}/members/{USER_BOB['id']}",
+            headers=_h(),
+        )
+        assert resp.status_code == 404
+
+
+class TestGroupDeletion:
+    """グループ削除と関連レコードの削除。"""
+
+    def test_admin_can_delete_group(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "ToDelete"}, headers=_h()).json()
+        gid = grp["id"]
+        assert gid in store.groups
+
+        resp = client.delete(f"/api/groups/{gid}", headers=_h())
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] is True
+        assert gid not in store.groups
+        # メンバーレコードも全て消える
+        assert not any(m["group_id"] == gid for m in store.members)
+
+    def test_non_admin_cannot_delete_group(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "NoDel"}, headers=_h()).json()
+        current["user"] = USER_BOB
+        client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": grp["invite_code"]},
+            headers=_h(),
+        )
+
+        # Bob (member) が削除を試みる → 403
+        resp = client.delete(f"/api/groups/{grp['id']}", headers=_h())
+        assert resp.status_code == 403
+        assert grp["id"] in store.groups
+
+    def test_delete_cascades_invitations(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "CascadeGrp"}, headers=_h()).json()
+        # Bob を招待
+        client.post(
+            f"/api/groups/{grp['id']}/members",
+            json={"username": "bob"},
+            headers=_h(),
+        )
+        assert len(store.invitations) == 1
+
+        # グループ削除
+        resp = client.delete(f"/api/groups/{grp['id']}", headers=_h())
+        assert resp.status_code == 200
+        # 招待も削除される
+        assert not any(inv["group_id"] == grp["id"] for inv in store.invitations)
+
+
+class TestEndToEndGroupLifecycle:
+    """作成 → 招待 → 参加 → ローテーション → 退会 → 削除 の一連フロー。"""
+
+    def test_full_group_lifecycle(self, client_and_state):
+        client, current, store = client_and_state
+
+        # 1. Alice がグループ作成
+        current["user"] = USER_ALICE
+        created = client.post(
+            "/api/groups",
+            json={"name": "FullFlow", "description": "E2E flow"},
+            headers=_h(),
+        )
+        assert created.status_code == 201
+        grp = created.json()
+        gid = grp["id"]
+        first_code = grp["invite_code"]
+
+        # 2. Bob を直接招待
+        inv_resp = client.post(
+            f"/api/groups/{gid}/members",
+            json={"username": "bob"},
+            headers=_h(),
+        )
+        assert inv_resp.status_code == 201
+        inv_id = inv_resp.json()["id"]
+
+        # 3. Bob が招待を承諾
+        current["user"] = USER_BOB
+        acc = client.post(f"/api/me/invitations/{inv_id}/accept", headers=_h())
+        assert acc.status_code == 200
+        assert acc.json()["status"] == "accepted"
+        assert any(m["user_id"] == USER_BOB["id"] and m["group_id"] == gid for m in store.members)
+
+        # 4. Alice が招待コードを再発行 → 旧コード無効化
+        current["user"] = USER_ALICE
+        rot = client.post(f"/api/groups/{gid}/invite-code/rotate", headers=_h())
+        assert rot.status_code == 200
+        new_code = rot.json()["invite_code"]
+        assert new_code != first_code
+
+        # 5. Bob が退会
+        current["user"] = USER_BOB
+        leave = client.delete(
+            f"/api/groups/{gid}/members/{USER_BOB['id']}",
+            headers=_h(),
+        )
+        assert leave.status_code == 200
+        assert not any(m["user_id"] == USER_BOB["id"] and m["group_id"] == gid for m in store.members)
+
+        # 6. Alice がグループを削除
+        current["user"] = USER_ALICE
+        dele = client.delete(f"/api/groups/{gid}", headers=_h())
+        assert dele.status_code == 200
+        assert gid not in store.groups
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_groups_visibility.py
+++ b/backend/tests/test_groups_visibility.py
@@ -1,0 +1,653 @@
+"""Issue #121: グループ管理と開示範囲制御のテスト。
+
+対象:
+  - `backend/api/routes/groups.py` (グループ CRUD / 招待 / 参加)
+  - `backend/api/routes/learning.py` の `_validate_visibility`
+  - `backend/api/schemas.py` の Group/Invitation/Visibility モデル
+
+戦略:
+  FastAPI のルータはすべて `_pg_session()` を経由して raw SQL を実行するため、
+  ここでは SQL 文字列から意図を判別して in-memory なデータを返す `_FakeSession` を使う。
+  services.get_user_group_ids / user_can_access_group など DB ヘルパはモンキーパッチで差し替える。
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime as dt
+import os
+import sys
+import uuid
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "api"))
+
+
+# ---------------------------------------------------------------------------
+# In-memory ストア
+# ---------------------------------------------------------------------------
+
+USER_ALICE = {
+    "id": "00000000-0000-0000-0000-00000000aaaa",
+    "username": "alice",
+    "email": "alice@test.local",
+    "role": "TEACHER",
+}
+
+USER_BOB = {
+    "id": "00000000-0000-0000-0000-00000000bbbb",
+    "username": "bob",
+    "email": "bob@test.local",
+    "role": "STUDENT",
+}
+
+
+class _Result:
+    def __init__(self, rows=None, scalar=None):
+        self._rows = rows or []
+        self._scalar = scalar
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+    def scalar(self):
+        if self._scalar is not None:
+            return self._scalar
+        if self._rows:
+            return self._rows[0][0]
+        return None
+
+
+class _Store:
+    """グループ・メンバー・招待・ユーザーを保持する in-memory 疑似 DB。"""
+
+    def __init__(self):
+        self.users = {USER_ALICE["id"]: USER_ALICE, USER_BOB["id"]: USER_BOB}
+        self.groups = {}  # id -> {id,name,description,invite_code,created_by,created_at,updated_at}
+        self.members = []  # list of {group_id, user_id, role, joined_at}
+        self.invitations = []  # list of invitations
+
+
+class _FakeSession:
+    """SQL 文字列の特徴から意図を判別し、`_Store` に対する CRUD を行う最小実装。"""
+
+    def __init__(self, store: _Store):
+        self.store = store
+
+    # -- helpers ----------------------------------------------------------
+    def _group_row(self, g):
+        return (
+            g["id"],
+            g["name"],
+            g["description"],
+            g.get("invite_code"),
+            g["created_by"],
+            g["created_at"],
+            g["updated_at"],
+        )
+
+    # -- Session API -----------------------------------------------------
+    def execute(self, query, params=None):
+        sql = str(query).strip()
+        p = params or {}
+
+        # --- INSERT into groups ---
+        if sql.startswith("INSERT INTO groups"):
+            gid = str(p["id"])
+            now = dt.datetime.utcnow()
+            self.store.groups[gid] = {
+                "id": gid,
+                "name": p["name"],
+                "description": p.get("description", ""),
+                "invite_code": p.get("invite_code"),
+                "created_by": p["created_by"],
+                "created_at": now,
+                "updated_at": now,
+            }
+            return _Result()
+
+        # --- INSERT into group_members ---
+        if sql.startswith("INSERT INTO group_members"):
+            self.store.members.append({
+                "group_id": str(p["gid"]),
+                "user_id": str(p["uid"]),
+                "role": p.get("role", "member") if "role" in p else ("admin" if "admin" in sql else "member"),
+                "joined_at": dt.datetime.utcnow(),
+            })
+            return _Result()
+
+        # --- INSERT into group_invitations ---
+        if sql.startswith("INSERT INTO group_invitations"):
+            self.store.invitations.append({
+                "id": str(p["id"]),
+                "group_id": str(p["gid"]),
+                "invitee_user_id": str(p["uid"]),
+                "inviter_user_id": str(p["inviter"]),
+                "status": "pending",
+                "created_at": dt.datetime.utcnow(),
+                "responded_at": None,
+            })
+            return _Result()
+
+        # --- SELECT role FROM group_members (membership check) ---
+        if "SELECT role FROM group_members" in sql and "WHERE group_id" in sql:
+            gid = str(p["gid"]); uid = str(p["uid"])
+            for m in self.store.members:
+                if m["group_id"] == gid and m["user_id"] == uid:
+                    return _Result([(m["role"],)])
+            return _Result([])
+
+        # --- SELECT 1 FROM group_members (already-member check) ---
+        if "SELECT 1 FROM group_members" in sql:
+            gid = str(p["gid"]); uid = str(p["uid"])
+            for m in self.store.members:
+                if m["group_id"] == gid and m["user_id"] == uid:
+                    return _Result([(1,)])
+            return _Result([])
+
+        # --- SELECT group detail by id ---
+        if "FROM groups WHERE id = CAST" in sql or "FROM groups WHERE id = :id" in sql:
+            gid = str(p["id"])
+            g = self.store.groups.get(gid)
+            if not g:
+                return _Result([])
+            if "SELECT name FROM groups" in sql:
+                return _Result([(g["name"],)])
+            return _Result([self._group_row(g)])
+
+        # --- SELECT group by invite_code ---
+        if "FROM groups WHERE invite_code" in sql:
+            code = p["code"]
+            for g in self.store.groups.values():
+                if g.get("invite_code") == code:
+                    return _Result([self._group_row(g)])
+            return _Result([])
+
+        # --- SELECT user by display_name ---
+        if "FROM users WHERE display_name" in sql:
+            name = p.get("name")
+            for u in self.store.users.values():
+                if u["username"] == name:
+                    return _Result([(u["id"], u["username"], u["email"])])
+            return _Result([])
+
+        # --- SELECT user by email ---
+        if "FROM users WHERE email" in sql:
+            email = p.get("email")
+            for u in self.store.users.values():
+                if u["email"] == email:
+                    return _Result([(u["id"], u["username"], u["email"])])
+            return _Result([])
+
+        # --- SELECT existing pending invitation ---
+        if "FROM group_invitations" in sql and "status = 'pending'" in sql and "LIMIT 1" in sql and "gi.invitee_user_id" not in sql:
+            gid = str(p["gid"]); uid = str(p["uid"])
+            for inv in self.store.invitations:
+                if (
+                    inv["group_id"] == gid
+                    and inv["invitee_user_id"] == uid
+                    and inv["status"] == "pending"
+                ):
+                    return _Result([(inv["id"], inv["created_at"])])
+            return _Result([])
+
+        # --- SELECT my invitations (user-scoped pending) ---
+        if "WHERE gi.invitee_user_id = CAST(:uid AS uuid)" in sql and "status = 'pending'" in sql:
+            uid = str(p["uid"])
+            out = []
+            for inv in self.store.invitations:
+                if inv["invitee_user_id"] == uid and inv["status"] == "pending":
+                    g = self.store.groups.get(inv["group_id"], {})
+                    invitee = self.store.users.get(inv["invitee_user_id"], {})
+                    inviter = self.store.users.get(inv["inviter_user_id"], {})
+                    out.append((
+                        inv["id"], inv["group_id"], g.get("name", ""),
+                        inv["invitee_user_id"], invitee.get("username", ""),
+                        inv["inviter_user_id"], inviter.get("username", ""),
+                        inv["status"], inv["created_at"], inv["responded_at"],
+                    ))
+            return _Result(out)
+
+        # --- SELECT single invitation by id (for _respond_invitation) ---
+        if "FROM group_invitations gi" in sql and "WHERE gi.id = CAST(:id AS uuid)" in sql and "status" in sql and "g.name" not in sql:
+            iid = str(p["id"])
+            for inv in self.store.invitations:
+                if inv["id"] == iid:
+                    return _Result([(inv["id"], inv["group_id"], inv["invitee_user_id"], inv["status"])])
+            return _Result([])
+
+        # --- SELECT invitation detail (joined) by id ---
+        if "FROM group_invitations gi" in sql and "WHERE gi.id = CAST(:id AS uuid)" in sql and "g.name" in sql:
+            iid = str(p["id"])
+            for inv in self.store.invitations:
+                if inv["id"] == iid:
+                    g = self.store.groups.get(inv["group_id"], {})
+                    invitee = self.store.users.get(inv["invitee_user_id"], {})
+                    inviter = self.store.users.get(inv["inviter_user_id"], {})
+                    return _Result([(
+                        inv["id"], inv["group_id"], g.get("name", ""),
+                        inv["invitee_user_id"], invitee.get("username", ""),
+                        inv["inviter_user_id"], inviter.get("username", ""),
+                        inv["status"], inv["created_at"], inv["responded_at"],
+                    )])
+            return _Result([])
+
+        # --- UPDATE invitation status ---
+        if sql.startswith("UPDATE group_invitations") and "SET status" in sql and "WHERE id = CAST" in sql:
+            iid = str(p["id"])
+            for inv in self.store.invitations:
+                if inv["id"] == iid:
+                    inv["status"] = p["status"]
+                    inv["responded_at"] = dt.datetime.utcnow()
+            return _Result()
+
+        # --- UPDATE invitation on join-by-code (pending → accepted for user) ---
+        if sql.startswith("UPDATE group_invitations") and "invitee_user_id" in sql:
+            gid = str(p["gid"]); uid = str(p["uid"])
+            for inv in self.store.invitations:
+                if (
+                    inv["group_id"] == gid
+                    and inv["invitee_user_id"] == uid
+                    and inv["status"] == "pending"
+                ):
+                    inv["status"] = "accepted"
+                    inv["responded_at"] = dt.datetime.utcnow()
+            return _Result()
+
+        # --- INSERT with ON CONFLICT (idempotent member add) ---
+        if "INSERT INTO group_members" in sql and "ON CONFLICT" in sql:
+            gid = str(p["gid"]); uid = str(p["uid"])
+            exists = any(m["group_id"] == gid and m["user_id"] == uid for m in self.store.members)
+            if not exists:
+                self.store.members.append({
+                    "group_id": gid, "user_id": uid, "role": "member",
+                    "joined_at": dt.datetime.utcnow(),
+                })
+            return _Result()
+
+        # --- list_my_groups: SELECT g.id ... JOIN group_members gm ... WHERE gm.user_id ---
+        # (must come before the generic COUNT(*) branch because this query contains a
+        # correlated subquery `(SELECT COUNT(*) FROM group_members gm2 ...)`.)
+        if "FROM groups g" in sql and "JOIN group_members gm" in sql and "gm.user_id = CAST" in sql:
+            uid = str(p["uid"])
+            out = []
+            for m in self.store.members:
+                if m["user_id"] != uid:
+                    continue
+                g = self.store.groups.get(m["group_id"])
+                if not g:
+                    continue
+                member_count = sum(1 for m2 in self.store.members if m2["group_id"] == g["id"])
+                out.append((
+                    g["id"], g["name"], g["description"], g.get("invite_code"),
+                    g["created_by"], g["created_at"], g["updated_at"],
+                    m["role"], member_count,
+                ))
+            return _Result(out)
+
+        # --- SELECT COUNT(*) member_count ---
+        if "SELECT COUNT(*) FROM group_members" in sql and "role = 'admin'" in sql:
+            gid = str(p["gid"])
+            n = sum(1 for m in self.store.members if m["group_id"] == gid and m["role"] == "admin")
+            return _Result(scalar=n)
+        if "SELECT COUNT(*) FROM group_members" in sql:
+            gid = str(p.get("gid") or p.get("id"))
+            n = sum(1 for m in self.store.members if m["group_id"] == gid)
+            return _Result(scalar=n)
+
+        # --- SELECT members for group detail ---
+        if "FROM group_members gm" in sql and "JOIN users u" in sql:
+            gid = str(p["gid"])
+            out = []
+            for m in self.store.members:
+                if m["group_id"] == gid:
+                    u = self.store.users.get(m["user_id"], {})
+                    out.append((
+                        u.get("id"), u.get("username"), u.get("email"),
+                        m["role"], m["joined_at"],
+                    ))
+            return _Result(out)
+
+        # --- DELETE group_members by group+user ---
+        if sql.startswith("DELETE FROM group_members"):
+            gid = str(p["gid"]); uid = str(p["uid"])
+            before = len(self.store.members)
+            self.store.members = [
+                m for m in self.store.members
+                if not (m["group_id"] == gid and m["user_id"] == uid)
+            ]
+            if len(self.store.members) < before:
+                return _Result([(str(uuid.uuid4()),)])  # RETURNING id dummy
+            return _Result([])
+
+        # --- DELETE group ---
+        if sql.startswith("DELETE FROM groups"):
+            gid = str(p["id"])
+            self.store.groups.pop(gid, None)
+            self.store.members = [m for m in self.store.members if m["group_id"] != gid]
+            self.store.invitations = [i for i in self.store.invitations if i["group_id"] != gid]
+            return _Result()
+
+        # --- UPDATE groups ---
+        if sql.startswith("UPDATE groups"):
+            gid = str(p["id"])
+            g = self.store.groups.get(gid)
+            if g:
+                if "name" in p:
+                    g["name"] = p["name"]
+                if "description" in p:
+                    g["description"] = p["description"]
+                if "code" in p:
+                    g["invite_code"] = p["code"]
+                g["updated_at"] = dt.datetime.utcnow()
+            return _Result()
+
+        # Default
+        return _Result()
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client_and_state(monkeypatch):
+    """TestClient + in-memory store + current-user holder を返す。"""
+    from fastapi.testclient import TestClient
+    from main import app
+    from dependencies import _get_current_user
+
+    store = _Store()
+    current = {"user": USER_ALICE}
+
+    def _override_current_user():
+        return current["user"]
+
+    app.dependency_overrides[_get_current_user] = _override_current_user
+
+    # routes.groups._pg_session と services の DB-touch 関数を差し替え
+    monkeypatch.setattr("routes.groups._pg_session", lambda: _FakeSession(store))
+    # services.user_can_access_group は visibility=group バリデーションで呼ばれる
+    def _user_can_access_group(user_id, group_id):
+        return any(m["user_id"] == str(user_id) and m["group_id"] == str(group_id) for m in store.members)
+    def _get_user_group_ids(user_id):
+        return [m["group_id"] for m in store.members if m["user_id"] == str(user_id)]
+    monkeypatch.setattr("services.user_can_access_group", _user_can_access_group)
+    monkeypatch.setattr("services.get_user_group_ids", _get_user_group_ids)
+    monkeypatch.setattr("routes.learning.user_can_access_group", _user_can_access_group)
+    monkeypatch.setattr("routes.learning.get_user_group_ids", _get_user_group_ids)
+
+    client = TestClient(app)
+    try:
+        yield client, current, store
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# ヘルパ関数
+# ---------------------------------------------------------------------------
+
+
+def _h():
+    return {"Authorization": "Bearer dummy"}
+
+
+# ---------------------------------------------------------------------------
+# Group CRUD + invite-code join
+# ---------------------------------------------------------------------------
+
+
+class TestGroupLifecycle:
+    def test_create_group_sets_creator_as_admin_with_invite_code(self, client_and_state):
+        client, current, store = client_and_state
+        current["user"] = USER_ALICE
+
+        resp = client.post(
+            "/api/groups",
+            json={"name": "研究室A", "description": "学習G"},
+            headers=_h(),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+
+        assert body["name"] == "研究室A"
+        assert body["description"] == "学習G"
+        assert body["my_role"] == "admin"
+        assert body["member_count"] == 1
+        assert body["invite_code"] and len(body["invite_code"]) >= 8
+
+        # メンバーに Alice が admin として追加されている
+        assert len(store.members) == 1
+        assert store.members[0]["role"] == "admin"
+        assert store.members[0]["user_id"] == USER_ALICE["id"]
+
+    def test_list_my_groups_shows_only_joined_groups(self, client_and_state):
+        client, current, store = client_and_state
+
+        # Alice が 1 つグループを作る
+        current["user"] = USER_ALICE
+        client.post("/api/groups", json={"name": "AliceGrp"}, headers=_h())
+
+        # Alice には見える
+        resp_a = client.get("/api/groups", headers=_h())
+        assert resp_a.status_code == 200
+        assert len(resp_a.json()) == 1
+        assert resp_a.json()[0]["name"] == "AliceGrp"
+
+        # Bob には見えない
+        current["user"] = USER_BOB
+        resp_b = client.get("/api/groups", headers=_h())
+        assert resp_b.status_code == 200
+        assert resp_b.json() == []
+
+    def test_join_by_invalid_code_returns_404(self, client_and_state):
+        client, current, _ = client_and_state
+        current["user"] = USER_BOB
+
+        resp = client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": "no-such-code"},
+            headers=_h(),
+        )
+        assert resp.status_code == 404
+
+    def test_join_by_valid_code_adds_member(self, client_and_state):
+        client, current, store = client_and_state
+
+        current["user"] = USER_ALICE
+        created = client.post("/api/groups", json={"name": "OpenGrp"}, headers=_h()).json()
+        code = created["invite_code"]
+
+        current["user"] = USER_BOB
+        resp = client.post(
+            "/api/groups/join-by-code",
+            json={"invite_code": code},
+            headers=_h(),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["name"] == "OpenGrp"
+        assert body["my_role"] == "member"
+        # Bob はメンバー（admin ではない）なので invite_code は隠される
+        assert body["invite_code"] is None
+
+        # Bob がメンバーに追加された
+        assert any(m["user_id"] == USER_BOB["id"] for m in store.members)
+
+
+class TestInvitationFlow:
+    def test_admin_invites_user_and_invitee_accepts(self, client_and_state):
+        client, current, store = client_and_state
+
+        # Alice がグループ作成
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "InviteGrp"}, headers=_h()).json()
+        gid = grp["id"]
+
+        # Alice が Bob を招待
+        resp = client.post(
+            f"/api/groups/{gid}/members",
+            json={"username": "bob"},
+            headers=_h(),
+        )
+        assert resp.status_code == 201, resp.text
+        inv = resp.json()
+        assert inv["status"] == "pending"
+        assert inv["invitee_username"] == "bob"
+
+        # Bob の招待一覧に出る
+        current["user"] = USER_BOB
+        mine = client.get("/api/me/invitations", headers=_h())
+        assert mine.status_code == 200
+        assert len(mine.json()) == 1
+        assert mine.json()[0]["group_name"] == "InviteGrp"
+
+        # Bob が承諾
+        acc = client.post(f"/api/me/invitations/{inv['id']}/accept", headers=_h())
+        assert acc.status_code == 200
+        assert acc.json()["status"] == "accepted"
+
+        # Bob がメンバーに加わっている
+        assert any(m["user_id"] == USER_BOB["id"] and m["group_id"] == gid for m in store.members)
+
+    def test_decline_does_not_add_member(self, client_and_state):
+        client, current, store = client_and_state
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "DeclineGrp"}, headers=_h()).json()
+        inv = client.post(
+            f"/api/groups/{grp['id']}/members",
+            json={"email": "bob@test.local"},
+            headers=_h(),
+        ).json()
+
+        current["user"] = USER_BOB
+        dec = client.post(f"/api/me/invitations/{inv['id']}/decline", headers=_h())
+        assert dec.status_code == 200
+        assert dec.json()["status"] == "declined"
+        assert not any(m["user_id"] == USER_BOB["id"] and m["group_id"] == grp["id"] for m in store.members)
+
+    def test_cannot_respond_to_other_users_invitation(self, client_and_state):
+        client, current, store = client_and_state
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "X"}, headers=_h()).json()
+        inv = client.post(
+            f"/api/groups/{grp['id']}/members",
+            json={"username": "bob"},
+            headers=_h(),
+        ).json()
+
+        # Alice が Bob 宛の招待を承諾しようとする → 403
+        current["user"] = USER_ALICE
+        resp = client.post(f"/api/me/invitations/{inv['id']}/accept", headers=_h())
+        assert resp.status_code == 403
+
+    def test_invite_unknown_user_returns_404(self, client_and_state):
+        client, current, _ = client_and_state
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "Y"}, headers=_h()).json()
+        resp = client.post(
+            f"/api/groups/{grp['id']}/members",
+            json={"username": "nobody"},
+            headers=_h(),
+        )
+        assert resp.status_code == 404
+
+
+class TestInviteCodeGeneration:
+    def test_generated_codes_are_url_safe_and_12_chars(self):
+        from routes.groups import _generate_invite_code
+        codes = {_generate_invite_code() for _ in range(50)}
+        # 衝突しない(ほぼ)
+        assert len(codes) == 50
+        for c in codes:
+            assert len(c) == 12
+            assert all(ch.isalnum() or ch in "-_" for ch in c)
+
+
+# ---------------------------------------------------------------------------
+# Visibility validation
+# ---------------------------------------------------------------------------
+
+
+class TestVisibilityValidation:
+    def test_invalid_visibility_string_400(self, client_and_state, monkeypatch):
+        from routes.learning import _validate_visibility
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            _validate_visibility("garbage", None, USER_ALICE["id"])
+        assert exc.value.status_code == 400
+
+    def test_group_visibility_requires_group_id(self, client_and_state):
+        from routes.learning import _validate_visibility
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            _validate_visibility("group", None, USER_ALICE["id"])
+        assert exc.value.status_code == 400
+
+    def test_group_visibility_requires_membership(self, client_and_state):
+        from routes.learning import _validate_visibility
+        from fastapi import HTTPException
+
+        # Alice は未参加のグループを指定 → 403
+        foreign_gid = "99999999-9999-9999-9999-999999999999"
+        with pytest.raises(HTTPException) as exc:
+            _validate_visibility("group", foreign_gid, USER_ALICE["id"])
+        assert exc.value.status_code == 403
+
+    def test_group_visibility_ok_when_member(self, client_and_state):
+        client, current, store = client_and_state
+        current["user"] = USER_ALICE
+        grp = client.post("/api/groups", json={"name": "MemGrp"}, headers=_h()).json()
+
+        from routes.learning import _validate_visibility
+        # Alice は作成者なので member（admin）。例外は飛ばないはず
+        _validate_visibility("group", grp["id"], USER_ALICE["id"])
+
+    def test_public_and_private_never_need_group_id(self, client_and_state):
+        from routes.learning import _validate_visibility
+        _validate_visibility("public", None, USER_ALICE["id"])
+        _validate_visibility("private", None, USER_ALICE["id"])
+
+
+# ---------------------------------------------------------------------------
+# Schema round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSchemas:
+    def test_group_out_serializes_minimum_fields(self):
+        from schemas import GroupOut
+        g = GroupOut(id="g1", name="G", created_by="u1")
+        d = g.model_dump()
+        assert d["id"] == "g1"
+        assert d["invite_code"] is None
+        assert d["my_role"] == "member"
+        assert d["member_count"] == 0
+
+    def test_group_invitation_out_defaults_pending(self):
+        from schemas import GroupInvitationOut
+        inv = GroupInvitationOut(id="i1", group_id="g1", invitee_user_id="u2", inviter_user_id="u1")
+        assert inv.status == "pending"
+
+    def test_visibility_update_request(self):
+        from schemas import VisibilityUpdateRequest
+        body = VisibilityUpdateRequest(visibility="group", group_id="gid-1")
+        assert body.visibility == "group"
+        assert body.group_id == "gid-1"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -40,4 +40,34 @@ server {
         proxy_read_timeout 120s;
         client_max_body_size 50m;
     }
+
+    # Groups API → api-server (グループ管理・招待)
+    location /api/groups/ {
+        proxy_pass http://api-server:8001/api/groups/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    # Groups collection (末尾スラッシュなし: POST /api/groups, GET /api/groups)
+    location = /api/groups {
+        proxy_pass http://api-server:8001/api/groups;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    # Me API → api-server (自分への招待管理)
+    location /api/me/ {
+        proxy_pass http://api-server:8001/api/me/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
 }

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -30,6 +30,7 @@
       <button class="admin-tab" data-tab="lecture-studio">原稿スタジオ</button>
       <button class="admin-tab" data-tab="stumbles">つまづきデータ</button>
       <button class="admin-tab" data-tab="schema-proposals">スキーマ提案</button>
+      <button class="admin-tab" data-tab="groups">グループ管理</button>
     </div>
 
     <!-- Materials tab -->
@@ -201,6 +202,52 @@
             <button id="sp-canary-confirm" class="admin-action-btn" style="margin-top:8px;font-size:12px">選択したコースに適用</button>
           </div>
           <div id="sp-approve-msg" class="upload-status" style="display:none;margin-top:8px"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Groups tab (Issue #121) -->
+    <div class="admin-panel" id="tab-groups">
+      <div class="admin-section">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+          <h3 class="admin-section-title" style="margin-bottom:0">グループ管理</h3>
+          <button id="groups-refresh" class="admin-action-btn">更新</button>
+        </div>
+        <p style="font-size:12px;color:var(--color-text-tertiary);margin-bottom:16px">
+          教材・コースをグループ内限定で共有したり、ゼミ生にアカウント招待を送ることができます。
+        </p>
+
+        <!-- Pending invitations for me -->
+        <div id="groups-my-invitations" style="margin-bottom:16px"></div>
+
+        <!-- Join by code form -->
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
+          <input type="text" id="groups-join-code" placeholder="招待コードを入力..." style="flex:1;max-width:240px;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+          <button id="groups-join-btn" class="admin-action-btn">招待コードで参加</button>
+        </div>
+
+        <!-- Create group form -->
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
+          <input type="text" id="groups-new-name" placeholder="新規グループ名..." style="flex:1;max-width:240px;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+          <input type="text" id="groups-new-desc" placeholder="説明 (任意)" style="flex:1;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+          <button id="groups-create-btn" class="admin-action-btn" style="background:var(--color-text-success);color:#fff">グループを作成</button>
+        </div>
+
+        <div id="groups-status" class="upload-status" style="display:none"></div>
+
+        <!-- Group list + details -->
+        <div style="display:flex;gap:16px">
+          <div style="flex:0 0 260px">
+            <h4 style="font-size:13px;margin:0 0 8px 0;color:var(--color-text-secondary)">所属グループ</h4>
+            <div id="groups-list" style="border:1px solid var(--color-border);border-radius:4px;overflow:hidden">
+              <div style="padding:12px;color:var(--color-text-tertiary);font-size:13px">読み込み中...</div>
+            </div>
+          </div>
+          <div style="flex:1">
+            <div id="groups-detail">
+              <p style="color:var(--color-text-tertiary);font-size:13px">グループを選択してください</p>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -221,17 +221,17 @@
         <div id="groups-my-invitations" style="margin-bottom:16px"></div>
 
         <!-- Join by code form -->
-        <div style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
+        <form id="groups-join-form" style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
           <input type="text" id="groups-join-code" placeholder="招待コードを入力..." style="flex:1;max-width:240px;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
-          <button id="groups-join-btn" class="admin-action-btn">招待コードで参加</button>
-        </div>
+          <button type="submit" id="groups-join-btn" class="admin-action-btn">招待コードで参加</button>
+        </form>
 
         <!-- Create group form -->
-        <div style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
+        <form id="groups-create-form" style="display:flex;gap:8px;align-items:center;margin-bottom:16px">
           <input type="text" id="groups-new-name" placeholder="新規グループ名..." style="flex:1;max-width:240px;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
           <input type="text" id="groups-new-desc" placeholder="説明 (任意)" style="flex:1;padding:6px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
-          <button id="groups-create-btn" class="admin-action-btn" style="background:var(--color-text-success);color:#fff">グループを作成</button>
-        </div>
+          <button type="submit" id="groups-create-btn" class="admin-action-btn" style="background:var(--color-text-success);color:#fff">グループを作成</button>
+        </form>
 
         <div id="groups-status" class="upload-status" style="display:none"></div>
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,6 +23,8 @@
       <div class="topbar-r">
         <span id="streak" style="color:var(--color-text-success)"></span>
         <span style="opacity:.3">|</span>
+        <button id="groups-btn" style="background:none;border:none;color:var(--color-text-secondary);cursor:pointer;font-size:12px;font-family:inherit" title="グループ管理">グループ <span id="groups-badge" style="display:none;background:var(--color-text-danger,#e53935);color:#fff;border-radius:8px;padding:1px 6px;margin-left:2px;font-size:10px">0</span></button>
+        <span style="opacity:.3">|</span>
         <span id="username"></span>
         <button id="logout-btn" style="background:none;border:none;color:var(--color-text-secondary);cursor:pointer;font-size:12px;font-family:inherit">ログアウト</button>
       </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -2416,6 +2416,304 @@
   }
 
   // ── Init ───────────────────────────────────────────────────────────
+  // ── Groups Management (Issue #121) ─────────────────────────────────
+  var _groupsState = { list: [], selectedId: null };
+
+  function initGroups() {
+    document.getElementById("groups-refresh").addEventListener("click", loadGroups);
+    document.getElementById("groups-create-btn").addEventListener("click", createGroup);
+    document.getElementById("groups-join-btn").addEventListener("click", joinByCode);
+    loadGroups();
+    loadMyInvitations();
+  }
+
+  function setGroupsStatus(msg, kind) {
+    var el = document.getElementById("groups-status");
+    if (!el) return;
+    if (!msg) { el.style.display = "none"; return; }
+    el.style.display = "block";
+    el.textContent = msg;
+    el.className = "upload-status upload-status-" + (kind || "info");
+  }
+
+  function loadGroups() {
+    apiFetch("/groups")
+      .then(function (res) { return res.json(); })
+      .then(function (list) {
+        _groupsState.list = list || [];
+        renderGroupsList();
+        // 選択解除されていたら先頭を選ぶ
+        if (_groupsState.list.length && !_groupsState.selectedId) {
+          selectGroup(_groupsState.list[0].id);
+        } else if (_groupsState.selectedId) {
+          selectGroup(_groupsState.selectedId);
+        }
+      })
+      .catch(function (e) { setGroupsStatus("グループ一覧の取得に失敗しました", "error"); });
+  }
+
+  function renderGroupsList() {
+    var el = document.getElementById("groups-list");
+    if (!_groupsState.list.length) {
+      el.innerHTML = '<div style="padding:12px;color:var(--color-text-tertiary);font-size:13px">まだグループに参加していません</div>';
+      return;
+    }
+    var html = "";
+    _groupsState.list.forEach(function (g) {
+      var badge = g.my_role === "admin" ? '<span style="color:var(--color-text-success);font-size:11px;margin-left:4px">(admin)</span>' : "";
+      var on = g.id === _groupsState.selectedId ? 'background:var(--color-bg-tertiary);' : "";
+      html += '<div data-gid="' + escHtml(g.id) + '" class="groups-item" style="padding:8px 12px;cursor:pointer;border-bottom:1px solid var(--color-border);' + on + '">' +
+        '<div style="font-size:13px">' + escHtml(g.name) + badge + '</div>' +
+        '<div style="font-size:11px;color:var(--color-text-tertiary)">メンバー ' + (g.member_count || 0) + "人</div>" +
+        "</div>";
+    });
+    el.innerHTML = html;
+    var items = el.querySelectorAll(".groups-item");
+    for (var i = 0; i < items.length; i++) {
+      items[i].addEventListener("click", function () {
+        selectGroup(this.getAttribute("data-gid"));
+      });
+    }
+  }
+
+  function selectGroup(groupId) {
+    _groupsState.selectedId = groupId;
+    renderGroupsList();
+    apiFetch("/groups/" + encodeURIComponent(groupId))
+      .then(function (res) {
+        if (!res.ok) throw new Error("failed");
+        return res.json();
+      })
+      .then(renderGroupDetail)
+      .catch(function () {
+        document.getElementById("groups-detail").innerHTML =
+          '<p style="color:var(--color-text-tertiary)">取得に失敗しました</p>';
+      });
+  }
+
+  function renderGroupDetail(g) {
+    var isAdmin = g.my_role === "admin";
+    var members = (g.members || []).map(function (m) {
+      var actions = "";
+      if (isAdmin && m.role !== "admin") {
+        actions = '<button class="admin-action-btn groups-remove-btn" data-uid="' + escHtml(m.user_id) + '" style="font-size:11px">除名</button>';
+      } else if (!isAdmin && m.user_id === _meUserId()) {
+        actions = '<button class="admin-action-btn groups-leave-btn" style="font-size:11px">退会</button>';
+      }
+      return '<tr><td>' + escHtml(m.username) + '</td><td>' + escHtml(m.email || "") + '</td><td>' + escHtml(m.role) + '</td><td>' + actions + '</td></tr>';
+    }).join("");
+
+    var inviteCodeBlock = "";
+    if (isAdmin && g.invite_code) {
+      inviteCodeBlock =
+        '<div style="margin:8px 0">' +
+        '<strong>招待コード:</strong> <code style="font-size:13px;padding:2px 6px;background:var(--color-bg-tertiary);border-radius:3px">' + escHtml(g.invite_code) + '</code>' +
+        ' <button id="groups-rotate-btn" class="admin-action-btn" style="font-size:11px;margin-left:8px">再発行</button>' +
+        "</div>";
+    }
+
+    var inviteByUser = "";
+    if (isAdmin) {
+      inviteByUser =
+        '<div style="margin-top:16px;padding:12px;background:var(--color-bg-secondary);border-radius:4px">' +
+        '<h4 style="font-size:13px;margin:0 0 8px 0">ユーザーを直接招待</h4>' +
+        '<div style="display:flex;gap:8px">' +
+        '<input type="text" id="groups-invite-username" placeholder="ユーザー名" style="flex:1;padding:4px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">' +
+        '<button id="groups-invite-btn" class="admin-action-btn">招待</button>' +
+        "</div></div>";
+    }
+
+    var dangerZone = "";
+    if (isAdmin) {
+      dangerZone =
+        '<div style="margin-top:24px">' +
+        '<button id="groups-delete-btn" class="admin-action-btn" style="background:#dc2626;color:#fff">グループを削除</button>' +
+        "</div>";
+    }
+
+    document.getElementById("groups-detail").innerHTML =
+      '<h3 style="margin:0 0 4px 0">' + escHtml(g.name) + "</h3>" +
+      '<p style="color:var(--color-text-secondary);font-size:13px;margin:0 0 8px 0">' + escHtml(g.description || "") + "</p>" +
+      inviteCodeBlock +
+      '<h4 style="font-size:13px;margin:16px 0 8px 0">メンバー (' + (g.members || []).length + ")</h4>" +
+      '<table class="admin-table"><thead><tr><th>ユーザー名</th><th>メール</th><th>ロール</th><th></th></tr></thead><tbody>' +
+      members + "</tbody></table>" +
+      inviteByUser +
+      dangerZone;
+
+    if (isAdmin) {
+      var rot = document.getElementById("groups-rotate-btn");
+      if (rot) rot.addEventListener("click", function () { rotateInviteCode(g.id); });
+      var invBtn = document.getElementById("groups-invite-btn");
+      if (invBtn) invBtn.addEventListener("click", function () {
+        var u = document.getElementById("groups-invite-username").value.trim();
+        if (!u) return;
+        inviteUser(g.id, u);
+      });
+      var del = document.getElementById("groups-delete-btn");
+      if (del) del.addEventListener("click", function () {
+        if (!confirm("グループ「" + g.name + "」を削除します。よろしいですか？")) return;
+        deleteGroup(g.id);
+      });
+      var removeBtns = document.querySelectorAll(".groups-remove-btn");
+      for (var i = 0; i < removeBtns.length; i++) {
+        removeBtns[i].addEventListener("click", function () {
+          removeMember(g.id, this.getAttribute("data-uid"));
+        });
+      }
+    } else {
+      var leave = document.querySelector(".groups-leave-btn");
+      if (leave) leave.addEventListener("click", function () {
+        if (!confirm("グループを退会しますか？")) return;
+        removeMember(g.id, _meUserId());
+      });
+    }
+  }
+
+  function _meUserId() {
+    var decoded = parseJwtPayload(state.token);
+    return decoded ? (decoded.sub || "") : "";
+  }
+
+  function createGroup() {
+    var name = document.getElementById("groups-new-name").value.trim();
+    var desc = document.getElementById("groups-new-desc").value.trim();
+    if (!name) { setGroupsStatus("グループ名を入力してください", "error"); return; }
+    apiFetch("/groups", {
+      method: "POST",
+      body: JSON.stringify({ name: name, description: desc }),
+    })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        return res.json();
+      })
+      .then(function (g) {
+        setGroupsStatus("グループ「" + g.name + "」を作成しました。招待コード: " + g.invite_code, "success");
+        document.getElementById("groups-new-name").value = "";
+        document.getElementById("groups-new-desc").value = "";
+        _groupsState.selectedId = g.id;
+        loadGroups();
+      })
+      .catch(function (e) { setGroupsStatus("作成失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function joinByCode() {
+    var code = document.getElementById("groups-join-code").value.trim();
+    if (!code) return;
+    apiFetch("/groups/join-by-code", {
+      method: "POST",
+      body: JSON.stringify({ invite_code: code }),
+    })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        return res.json();
+      })
+      .then(function (g) {
+        setGroupsStatus("グループ「" + g.name + "」に参加しました。", "success");
+        document.getElementById("groups-join-code").value = "";
+        _groupsState.selectedId = g.id;
+        loadGroups();
+      })
+      .catch(function (e) { setGroupsStatus("参加失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function rotateInviteCode(gid) {
+    apiFetch("/groups/" + encodeURIComponent(gid) + "/invite-code/rotate", { method: "POST" })
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        setGroupsStatus("招待コードを再発行しました: " + data.invite_code, "success");
+        selectGroup(gid);
+      });
+  }
+
+  function inviteUser(gid, username) {
+    apiFetch("/groups/" + encodeURIComponent(gid) + "/members", {
+      method: "POST",
+      body: JSON.stringify({ username: username }),
+    })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        return res.json();
+      })
+      .then(function () {
+        setGroupsStatus("ユーザー「" + username + "」を招待しました。", "success");
+        document.getElementById("groups-invite-username").value = "";
+        selectGroup(gid);
+      })
+      .catch(function (e) { setGroupsStatus("招待失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function removeMember(gid, uid) {
+    apiFetch("/groups/" + encodeURIComponent(gid) + "/members/" + encodeURIComponent(uid), { method: "DELETE" })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        setGroupsStatus("メンバーを削除しました。", "success");
+        loadGroups();
+      })
+      .catch(function (e) { setGroupsStatus("削除失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function deleteGroup(gid) {
+    apiFetch("/groups/" + encodeURIComponent(gid), { method: "DELETE" })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        setGroupsStatus("グループを削除しました。", "success");
+        _groupsState.selectedId = null;
+        document.getElementById("groups-detail").innerHTML =
+          '<p style="color:var(--color-text-tertiary)">グループを選択してください</p>';
+        loadGroups();
+      })
+      .catch(function (e) { setGroupsStatus("削除失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function loadMyInvitations() {
+    apiFetch("/me/invitations")
+      .then(function (res) { return res.json(); })
+      .then(function (list) {
+        var el = document.getElementById("groups-my-invitations");
+        if (!list || !list.length) { el.innerHTML = ""; return; }
+        var html = '<div style="padding:12px;background:var(--color-bg-secondary);border:1px solid var(--color-border);border-radius:4px;margin-bottom:12px">' +
+          '<h4 style="font-size:13px;margin:0 0 8px 0">未承諾の招待 (' + list.length + ")</h4>";
+        list.forEach(function (inv) {
+          html += '<div style="display:flex;align-items:center;gap:8px;padding:4px 0">' +
+            '<span style="flex:1;font-size:13px">グループ「' + escHtml(inv.group_name) + '」 (招待者: ' + escHtml(inv.inviter_username) + ")</span>" +
+            '<button class="admin-action-btn groups-inv-accept" data-id="' + escHtml(inv.id) + '" style="font-size:11px;background:var(--color-text-success);color:#fff">承諾</button>' +
+            '<button class="admin-action-btn groups-inv-decline" data-id="' + escHtml(inv.id) + '" style="font-size:11px">辞退</button>' +
+            "</div>";
+        });
+        html += "</div>";
+        el.innerHTML = html;
+        var accepts = el.querySelectorAll(".groups-inv-accept");
+        for (var i = 0; i < accepts.length; i++) {
+          accepts[i].addEventListener("click", function () { respondInvitation(this.getAttribute("data-id"), "accept"); });
+        }
+        var declines = el.querySelectorAll(".groups-inv-decline");
+        for (var j = 0; j < declines.length; j++) {
+          declines[j].addEventListener("click", function () { respondInvitation(this.getAttribute("data-id"), "decline"); });
+        }
+      });
+  }
+
+  function respondInvitation(invId, action) {
+    apiFetch("/me/invitations/" + encodeURIComponent(invId) + "/" + action, { method: "POST" })
+      .then(function (res) {
+        if (!res.ok) return res.json().then(function (d) { throw d; });
+        setGroupsStatus("招待を" + (action === "accept" ? "承諾" : "辞退") + "しました。", "success");
+        loadMyInvitations();
+        loadGroups();
+      })
+      .catch(function (e) { setGroupsStatus("操作失敗: " + (e.detail || "不明なエラー"), "error"); });
+  }
+
+  function parseJwtPayload(token) {
+    try {
+      var parts = token.split(".");
+      if (parts.length !== 3) return null;
+      var payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+      return JSON.parse(atob(payload));
+    } catch (e) { return null; }
+  }
+
   function initApp() {
     // Role-based access control
     if (!setupRoleBasedUI()) return;
@@ -2431,6 +2729,7 @@
     initSchemaProposals();
     initSchemaEvolution();
     initUserManagement();
+    initGroups();
     initLogout();
     loadMaterials();
 

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -2420,9 +2420,25 @@
   var _groupsState = { list: [], selectedId: null };
 
   function initGroups() {
-    document.getElementById("groups-refresh").addEventListener("click", loadGroups);
-    document.getElementById("groups-create-btn").addEventListener("click", createGroup);
-    document.getElementById("groups-join-btn").addEventListener("click", joinByCode);
+    var refreshBtn = document.getElementById("groups-refresh");
+    if (refreshBtn) refreshBtn.addEventListener("click", loadGroups);
+
+    var createForm = document.getElementById("groups-create-form");
+    if (createForm) {
+      createForm.addEventListener("submit", function (e) {
+        e.preventDefault();
+        createGroup();
+      });
+    }
+
+    var joinForm = document.getElementById("groups-join-form");
+    if (joinForm) {
+      joinForm.addEventListener("submit", function (e) {
+        e.preventDefault();
+        joinByCode();
+      });
+    }
+
     loadGroups();
     loadMyInvitations();
   }

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -819,7 +819,203 @@
     initTabs();
     initInput();
     initLogout();
+    initGroups();
     await initCourseSelector();
+    loadInvitationBadge();
+  }
+
+  // ── Groups (Issue #121) ────────────────────────────────────────────
+  function initGroups() {
+    var btn = document.getElementById("groups-btn");
+    if (btn) btn.addEventListener("click", openGroupsModal);
+  }
+
+  async function loadInvitationBadge() {
+    try {
+      var res = await apiFetch("/me/invitations");
+      if (!res.ok) return;
+      var list = await res.json();
+      var pending = (list || []).filter(function (i) { return i.status === "pending"; });
+      var badge = document.getElementById("groups-badge");
+      if (badge) {
+        if (pending.length > 0) {
+          badge.textContent = String(pending.length);
+          badge.style.display = "";
+        } else {
+          badge.style.display = "none";
+        }
+      }
+    } catch (_) { /* ignore */ }
+  }
+
+  function openGroupsModal() {
+    if (document.getElementById("groups-overlay")) return;
+    var overlay = document.createElement("div");
+    overlay.id = "groups-overlay";
+    overlay.className = "auth-overlay";
+    overlay.innerHTML =
+      '<div class="auth-box" style="width:440px;max-height:80vh;overflow-y:auto">' +
+        '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:14px">' +
+          '<h2 style="margin:0">グループ</h2>' +
+          '<button id="groups-close" style="background:none;border:none;font-size:20px;cursor:pointer;color:var(--color-text-secondary)">&times;</button>' +
+        '</div>' +
+        '<div id="groups-invitations-section">' +
+          '<div style="font-size:12px;font-weight:600;color:var(--color-text-secondary);margin-bottom:6px">招待</div>' +
+          '<div id="groups-invitations-list" style="margin-bottom:14px;font-size:13px">読み込み中...</div>' +
+        '</div>' +
+        '<div>' +
+          '<div style="font-size:12px;font-weight:600;color:var(--color-text-secondary);margin-bottom:6px">招待コードで参加</div>' +
+          '<form id="groups-join-form" style="display:flex;gap:6px;margin-bottom:14px">' +
+            '<input id="groups-join-code" type="text" placeholder="招待コード" style="flex:1;padding:8px 10px;border:0.5px solid var(--color-border-secondary);border-radius:8px;font-size:13px" required>' +
+            '<button type="submit" style="padding:8px 14px;border-radius:8px;background:var(--color-text-info);color:#fff;border:none;cursor:pointer;font-size:13px">参加</button>' +
+          '</form>' +
+        '</div>' +
+        '<div>' +
+          '<div style="font-size:12px;font-weight:600;color:var(--color-text-secondary);margin-bottom:6px">参加中のグループ</div>' +
+          '<div id="groups-my-list" style="font-size:13px">読み込み中...</div>' +
+        '</div>' +
+        '<div id="groups-status" style="margin-top:10px;font-size:12px;min-height:16px"></div>' +
+      '</div>';
+    document.body.appendChild(overlay);
+
+    document.getElementById("groups-close").addEventListener("click", closeGroupsModal);
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) closeGroupsModal();
+    });
+    document.getElementById("groups-join-form").addEventListener("submit", function (e) {
+      e.preventDefault();
+      var code = document.getElementById("groups-join-code").value.trim();
+      if (code) joinGroupByCode(code);
+    });
+
+    refreshGroupsModal();
+  }
+
+  function closeGroupsModal() {
+    var overlay = document.getElementById("groups-overlay");
+    if (overlay) overlay.remove();
+  }
+
+  function setGroupsModalStatus(msg, isError) {
+    var el = document.getElementById("groups-status");
+    if (!el) return;
+    el.textContent = msg || "";
+    el.style.color = isError ? "var(--color-text-danger)" : "var(--color-text-success)";
+  }
+
+  async function refreshGroupsModal() {
+    await Promise.all([renderInvitations(), renderMyGroups()]);
+    loadInvitationBadge();
+  }
+
+  async function renderInvitations() {
+    var container = document.getElementById("groups-invitations-list");
+    if (!container) return;
+    try {
+      var res = await apiFetch("/me/invitations");
+      if (!res.ok) { container.textContent = "読み込みに失敗しました"; return; }
+      var invites = await res.json();
+      var pending = (invites || []).filter(function (i) { return i.status === "pending"; });
+      if (pending.length === 0) {
+        container.innerHTML = '<div style="color:var(--color-text-tertiary)">保留中の招待はありません</div>';
+        return;
+      }
+      var html = "";
+      pending.forEach(function (inv) {
+        html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px;border:0.5px solid var(--color-border-secondary);border-radius:8px;margin-bottom:6px">';
+        html += '<div><div style="font-weight:500">' + escHtml(inv.group_name || "(グループ)") + '</div>';
+        html += '<div style="font-size:11px;color:var(--color-text-tertiary)">招待者: ' + escHtml(inv.inviter_username || "?") + '</div></div>';
+        html += '<div style="display:flex;gap:4px">';
+        html += '<button data-action="accept" data-id="' + escHtml(inv.id) + '" style="padding:4px 10px;border-radius:6px;background:var(--color-text-info);color:#fff;border:none;cursor:pointer;font-size:12px">承諾</button>';
+        html += '<button data-action="decline" data-id="' + escHtml(inv.id) + '" style="padding:4px 10px;border-radius:6px;background:var(--color-background-secondary);color:var(--color-text-primary);border:0.5px solid var(--color-border-secondary);cursor:pointer;font-size:12px">辞退</button>';
+        html += '</div></div>';
+      });
+      container.innerHTML = html;
+      container.querySelectorAll("button[data-action]").forEach(function (b) {
+        b.addEventListener("click", function () {
+          respondInvitation(b.getAttribute("data-id"), b.getAttribute("data-action"));
+        });
+      });
+    } catch (_) {
+      container.textContent = "読み込みに失敗しました";
+    }
+  }
+
+  async function renderMyGroups() {
+    var container = document.getElementById("groups-my-list");
+    if (!container) return;
+    try {
+      var res = await apiFetch("/groups");
+      if (!res.ok) { container.textContent = "読み込みに失敗しました"; return; }
+      var groups = await res.json();
+      if (!groups || groups.length === 0) {
+        container.innerHTML = '<div style="color:var(--color-text-tertiary)">参加中のグループはありません</div>';
+        return;
+      }
+      var html = "";
+      groups.forEach(function (g) {
+        html += '<div style="padding:8px;border:0.5px solid var(--color-border-secondary);border-radius:8px;margin-bottom:6px">';
+        html += '<div style="font-weight:500">' + escHtml(g.name) + '</div>';
+        if (g.description) {
+          html += '<div style="font-size:11px;color:var(--color-text-tertiary);margin-top:2px">' + escHtml(g.description) + '</div>';
+        }
+        html += '<div style="font-size:11px;color:var(--color-text-tertiary);margin-top:2px">ロール: ' + escHtml(g.my_role || "member") + '</div>';
+        if (g.invite_code) {
+          html += '<div style="font-size:11px;color:var(--color-text-tertiary);margin-top:2px">招待コード: <code>' + escHtml(g.invite_code) + '</code></div>';
+        }
+        html += '</div>';
+      });
+      container.innerHTML = html;
+    } catch (_) {
+      container.textContent = "読み込みに失敗しました";
+    }
+  }
+
+  async function respondInvitation(invitationId, action) {
+    try {
+      var res = await apiFetch("/me/invitations/" + invitationId + "/" + action, { method: "POST" });
+      if (!res.ok) {
+        var err = await res.json().catch(function () { return {}; });
+        setGroupsModalStatus(err.detail || "処理に失敗しました", true);
+        return;
+      }
+      setGroupsModalStatus(action === "accept" ? "グループに参加しました" : "招待を辞退しました", false);
+      await refreshGroupsModal();
+      // New group → refresh course list so group-shared courses appear
+      if (action === "accept") {
+        var courses = await loadCourses();
+        _allCourses = courses;
+        var ownCourses = courses.filter(function (c) { return !c.is_enrollable; });
+        var enrollableCourses = courses.filter(function (c) { return c.is_enrollable; });
+        renderCourseSelect(ownCourses, enrollableCourses);
+      }
+    } catch (_) {
+      setGroupsModalStatus("処理に失敗しました", true);
+    }
+  }
+
+  async function joinGroupByCode(code) {
+    try {
+      var res = await apiFetch("/groups/join-by-code", {
+        method: "POST",
+        body: JSON.stringify({ invite_code: code }),
+      });
+      if (!res.ok) {
+        var err = await res.json().catch(function () { return {}; });
+        setGroupsModalStatus(err.detail || "参加に失敗しました", true);
+        return;
+      }
+      setGroupsModalStatus("グループに参加しました", false);
+      document.getElementById("groups-join-code").value = "";
+      await refreshGroupsModal();
+      var courses = await loadCourses();
+      _allCourses = courses;
+      var ownCourses = courses.filter(function (c) { return !c.is_enrollable; });
+      var enrollableCourses = courses.filter(function (c) { return c.is_enrollable; });
+      renderCourseSelect(ownCourses, enrollableCourses);
+    } catch (_) {
+      setGroupsModalStatus("参加に失敗しました", true);
+    }
   }
 
   // ── Expose sendPrompt globally for inline onclick ──────────────────


### PR DESCRIPTION
## Summary
Implements group management functionality and visibility-based access control for learning materials and courses, enabling teachers to organize students into groups and control resource sharing.

## Key Changes

### Backend
- **New Groups API** (`backend/api/routes/groups.py`): Complete group management endpoints including:
  - Group CRUD operations (create, list, get details, update, delete)
  - Member management (add, remove, list)
  - Invite code generation and rotation
  - Direct user invitations with acceptance/decline workflow
  - Join-by-code functionality for group enrollment

- **Access Control**: 
  - Added `_validate_visibility()` in `learning.py` to enforce visibility rules
  - New helper functions `get_user_group_ids()` and `user_can_access_group()` in `services.py`
  - Added `get_accessible_course_data()` to respect visibility settings when retrieving courses

- **Database Schema** (`backend/db/009_groups_visibility.sql`):
  - New `groups` table with invite codes and metadata
  - New `group_members` table for membership tracking
  - New `group_invitations` table for invitation workflow
  - Added `visibility` and `group_id` columns to `documents` and `learning_courses` tables

- **Models & Schemas**:
  - Updated `Document` and `LearningCourse` models with visibility and group_id fields
  - New request/response schemas: `GroupCreateRequest`, `GroupDetailOut`, `GroupInvitationOut`, `VisibilityUpdateRequest`
  - Extended `CourseCreateRequest` and `CourseUpdateRequest` with visibility options

- **Material Visibility API** (`admin.py`):
  - New endpoint `PUT /materials/{material_id}/visibility` to update material access control

### Frontend
- **Admin Panel** (`admin.html`, `admin.js`):
  - New "グループ管理" (Group Management) tab with full CRUD UI
  - Group creation, member management, invite code rotation
  - Direct user invitation interface

- **User Interface** (`index.html`, `app.js`):
  - New groups modal accessible from top navigation
  - Invitation badge showing pending invitations count
  - Join-by-code interface for group enrollment
  - Invitation acceptance/decline workflow

### Testing
- Comprehensive test suite (`test_groups_visibility.py`) with 653 lines covering:
  - Group CRUD operations
  - Member management and permissions
  - Invitation workflows
  - Visibility validation for courses and materials
  - In-memory fake session for isolated testing

## Implementation Details
- Uses raw SQL with parameterized queries for database operations
- Invite codes are 12-character URL-safe tokens generated via `secrets.token_urlsafe()`
- Group admin role required for most management operations
- Visibility model supports three levels: `private` (owner only), `group` (group members), `public` (published templates)
- Invitation system tracks status (pending/accepted/declined) with timestamps

https://claude.ai/code/session_01GJZA1oYywk7YA7rsxbHXQT