### PR TITLE
Refactor course enrollment: replace cloning with learning_states

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -87,11 +87,11 @@ def _run_migrations() -> None:
         ))
 
         # A2: learning_courses への追加カラム
+        # NOTE: cloned_from カラムは Issue #133 (Migration 011) で廃止された。
         for ddl in [
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS is_template  BOOLEAN NOT NULL DEFAULT false",
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS is_published BOOLEAN NOT NULL DEFAULT false",
             "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS owner_id     UUID REFERENCES users(id)",
-            "ALTER TABLE learning_courses ADD COLUMN IF NOT EXISTS cloned_from  TEXT REFERENCES learning_courses(id)",
         ]:
             session.execute(sa_text(ddl))
         session.execute(sa_text(
@@ -336,8 +336,46 @@ def _run_migrations() -> None:
             "ON course_group_permissions(group_id, permission)"
         ))
 
+        # Migration 011: コース原本と学習状態の完全分離 (Issue #133)
+        # マスターコースとユーザーごとの学習状態を分離する。
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS learning_states (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                course_id TEXT NOT NULL REFERENCES learning_courses(id) ON DELETE CASCADE,
+                progress_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+                personal_graph JSONB NOT NULL DEFAULT '{}'::jsonb,
+                enrolled_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE (user_id, course_id)
+            )
+        """))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_learning_states_user ON learning_states(user_id)"
+        ))
+        session.execute(sa_text(
+            "CREATE INDEX IF NOT EXISTS idx_learning_states_course ON learning_states(course_id)"
+        ))
+        # 既存の cloned_from カラムがあれば、クローンコースとその履歴をハードリセット後にカラム廃止
+        session.execute(sa_text("""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'learning_courses' AND column_name = 'cloned_from'
+                ) THEN
+                    DELETE FROM learning_chat_history
+                    WHERE course_id IN (
+                        SELECT id FROM learning_courses WHERE cloned_from IS NOT NULL
+                    );
+                    DELETE FROM learning_courses WHERE cloned_from IS NOT NULL;
+                    ALTER TABLE learning_courses DROP COLUMN cloned_from;
+                END IF;
+            END $$
+        """))
+
         session.commit()
-        logger.info("Migrations (002-010) applied successfully.")
+        logger.info("Migrations (002-011) applied successfully.")
 
         # Seed builtin schema types/predicates
         from core.schema_registry import seed_builtin_schema

--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import uuid
 
@@ -24,7 +23,9 @@ from services import (
     calculate_progress,
     check_prerequisites,
     detect_and_record_misconception,
+    enroll_user_in_course,
     get_course_data,
+    get_editable_course_data,
     get_user_group_ids,
     log_unanswered_query,
     persist_chat_history,
@@ -106,10 +107,14 @@ def list_courses(
 ) -> list[LearningCourseOut]:
     """ユーザーが登録しているコース一覧を返す。
 
+    Issue #133: 「1 つの不変なマスターコース」+「ユーザー個別の learning_states」
+    モデルに変更。受講時にコースをクローンせず、learning_states にレコードを作る。
+
     以下を返す:
-    - 自分が所有するコース
-    - visibility='public' かつ公開テンプレートのコース（受講可能）
-    - visibility='group' かつ自分が参加するグループのコース（受講可能）
+    - 自分が所有するコース（learning_courses.user_id = 自分）
+    - 自分が受講済みのマスターコース（learning_states 経由）
+    - visibility='public' かつ公開テンプレートで未受講のコース（受講可能）
+    - 自分が参加するグループに共有されているマスターコースで未受講のもの（受講可能）
     """
     user_groups = get_user_group_ids(current_user["id"])
 
@@ -129,7 +134,24 @@ def list_courses(
             {"user_id": current_user["id"]},
         ).fetchall()
 
-        # 公開テンプレート
+        # 受講中のマスターコース（learning_states 経由）
+        enrolled_records = session.execute(
+            sa_text("""
+                SELECT lc.id, lc.title,
+                       COALESCE(lc.is_template, false) AS is_template,
+                       COALESCE(lc.is_published, false) AS is_published,
+                       COALESCE(lc.visibility, 'private') AS visibility,
+                       lc.group_id,
+                       COALESCE(lc.description, '') AS description
+                FROM learning_courses lc
+                JOIN learning_states ls ON ls.course_id = lc.id
+                WHERE ls.user_id = CAST(:user_id AS uuid)
+                  AND lc.user_id != CAST(:user_id AS uuid)
+            """),
+            {"user_id": current_user["id"]},
+        ).fetchall()
+
+        # 公開テンプレート（未受講のみ）
         public_records = session.execute(
             sa_text("""
                 SELECT lc.id, lc.title,
