### PR TITLE
Separate course master data from per-user learning state (Issue #133)

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -82,7 +82,6 @@ def _run_migrations() -> None:
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS is_template  BOOLEAN NOT NULL DEFAULT false",
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS is_published BOOLEAN NOT NULL DEFAULT false",
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS owner_id     UUID REFERENCES users(id)",
-            "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS cloned_from  TEXT REFERENCES learning_courses(id)",
         ]:
             session.execute(sa_text(ddl))
         session.execute(sa_text(
@@ -232,8 +231,48 @@ def _run_migrations() -> None:
         session.execute(sa_text("DROP INDEX IF EXISTS idx_chunks_arxiv"))
         session.execute(sa_text("ALTER TABLE chunks DROP COLUMN IF EXISTS arxiv_id"))
 
+        # Migration 011: コース原本と学習状態の完全分離 (Issue #133)
+        # 既存のクローンを持つDBを本マイグレーションで破壊的に正規化する。
+        # cloned_from カラムはパース時解決のため、存在確認してから動的SQLで実行する。
+        has_cloned_from = session.execute(sa_text("""
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'learning_courses' AND column_name = 'cloned_from'
+        """)).fetchone()
+        if has_cloned_from:
+            session.execute(sa_text("""
+                DELETE FROM learning_chat_history
+                WHERE course_id IN (
+                    SELECT id FROM learning_courses WHERE cloned_from IS NOT NULL
+                )
+            """))
+            session.execute(sa_text(
+                "DELETE FROM learning_courses WHERE cloned_from IS NOT NULL"
+            ))
+            session.execute(sa_text(
+                "ALTER TABLE learning_courses DROP COLUMN cloned_from"
+            ))
+
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS learning_states (
+                id             UUID PRIMARY KEY,
+                user_id        UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                course_id      TEXT NOT NULL REFERENCES learning_courses(id) ON DELETE CASCADE,
+                progress_data  JSONB DEFAULT '{}'::jsonb,
+                personal_graph JSONB DEFAULT '{}'::jsonb,
+                enrolled_at    TIMESTAMPTZ DEFAULT now(),
+                updated_at     TIMESTAMPTZ DEFAULT now(),
+                UNIQUE (user_id, course_id)
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_learning_states_user ON learning_states(user_id)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_learning_states_course ON learning_states(course_id)"
+        ))
+
         session.commit()
-        logger.info("Migrations (002-007) applied successfully.")
+        logger.info("Migrations (002-007, 011) applied successfully.")
 
         # Seed builtin schema types/predicates
         from core.schema_registry import seed_builtin_schema

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -994,7 +994,8 @@ def delete_course(
         record = session.execute(
             sa_text("""
                 SELECT id, title FROM learning_courses
-                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+                WHERE id = :course_id
+                  AND (owner_id = CAST(:user_id AS uuid) OR user_id = CAST(:user_id AS uuid))
                 LIMIT 1
             """),
             {"course_id": course_id, "user_id": current_user["id"]},
@@ -1015,11 +1016,12 @@ def delete_course(
             sa_text("DELETE FROM learning_chat_history WHERE course_id = :cid"),
             {"cid": course_id},
         )
-        # コース削除
+        # コース削除 (ON DELETE CASCADE により learning_states も自動削除)
         session.execute(
             sa_text("""
                 DELETE FROM learning_courses
-                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+                WHERE id = :course_id
+                  AND (owner_id = CAST(:user_id AS uuid) OR user_id = CAST(:user_id AS uuid))
             """),
             {"course_id": course_id, "user_id": current_user["id"]},
         )

--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 
@@ -24,7 +23,10 @@ from services import (
     calculate_progress,
     check_prerequisites,
     detect_and_record_misconception,
+    ensure_learning_state,
     get_course_data,
+    get_course_master,
+    get_course_owner,
     log_unanswered_query,
     persist_chat_history,
     save_course_data,
@@ -71,16 +73,35 @@ def create_course(
 def list_courses(
     current_user: dict = Depends(_get_current_user),
 ) -> list[LearningCourseOut]:
-    """ユーザーが登録しているコース一覧を返す。公開テンプレートも含む。"""
+    """ユーザーがアクセス可能なコース一覧を返す。
+
+    Issue #133 以降、学生は learning_states で受講中のコースのみを「マイコース」として扱い、
+    まだ受講していない公開テンプレートは「受講可能」として提示する。教員は自分が所有する
+    コース (is_template=true のもの含む) も合わせて返す。
+    """
     session = _pg_session()
     try:
         own_records = session.execute(
             sa_text("""
-                SELECT id, title,
-                       COALESCE(is_template, false) AS is_template,
-                       COALESCE(is_published, false) AS is_published
-                FROM learning_courses
-                WHERE user_id = CAST(:user_id AS uuid)
+                SELECT lc.id, lc.title,
+                       COALESCE(lc.is_template, false) AS is_template,
+                       COALESCE(lc.is_published, false) AS is_published
+                FROM learning_courses lc
+                WHERE lc.owner_id = CAST(:user_id AS uuid)
+                   OR lc.user_id = CAST(:user_id AS uuid)
+            """),
+            {"user_id": current_user["id"]},
+        ).fetchall()
+
+        enrolled_records = session.execute(
+            sa_text("""
+                SELECT lc.id, lc.title,
+                       COALESCE(lc.is_template, false) AS is_template,
+                       COALESCE(lc.is_published, false) AS is_published
+                FROM learning_states ls
+                JOIN learning_courses lc ON lc.id = ls.course_id
+                WHERE ls.user_id = CAST(:user_id AS uuid)
+                  AND COALESCE(lc.owner_id, lc.user_id) != CAST(:user_id AS uuid)
             """),
             {"user_id": current_user["id"]},
         ).fetchall()
@@ -90,11 +111,11 @@ def list_courses(
                 SELECT lc.id, lc.title
                 FROM learning_courses lc
                 WHERE lc.is_published = true AND lc.is_template = true
-                  AND lc.user_id != CAST(:user_id AS uuid)
+                  AND COALESCE(lc.owner_id, lc.user_id) != CAST(:user_id AS uuid)
                   AND NOT EXISTS (
-                      SELECT 1 FROM learning_courses lc2
-                      WHERE lc2.user_id = CAST(:user_id AS uuid)
-                        AND lc2.cloned_from = lc.id
+                      SELECT 1 FROM learning_states ls
+                      WHERE ls.user_id = CAST(:user_id AS uuid)
+                        AND ls.course_id = lc.id
                   )
             """),
             {"user_id": current_user["id"]},
@@ -102,26 +123,30 @@ def list_courses(
     finally:
         session.close()
 
-    courses = [
-        LearningCourseOut(
+    seen: set[str] = set()
+    courses: list[LearningCourseOut] = []
+    for r in list(own_records) + list(enrolled_records):
+        if r[0] in seen:
+            continue
+        seen.add(r[0])
+        courses.append(LearningCourseOut(
             id=r[0],
             title=r[1],
             is_template=bool(r[2]),
             is_published=bool(r[3]),
             is_enrollable=False,
-        )
-        for r in own_records
-    ]
-    courses.extend(
-        LearningCourseOut(
+        ))
+    for r in template_records:
+        if r[0] in seen:
+            continue
+        seen.add(r[0])
+        courses.append(LearningCourseOut(
             id=r[0],
             title=r[1],
             is_template=True,
             is_published=True,
             is_enrollable=True,
-        )
-        for r in template_records
-    )
+        ))
     return courses
 
 
@@ -144,11 +169,17 @@ def update_course(
     body: CourseUpdateRequest,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseDetail:
-    """コースを部分更新する。指定されたフィールドのみ上書き。"""
-    data = get_course_data(current_user["id"], course_id)
-    if not data:
+    """コース原本を部分更新する。コース所有者のみ許可。"""
+    owner_id = get_course_owner(course_id)
+    if not owner_id:
         raise HTTPException(status_code=404, detail="Course not found")
+    if owner_id != current_user["id"]:
+        raise HTTPException(
+            status_code=403,
+            detail="コース原本を編集できるのは所有者のみです。",
+        )
 
+    data = get_course_master(course_id) or {}
     if body.title is not None:
         data["title"] = body.title
     if body.chapters is not None:
@@ -161,7 +192,7 @@ def update_course(
         data["sources"] = [s.model_dump() for s in body.sources]
 
     save_course_data(current_user["id"], course_id, data)
-    logger.info("Updated course %s for user=%s", course_id, current_user["id"])
+    logger.info("Updated course %s for owner=%s", course_id, current_user["id"])
 
     return LearningCourseDetail(**data)
 
@@ -208,12 +239,16 @@ def enroll_course(
     course_id: str,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseOut:
-    """公開テンプレートコースをクローンして自分のコースとして登録する。"""
+    """公開テンプレートコースを受講登録する (Issue #133)。
+
+    コースのクローンは作成せず、learning_states に (user_id, course_id) の状態行を
+    登録するのみ。UNIQUE 制約により重複受講は DB レベルでブロックされる。
+    """
     session = _pg_session()
     try:
         record = session.execute(
             sa_text("""
-                SELECT data FROM learning_courses
+                SELECT id, title FROM learning_courses
                 WHERE id = :course_id AND is_published = true AND is_template = true
                 LIMIT 1
             """),
@@ -222,35 +257,21 @@ def enroll_course(
     finally:
         session.close()
 
-    if not record or not record[0]:
+    if not record:
         raise HTTPException(status_code=404, detail="Published course not found")
 
-    template_data = record[0] if isinstance(record[0], dict) else json.loads(record[0])
-
-    new_course_id = str(uuid.uuid4())[:8]
-    cloned_data = dict(template_data)
-    cloned_data["id"] = new_course_id
-
-    save_course_data(current_user["id"], new_course_id, cloned_data)
-
-    session = _pg_session()
-    try:
-        session.execute(
-            sa_text("UPDATE learning_courses SET cloned_from = :original_id WHERE id = :id"),
-            {"id": new_course_id, "original_id": course_id},
-        )
-        session.commit()
-    except Exception:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+    ensure_learning_state(current_user["id"], course_id)
 
     logger.info(
-        "User=%s enrolled in course %s (cloned as %s)",
-        current_user["id"], course_id, new_course_id,
+        "User=%s enrolled in course %s", current_user["id"], course_id,
     )
-    return LearningCourseOut(id=new_course_id, title=cloned_data.get("title", ""))
+    return LearningCourseOut(
+        id=record[0],
+        title=record[1] or "",
+        is_template=True,
+        is_published=True,
+        is_enrollable=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -132,16 +132,96 @@ def get_background_task(task_id: str) -> dict | None:
 
 
 def get_course_data(user_id: str, course_id: str) -> dict | None:
-    """PostgreSQL から LearningCourse データを取得する。"""
+    """コース原本 + 当該ユーザーの personal_graph をマージして返す。
+
+    Issue #133: コース原本 (learning_courses.data) は不変。
+    ユーザー固有の状態 (誤解メモ等) は learning_states.personal_graph に保持し、
+    読み出し時にトピック単位でオーバーレイする。
+
+    アクセス権:
+      - コース所有者 (owner_id) は常にアクセス可能
+      - learning_states に行がある (受講済み) ユーザーはアクセス可能
+      - それ以外は None
+    """
     session = _pg_session()
     try:
         record = session.execute(
             sa_text("""
-                SELECT data FROM learning_courses
-                WHERE user_id = CAST(:user_id AS uuid) AND id = :course_id
+                SELECT lc.data, lc.owner_id, lc.user_id
+                FROM learning_courses lc
+                WHERE lc.id = :course_id
                 LIMIT 1
             """),
-            {"user_id": user_id, "course_id": course_id},
+            {"course_id": course_id},
+        ).fetchone()
+        if not record or not record[0]:
+            return None
+        master = record[0] if isinstance(record[0], dict) else json.loads(record[0])
+        owner_id = str(record[1]) if record[1] else None
+        legacy_user_id = str(record[2]) if record[2] else None
+
+        is_owner = user_id in (owner_id, legacy_user_id)
+
+        personal: dict = {}
+        if not is_owner:
+            state_row = session.execute(
+                sa_text("""
+                    SELECT personal_graph FROM learning_states
+                    WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                    LIMIT 1
+                """),
+                {"user_id": user_id, "course_id": course_id},
+            ).fetchone()
+            if not state_row:
+                return None
+            personal = (
+                state_row[0] if isinstance(state_row[0], dict)
+                else (json.loads(state_row[0]) if state_row[0] else {})
+            )
+        else:
+            # 所有者(教員)自身にも personal_graph をオーバーレイする（自己確認用）
+            state_row = session.execute(
+                sa_text("""
+                    SELECT personal_graph FROM learning_states
+                    WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                    LIMIT 1
+                """),
+                {"user_id": user_id, "course_id": course_id},
+            ).fetchone()
+            if state_row and state_row[0]:
+                personal = (
+                    state_row[0] if isinstance(state_row[0], dict)
+                    else json.loads(state_row[0])
+                )
+    finally:
+        session.close()
+
+    return _overlay_personal_graph(master, personal)
+
+
+def _overlay_personal_graph(master: dict, personal: dict) -> dict:
+    """master コースデータに personal_graph を非破壊的にマージする。
+
+    現状の personal_graph スキーマ:
+      {"topic_misconceptions": {"<topic_id>": [LearningMisconception, ...]}}
+    """
+    merged = json.loads(json.dumps(master, ensure_ascii=False))  # deep copy
+    topic_misc: dict = (personal or {}).get("topic_misconceptions", {}) or {}
+    if topic_misc:
+        for t in merged.get("topics", []):
+            tid = t.get("id")
+            if tid and tid in topic_misc:
+                t["misconceptions"] = topic_misc[tid][:5]
+    return merged
+
+
+def get_course_master(course_id: str) -> dict | None:
+    """コース原本 (personal_graph オーバーレイなし) を返す。"""
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("SELECT data FROM learning_courses WHERE id = :course_id LIMIT 1"),
+            {"course_id": course_id},
         ).fetchone()
         if record and record[0]:
             return record[0] if isinstance(record[0], dict) else json.loads(record[0])
@@ -150,8 +230,30 @@ def get_course_data(user_id: str, course_id: str) -> dict | None:
     return None
 
 
+def get_course_owner(course_id: str) -> str | None:
+    """コースの owner_id (所有者の user_id) を返す。"""
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("""
+                SELECT COALESCE(owner_id, user_id) FROM learning_courses
+                WHERE id = :course_id LIMIT 1
+            """),
+            {"course_id": course_id},
+        ).fetchone()
+        if record and record[0]:
+            return str(record[0])
+    finally:
+        session.close()
+    return None
+
+
 def save_course_data(user_id: str, course_id: str, data: dict, is_template: bool = False) -> None:
-    """LearningCourse データを PostgreSQL に UPSERT する。"""
+    """コース原本 (マスター) を UPSERT する。
+
+    Issue #133 以降、このヘルパーは「コース所有者 (教員)」が原本を書き換える時のみ
+    使用する想定。呼び出し側で所有者チェックを行うこと。
+    """
     session = _pg_session()
     try:
         session.execute(
@@ -188,19 +290,121 @@ def save_course_data(user_id: str, course_id: str, data: dict, is_template: bool
 
 
 def delete_course_data(user_id: str, course_id: str) -> bool:
-    """LearningCourse レコードを削除する。"""
+    """コース原本を削除する。所有者 (owner_id もしくは user_id) のみ削除可能。
+
+    ON DELETE CASCADE により関連する learning_states も自動削除される。
+    """
     session = _pg_session()
     try:
         result = session.execute(
             sa_text("""
                 DELETE FROM learning_courses
-                WHERE id = :course_id AND user_id = CAST(:user_id AS uuid)
+                WHERE id = :course_id
+                  AND (owner_id = CAST(:user_id AS uuid) OR user_id = CAST(:user_id AS uuid))
                 RETURNING id
             """),
             {"course_id": course_id, "user_id": user_id},
         ).fetchone()
         session.commit()
         return result is not None
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Learning State helpers (Issue #133)
+# ---------------------------------------------------------------------------
+
+
+def get_learning_state(user_id: str, course_id: str) -> dict | None:
+    """受講中ユーザーの learning_states レコードを返す。"""
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("""
+                SELECT id, progress_data, personal_graph, enrolled_at, updated_at
+                FROM learning_states
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                LIMIT 1
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        ).fetchone()
+        if not record:
+            return None
+        progress = record[1] if isinstance(record[1], dict) else (json.loads(record[1]) if record[1] else {})
+        personal = record[2] if isinstance(record[2], dict) else (json.loads(record[2]) if record[2] else {})
+        return {
+            "id": str(record[0]),
+            "progress_data": progress or {},
+            "personal_graph": personal or {},
+            "enrolled_at": record[3].isoformat() if record[3] else "",
+            "updated_at": record[4].isoformat() if record[4] else "",
+        }
+    finally:
+        session.close()
+
+
+def ensure_learning_state(user_id: str, course_id: str) -> str:
+    """受講状態行を作成 (存在しない場合のみ)。UNIQUE(user_id, course_id) で増殖防止。"""
+    session = _pg_session()
+    try:
+        record = session.execute(
+            sa_text("""
+                INSERT INTO learning_states (id, user_id, course_id, progress_data, personal_graph)
+                VALUES (
+                    :state_id,
+                    CAST(:user_id AS uuid),
+                    :course_id,
+                    '{}'::jsonb,
+                    '{}'::jsonb
+                )
+                ON CONFLICT (user_id, course_id) DO UPDATE
+                    SET updated_at = learning_states.updated_at
+                RETURNING id
+            """),
+            {
+                "state_id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "course_id": course_id,
+            },
+        ).fetchone()
+        session.commit()
+        return str(record[0]) if record else ""
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def update_personal_graph(user_id: str, course_id: str, personal_graph: dict) -> None:
+    """learning_states.personal_graph を上書き保存する (UPSERT)。"""
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO learning_states (id, user_id, course_id, personal_graph)
+                VALUES (
+                    :state_id,
+                    CAST(:user_id AS uuid),
+                    :course_id,
+                    CAST(:personal AS jsonb)
+                )
+                ON CONFLICT (user_id, course_id) DO UPDATE
+                    SET personal_graph = CAST(:personal AS jsonb),
+                        updated_at = now()
+            """),
+            {
+                "state_id": str(uuid.uuid4()),
+                "user_id": user_id,
+                "course_id": course_id,
+                "personal": json.dumps(personal_graph, ensure_ascii=False),
+            },
+        )
+        session.commit()
     except Exception:
         session.rollback()
         raise
@@ -365,16 +569,19 @@ def search_chunks_with_metadata(
 
 
 def calculate_progress(user_id: str, course_id: str, course_data: dict) -> dict:
-    """コースデータとチャット履歴から進捗を計算する。"""
+    """コースデータとチャット履歴から進捗を計算する。
+
+    誤解件数はコース原本ではなく、当該ユーザーの personal_graph から集計する。
+    """
     topics = course_data.get("topics", [])
     concepts = course_data.get("concepts", [])
 
     mastered = sum(1 for c in concepts if c.get("status") == "mastered")
     learning = sum(1 for c in concepts if c.get("status") == "learning")
 
-    total_misconceptions = 0
-    for t in topics:
-        total_misconceptions += len(t.get("misconceptions", []))
+    state = get_learning_state(user_id, course_id) or {}
+    topic_misc = (state.get("personal_graph") or {}).get("topic_misconceptions", {}) or {}
+    total_misconceptions = sum(len(v or []) for v in topic_misc.values())
 
     sessions_list = []
     pg_session = _pg_session()
@@ -603,7 +810,11 @@ def detect_and_record_misconception(
     user_message: str,
     ai_response: str,
 ) -> dict | None:
-    """AI応答から誤解を検出し、コースデータに記録する。"""
+    """AI応答から誤解を検出し、ユーザー固有の learning_states.personal_graph に記録する。
+
+    Issue #133: コース原本 (learning_courses.data) は絶対に書き換えない。
+    検出した誤解は personal_graph["topic_misconceptions"][topic_id] に積む。
+    """
     wrong = user_message
     if len(wrong) > 60:
         wrong = wrong[:60] + "…"
@@ -626,18 +837,27 @@ def detect_and_record_misconception(
         "correct": correct,
     }
 
-    for t in course_data.get("topics", []):
-        if t.get("id") == topic_id:
-            if "misconceptions" not in t:
-                t["misconceptions"] = []
-            t["misconceptions"].insert(0, misconception)
-            t["misconceptions"] = t["misconceptions"][:5]
-            break
+    state = get_learning_state(user_id, course_id) or {}
+    personal = dict(state.get("personal_graph") or {})
+    topic_misc: dict = dict(personal.get("topic_misconceptions") or {})
+    current = list(topic_misc.get(topic_id) or [])
+    current.insert(0, misconception)
+    topic_misc[topic_id] = current[:5]
+    personal["topic_misconceptions"] = topic_misc
 
-    save_course_data(user_id, course_id, course_data)
+    update_personal_graph(user_id, course_id, personal)
+
+    # UI 更新用に、トピック単位で誤解を反映した topics を返す
+    updated_topics = []
+    for t in course_data.get("topics", []):
+        t = dict(t)
+        tid = t.get("id")
+        if tid and tid in topic_misc:
+            t["misconceptions"] = topic_misc[tid]
+        updated_topics.append(t)
 
     return {
-        "topics": course_data.get("topics", []),
+        "topics": updated_topics,
         "concepts": course_data.get("concepts", []),
     }
 

--- a/backend/db/011_course_states_separation.sql
+++ b/backend/db/011_course_states_separation.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- Migration 011: コース原本と学習状態の完全分離 (Issue #133)
+-- ============================================================
+-- 既存のクローンデータ（学習状態の残骸）はすべてハードリセット（削除）し、
+-- 「1つの不変なマスターコース」対「無数のユーザーの学習状態（差分データ）」
+-- アーキテクチャへ移行する。
+
+BEGIN;
+
+-- 1. 既存のクローンに紐づくチャット履歴をすべて削除
+DELETE FROM learning_chat_history
+WHERE course_id IN (SELECT id FROM learning_courses WHERE cloned_from IS NOT NULL);
+
+-- 2. 既存のクローンコース（学習状態の残骸）をすべて削除（マスターのみが残る）
+DELETE FROM learning_courses
+WHERE cloned_from IS NOT NULL;
+
+-- 3. 新しい学習状態（State）テーブルの作成
+CREATE TABLE learning_states (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    course_id TEXT NOT NULL REFERENCES learning_courses(id) ON DELETE CASCADE,
+    progress_data JSONB DEFAULT '{}'::jsonb,  -- 進捗やテストのスコアなど
+    personal_graph JSONB DEFAULT '{}'::jsonb, -- AIが見つけた誤解や個別メモの差分
+    enrolled_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (user_id, course_id) -- 二重受講（増殖バグ）をDBレベルで完全ブロック
+);
+
+CREATE INDEX idx_learning_states_user ON learning_states(user_id);
+CREATE INDEX idx_learning_states_course ON learning_states(course_id);
+
+-- 4. 役割を終えた旧カラムの削除
+ALTER TABLE learning_courses DROP COLUMN cloned_from;
+
+COMMIT;


### PR DESCRIPTION
## Summary

This PR implements a fundamental architectural change to separate immutable course master data from per-user learning state, addressing Issue #133. Instead of cloning entire courses for each student, the system now maintains a single master course and stores user-specific data (misconceptions, progress) in a new `learning_states` table.

## Key Changes

### Database Schema
- **New `learning_states` table**: Stores per-user course state with `progress_data` and `personal_graph` (JSON columns for user-specific misconceptions and notes)
- **Removed `cloned_from` column**: No longer needed with the new architecture
- **Added `owner_id` column to `learning_courses`**: Distinguishes course creators from legacy `user_id` field
- **Migration 011**: Destructively migrates existing cloned courses to the new model, deleting all cloned course data and chat history

### Course Data Access (`services.py`)
- **`get_course_data()`**: Now merges master course data with user's personal graph at read time, with access control:
  - Course owners always have access
  - Non-owners must have a `learning_states` row (enrolled students)
- **`_overlay_personal_graph()`**: New helper that non-destructively overlays user-specific misconceptions onto the master course data
- **`get_course_master()`**: New function to retrieve raw master course without overlays
- **`get_course_owner()`**: New function to retrieve course owner ID
- **Learning state helpers**: New functions `get_learning_state()`, `ensure_learning_state()`, and `update_personal_graph()` for managing per-user state

### Misconception Detection
- **`detect_and_record_misconception()`**: Now writes to `learning_states.personal_graph` instead of modifying the master course
- **`calculate_progress()`**: Aggregates misconceptions from user's personal graph rather than master course data

### Course Enrollment (`routes/learning.py`)
- **`enroll_course()`**: Simplified to create a `learning_states` row instead of cloning the entire course
- **`list_courses()`**: Refactored to show:
  - Owned courses (for instructors)
  - Enrolled courses (from `learning_states`)
  - Available public templates (not yet enrolled)
- **`update_course()`**: Added owner verification; only course owners can edit the master

### Access Control
- Course deletion now checks both `owner_id` and legacy `user_id` fields
- Admin course deletion updated to respect new ownership model
- ON DELETE CASCADE ensures `learning_states` rows are cleaned up when courses are deleted

## Implementation Details

- **Non-destructive merging**: Course master data is deep-copied before overlaying personal graph to prevent accidental mutations
- **UNIQUE constraint**: `learning_states(user_id, course_id)` prevents duplicate enrollments at the database level
- **Backward compatibility**: Handles both `owner_id` and legacy `user_id` for course ownership during transition
- **JSON handling**: Robust handling of both dict and JSON string formats for JSONB columns
- **Timestamp tracking**: `learning_states` tracks `enrolled_at` and `updated_at` for audit purposes

https://claude.ai/code/session_013sw5XEWCvg1f8fZXhPepnj