@@ -141,15 +163,15 @@ def list_courses(
                   AND COALESCE(lc.visibility, 'public') = 'public'
                   AND lc.user_id != CAST(:user_id AS uuid)
                   AND NOT EXISTS (
-                      SELECT 1 FROM learning_courses lc2
-                      WHERE lc2.user_id = CAST(:user_id AS uuid)
-                        AND lc2.cloned_from = lc.id
+                      SELECT 1 FROM learning_states ls
+                      WHERE ls.user_id = CAST(:user_id AS uuid)
+                        AND ls.course_id = lc.id
                   )
             """),
             {"user_id": current_user["id"]},
         ).fetchall()
 
-        # グループ共有コース（自分が参加するグループ）
+        # グループ共有コース（自分が参加するグループ、かつ未受講のみ）
         # - 旧: learning_courses.group_id + visibility='group' を参照
         # - 新: course_group_permissions 多対多マッピング (viewer/editor)
         if user_groups:
@@ -175,9 +197,9 @@ def list_courses(
                               AND cgp.permission IN ('viewer', 'editor'))
                       )
                       AND NOT EXISTS (
-                          SELECT 1 FROM learning_courses lc2
-                          WHERE lc2.user_id = CAST(:user_id AS uuid)
-                            AND lc2.cloned_from = lc.id
+                          SELECT 1 FROM learning_states ls
+                          WHERE ls.user_id = CAST(:user_id AS uuid)
+                            AND ls.course_id = lc.id
                       )
                 """),
                 params,
@@ -200,6 +222,20 @@ def list_courses(
         )
         for r in own_records
     ]
+    # 受講中のマスターコースも「マイコース」として並べる（is_enrollable=False）
+    courses.extend(
+        LearningCourseOut(
+            id=r[0],
+            title=r[1],
+            is_template=bool(r[2]),
+            is_published=bool(r[3]),
+            is_enrollable=False,
+            visibility=r[4] or "private",
+            group_id=str(r[5]) if r[5] else None,
+            description=r[6] or "",
+        )
+        for r in enrolled_records
+    )
     courses.extend(
         LearningCourseOut(
             id=r[0],
@@ -227,9 +263,8 @@ def list_courses(
         for r in group_records
     )
 
-    # visibility='public' のテンプレートに course_group_permissions が張られていると
-    # public_records と group_records の両方にヒットし、同じコースが二度出る。
-    # own > public > group の優先順位で先勝ちで重複排除する。
+    # 同一マスターコースが own / enrolled / public / group 経由で複数ヒットする場合は
+    # own > enrolled > public > group の優先順位で先勝ちで重複排除する。
     seen_ids: set[str] = set()
     unique_courses: list[LearningCourseOut] = []
     for c in courses:
@@ -259,8 +294,12 @@ def update_course(
     body: CourseUpdateRequest,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseDetail:
-    """コースを部分更新する。指定されたフィールドのみ上書き。"""
-    data = get_course_data(current_user["id"], course_id)
+    """コースを部分更新する。指定されたフィールドのみ上書き。
+
+    Issue #133: 受講者はマスターコースを改変できない（learning_states に個別の
+    差分を持つのみ）。所有者または editor 権限グループのメンバーのみ編集可能。
+    """
+    data = get_editable_course_data(current_user["id"], course_id)
     if not data:
         raise HTTPException(status_code=404, detail="Course not found")
 
@@ -323,12 +362,18 @@ def enroll_course(
     course_id: str,
     current_user: dict = Depends(_get_current_user),
 ) -> LearningCourseOut:
-    """受講可能なコース（公開/グループ共有）をクローンして自分のコースとして登録する。"""
+    """受講可能なコース（公開/グループ共有）に受講登録する。
+
+    Issue #133: 旧仕様ではマスターコースを丸ごとクローンしていたが、
+    learning_states にレコードを作成する方式に変更。マスターコースは
+    不変に保たれ、ユーザーの学習状態のみが差分として管理される。
+    UNIQUE (user_id, course_id) により二重受講はDBレベルでブロックされる。
+    """
     session = _pg_session()
     try:
         record = session.execute(
             sa_text("""
-                SELECT data, COALESCE(visibility, 'private'), group_id,
+                SELECT title, COALESCE(visibility, 'private'), group_id,
                        COALESCE(is_published, false), COALESCE(is_template, false)
                 FROM learning_courses
                 WHERE id = :course_id
@@ -339,10 +384,10 @@ def enroll_course(
     finally:
         session.close()
 
-    if not record or not record[0]:
+    if not record:
         raise HTTPException(status_code=404, detail="Course not found")
 
-    data_raw, visibility, group_id, is_published, is_template = record
+    title, visibility, group_id, is_published, is_template = record
     enrollable = False
     if visibility == "public" and is_published and is_template:
         enrollable = True
@@ -357,32 +402,13 @@ def enroll_course(
     if not enrollable:
         raise HTTPException(status_code=403, detail="このコースを受講する権限がありません")
 
-    template_data = data_raw if isinstance(data_raw, dict) else json.loads(data_raw)
-
-    new_course_id = str(uuid.uuid4())[:8]
-    cloned_data = dict(template_data)
-    cloned_data["id"] = new_course_id
-
-    save_course_data(current_user["id"], new_course_id, cloned_data)
-
-    session = _pg_session()
-    try:
-        session.execute(
-            sa_text("UPDATE learning_courses SET cloned_from = :original_id WHERE id = :id"),
-            {"id": new_course_id, "original_id": course_id},
-        )
-        session.commit()
-    except Exception:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+    enroll_user_in_course(current_user["id"], course_id)
 
     logger.info(
-        "User=%s enrolled in course %s (cloned as %s)",
-        current_user["id"], course_id, new_course_id,
+        "User=%s enrolled in master course %s (learning_states row created)",
+        current_user["id"], course_id,
     )
-    return LearningCourseOut(id=new_course_id, title=cloned_data.get("title", ""))
+    return LearningCourseOut(id=course_id, title=title or "")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -132,22 +132,155 @@ def get_background_task(task_id: str) -> dict | None:
 
 
 def get_course_data(user_id: str, course_id: str) -> dict | None:
-    """PostgreSQL から LearningCourse データを取得する（オーナー限定）。"""
+    """LearningCourse データを取得する（オーナー or 受講者）。
+
+    Issue #133: 受講時のクローン作成を廃止し、「1 つの不変なマスターコース」 +
+    「ユーザーごとの学習状態（learning_states）」の構成に変更。
+    - オーナー本人はそのままマスターデータを返す。
+    - 受講者（learning_states に行がある）はマスターデータに
+      personal_graph の差分（誤解など）をマージして返す。
+    - それ以外は None を返す（アクセス不可）。
+    """
     session = _pg_session()
     try:
         record = session.execute(
             sa_text("""
-                SELECT data FROM learning_courses
-                WHERE user_id = CAST(:user_id AS uuid) AND id = :course_id
+                SELECT data, user_id FROM learning_courses
+                WHERE id = :course_id
+                LIMIT 1
+            """),
+            {"course_id": course_id},
+        ).fetchone()
+        if not record or not record[0]:
+            return None
+
+        data = record[0] if isinstance(record[0], dict) else json.loads(record[0])
+        owner_id = record[1]
+
+        if str(owner_id) == str(user_id):
+            return data
+
+        # 受講者: learning_states.personal_graph をマージする
+        state_row = session.execute(
+            sa_text("""
+                SELECT personal_graph FROM learning_states
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
                 LIMIT 1
             """),
             {"user_id": user_id, "course_id": course_id},
         ).fetchone()
-        if record and record[0]:
-            return record[0] if isinstance(record[0], dict) else json.loads(record[0])
+        if not state_row:
+            return None
+
+        personal_raw = state_row[0] if state_row[0] is not None else {}
+        personal = personal_raw if isinstance(personal_raw, dict) else json.loads(personal_raw)
+        misconceptions_by_topic = personal.get("misconceptions_by_topic", {}) or {}
+        for topic in data.get("topics", []):
+            tid = topic.get("id", "")
+            per_topic = misconceptions_by_topic.get(tid, [])
+            if per_topic:
+                base = topic.get("misconceptions", []) or []
+                topic["misconceptions"] = (per_topic + base)[:5]
+        return data
     finally:
         session.close()
-    return None
+
+
+def user_is_enrolled(user_id: str, course_id: str) -> bool:
+    """ユーザーが learning_states を通じてコースに受講登録済みかを判定する。"""
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT 1 FROM learning_states
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                LIMIT 1
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        ).fetchone()
+        return row is not None
+    finally:
+        session.close()
+
+
+def enroll_user_in_course(user_id: str, course_id: str) -> None:
+    """learning_states に受講レコードを作成する（UNIQUE で二重受講を防止）。"""
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO learning_states (user_id, course_id)
+                VALUES (CAST(:user_id AS uuid), :course_id)
+                ON CONFLICT (user_id, course_id) DO NOTHING
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def record_personal_misconception(
+    user_id: str,
+    course_id: str,
+    topic_id: str,
+    misconception: dict,
+) -> None:
+    """learning_states.personal_graph.misconceptions_by_topic に誤解を記録する。
+
+    受講者が学習チャットで検出した誤解は、マスターコースではなくこの per-user 状態に保存する。
+    per-topic で最新 5 件まで保持する（マスターの misconceptions と同じ上限）。
+    未受講の場合はレコードを自動生成してから書き込む（オーナーが自コースで学習する場合など）。
+    """
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text("""
+                INSERT INTO learning_states (user_id, course_id)
+                VALUES (CAST(:user_id AS uuid), :course_id)
+                ON CONFLICT (user_id, course_id) DO NOTHING
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        )
+        row = session.execute(
+            sa_text("""
+                SELECT personal_graph FROM learning_states
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                LIMIT 1
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        ).fetchone()
+
+        personal_raw = row[0] if row and row[0] is not None else {}
+        personal = personal_raw if isinstance(personal_raw, dict) else json.loads(personal_raw)
+        by_topic = personal.get("misconceptions_by_topic", {}) or {}
+        current = by_topic.get(topic_id, []) or []
+        current = [misconception] + current
+        by_topic[topic_id] = current[:5]
+        personal["misconceptions_by_topic"] = by_topic
+
+        session.execute(
+            sa_text("""
+                UPDATE learning_states
+                SET personal_graph = CAST(:personal AS jsonb),
+                    updated_at = now()
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+            """),
+            {
+                "user_id": user_id,
+                "course_id": course_id,
+                "personal": json.dumps(personal, ensure_ascii=False),
+            },
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def _fetch_course_data_row(course_id: str) -> dict | None:
@@ -847,7 +980,11 @@ def detect_and_record_misconception(
     user_message: str,
     ai_response: str,
 ) -> dict | None:
-    """AI応答から誤解を検出し、コースデータに記録する。"""
+    """AI応答から誤解を検出し、ユーザー個別の learning_states.personal_graph に記録する。
+
+    Issue #133: マスターコースは不変に保ち、誤解はユーザーごとの learning_states に保存する。
+    レスポンス用にはマージ済みの topics をコピーして返す。
+    """
     wrong = user_message
     if len(wrong) > 60:
         wrong = wrong[:60] + "…"
@@ -870,18 +1007,24 @@ def detect_and_record_misconception(
         "correct": correct,
     }
 
-    for t in course_data.get("topics", []):
+    try:
+        record_personal_misconception(user_id, course_id, topic_id, misconception)
+    except Exception:
+        logger.exception(
+            "Failed to record misconception to learning_states for user=%s course=%s",
+            user_id, course_id,
+        )
+
+    # UI 更新用レスポンス: course_data をコピーして当該 topic に今回の誤解を混ぜる
+    updated_topics = [dict(t) for t in course_data.get("topics", [])]
+    for t in updated_topics:
         if t.get("id") == topic_id:
-            if "misconceptions" not in t:
-                t["misconceptions"] = []
-            t["misconceptions"].insert(0, misconception)
-            t["misconceptions"] = t["misconceptions"][:5]
+            merged = [misconception] + list(t.get("misconceptions", []) or [])
+            t["misconceptions"] = merged[:5]
             break
 
-    save_course_data(user_id, course_id, course_data)
-
     return {
-        "topics": course_data.get("topics", []),
+        "topics": updated_topics,
         "concepts": course_data.get("concepts", []),
     }
 

--- a/backend/db/011_course_states_separation.sql
+++ b/backend/db/011_course_states_separation.sql
@@ -1,0 +1,40 @@
+-- Migration 011: コース原本と学習状態（State）の完全分離 (Issue #133)
+--
+-- 従来、受講（Enroll）時に learning_courses を丸ごとクローンしていたが、以下の
+-- 技術的負債を生んでいたため、「1つの不変なマスターコース」に対し「ユーザーの
+-- 学習状態（差分データ）」を learning_states で紐づける構造に刷新する。
+--   1. マスター更新がクローンに反映されない（陳腐化）
+--   2. マスターが削除されてもクローンが残る（ゴーストデータ）
+--   3. UI 操作等で同一マスターから複数クローンが生成される（増殖バグ）
+--
+-- ※ 既存のクローンデータ（学習状態）はすべてハードリセット（削除）する。
+
+BEGIN;
+
+-- 1. 既存のクローンに紐づくチャット履歴をすべて削除
+DELETE FROM learning_chat_history
+WHERE course_id IN (SELECT id FROM learning_courses WHERE cloned_from IS NOT NULL);
+
+-- 2. 既存のクローンコース（学習状態の残骸）をすべて削除（マスターのみが残る）
+DELETE FROM learning_courses
+WHERE cloned_from IS NOT NULL;
+
+-- 3. 新しい学習状態（State）テーブルの作成
+CREATE TABLE IF NOT EXISTS learning_states (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    course_id TEXT NOT NULL REFERENCES learning_courses(id) ON DELETE CASCADE,
+    progress_data JSONB NOT NULL DEFAULT '{}'::jsonb,   -- 進捗やテストのスコアなど
+    personal_graph JSONB NOT NULL DEFAULT '{}'::jsonb,  -- AIが見つけた誤解や個別メモの差分
+    enrolled_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, course_id)  -- 二重受講（増殖バグ）をDBレベルで完全ブロック
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_states_user ON learning_states(user_id);
+CREATE INDEX IF NOT EXISTS idx_learning_states_course ON learning_states(course_id);
+
+-- 4. 役割を終えた旧カラムの削除
+ALTER TABLE learning_courses DROP COLUMN IF EXISTS cloned_from;
+
+COMMIT;

--- a/backend/tests/test_issue_131_group_shared_courses.py
+++ b/backend/tests/test_issue_131_group_shared_courses.py
@@ -51,14 +51,18 @@ class TestListCoursesSharedViaPermissions:
             "ユーザーの所属グループを利用してフィルタしていない"
         )
 
-    def test_excludes_already_cloned_templates(self):
-        """既にクローン済みのテンプレートは再度出さない。"""
+    def test_excludes_already_enrolled_templates(self):
+        """既に受講済みのテンプレートは再度出さない。
+
+        Issue #133 でクローン方式から learning_states 方式へ移行したため、
+        既受講かどうかは learning_states のレコード存在で判定する。
+        """
         body = self._list_courses_body()
         assert re.search(
-            r"NOT\s+EXISTS\s*\(.*?cloned_from\s*=\s*lc\.id",
+            r"NOT\s+EXISTS\s*\(.*?FROM\s+learning_states\s+ls.*?ls\.course_id\s*=\s*lc\.id",
             body,
             re.DOTALL,
-        ), "既にクローン済みコースを除外する NOT EXISTS 句が見当たらない"
+        ), "既受講コースを除外する learning_states の NOT EXISTS 句が見当たらない"
 
     def test_deduplicates_by_course_id(self):
         """visibility='public' のテンプレートが course_group_permissions に


### PR DESCRIPTION
## Summary

This PR implements Issue #133, replacing the course cloning model with a unified master course + per-user learning state architecture. Previously, when users enrolled in a course, the entire course was cloned into their account. Now, a single immutable master course is shared, and each user's learning progress and personal misconceptions are tracked separately in a new `learning_states` table.

## Key Changes

### Database Schema
- **New table `learning_states`**: Tracks per-user enrollment and learning state
  - `user_id`, `course_id`: Composite unique key prevents duplicate enrollments at DB level
  - `progress_data`: User's progress, test scores, etc.
  - `personal_graph`: User-specific misconceptions and notes detected during learning
  - Indexes on `user_id` and `course_id` for efficient queries
- **Removed `cloned_from` column** from `learning_courses` (Migration 011)
- **Data cleanup**: All existing cloned courses and their chat histories are deleted during migration

### Service Layer (`backend/api/services.py`)
- **`get_course_data()`**: Now returns master course data to owner, or master data merged with user's personal misconceptions for enrolled learners
- **`user_is_enrolled()`**: New helper to check if user has a `learning_states` record
- **`enroll_user_in_course()`**: Creates a `learning_states` record instead of cloning; `ON CONFLICT DO NOTHING` prevents duplicates
- **`record_personal_misconception()`**: Records detected misconceptions in user's `personal_graph` instead of modifying master course; auto-creates `learning_states` record if needed
- **`detect_and_record_misconception()`**: Updated to write to `learning_states` and return merged topics for UI without persisting to master course

### Routes (`backend/api/routes/learning.py`)
- **`list_courses()`**: 
  - Now queries `learning_states` to find enrolled courses instead of checking `cloned_from`
  - Includes enrolled master courses in results with `is_enrollable=False`
  - Deduplicates by course ID with priority: own > enrolled > public > group
- **`update_course()`**: Uses new `get_editable_course_data()` to enforce that only owners/editors can modify master courses
- **`enroll_course()`**: 
  - Calls `enroll_user_in_course()` to create `learning_states` record
  - No longer clones course data or generates new course IDs
  - Returns original master course ID

### Migration
- **Migration 011** (`backend/db/011_course_states_separation.sql` and inline in `main.py`):
  - Deletes all cloned courses and associated chat history
  - Creates `learning_states` table with proper indexes
  - Drops `cloned_from` column from `learning_courses`

## Notable Implementation Details

- **Master course immutability**: Only course owner or group editors can modify the master; learners cannot change it
- **Misconception merging**: When returning course data to learners, personal misconceptions from `learning_states.personal_graph` are merged with master misconceptions (up to 5 per topic)
- **Automatic enrollment**: `record_personal_misconception()` auto-creates a `learning_states` record if the user hasn't explicitly enrolled (e.g., owner learning their own course)
- **UI response handling**: `detect_and_record_misconception()` returns a copy of course data with the new misconception merged in, without persisting changes to the master
- **Backward compatibility**: Tests updated to verify `learning_states` queries instead of `cloned_from` checks

https://claude.ai/code/session_0156L9VPkwxdzn7DCZLC7sic