### PR TITLE
Implement auto-chaining pipeline for script and audio generation (Issue #139)

### DIFF
--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -187,6 +187,8 @@ def _batch_generate_worker(
                 )
                 session.commit()
                 generated += 1
+                # レート制限対策: 生成チャンク間に短い待機を挟む
+                time.sleep(1.5)
 
             # チャンクごとに進捗を更新
             processed = generated + skipped

--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -32,8 +32,10 @@ from schemas import (
     LectureScriptSaveRequest,
     LectureScriptSaveResponse,
 )
+from schemas import BackgroundTaskOut
 from services import (
     create_background_task,
+    get_active_task_for_course,
     get_course_data,
     get_editable_course_data,
     get_viewable_course_data,
@@ -133,8 +135,14 @@ def _batch_generate_worker(
     chunks: list[dict],
     override: bool,
     course_data: dict,
+    auto_audio: bool = False,
+    user_id: str | None = None,
 ) -> None:
-    """バックグラウンドスレッドでスクリプトを一括生成する。"""
+    """バックグラウンドスレッドでスクリプトを一括生成する。
+
+    auto_audio=True の場合、完了後に音声生成タスクを自動的にキックし、
+    結果データの ``next_task_id`` に新タスクIDを格納する (Issue #139)。
+    """
     total = len(chunks)
     generated = 0
     skipped = 0
@@ -199,13 +207,38 @@ def _batch_generate_worker(
     finally:
         session.close()
 
-    update_background_task(task_id, "completed", result_data={
+    # 自動パイプライン: 完了時に音声生成タスクをチェイン (Issue #139)
+    next_task_id: str | None = None
+    if auto_audio:
+        try:
+            fresh_chunks = _get_course_chunks(course_data)
+            audio_task_id = str(uuid.uuid4())[:12]
+            create_background_task(audio_task_id, "audio_generation", user_id)
+            threading.Thread(
+                target=_batch_audio_worker,
+                args=(audio_task_id, course_id, fresh_chunks),
+                daemon=True,
+            ).start()
+            next_task_id = audio_task_id
+            logger.info(
+                "auto_audio chain: script task=%s -> audio task=%s (course=%s)",
+                task_id, audio_task_id, course_id,
+            )
+        except Exception:
+            logger.exception("Failed to auto-chain audio task after script task %s", task_id)
+
+    completion_data = {
         "course_id": course_id,
         "total_chunks": total,
         "generated": generated,
         "skipped": skipped,
         "progress": 100,
-    })
+    }
+    if next_task_id:
+        completion_data["next_task_id"] = next_task_id
+        completion_data["next_task_type"] = "audio_generation"
+
+    update_background_task(task_id, "completed", result_data=completion_data)
     logger.info(
         "batch_generate_worker completed: task=%s course=%s generated=%d skipped=%d",
         task_id, course_id, generated, skipped,
@@ -247,14 +280,22 @@ def batch_generate_scripts(
 
     thread = threading.Thread(
         target=_batch_generate_worker,
-        args=(task_id, course_id, chunks, body.override, course_data),
+        args=(
+            task_id,
+            course_id,
+            chunks,
+            body.override,
+            course_data,
+            body.auto_audio,
+            current_user["id"],
+        ),
         daemon=True,
     )
     thread.start()
 
     logger.info(
-        "batch_generate_scripts accepted: task=%s course=%s chunks=%d by user=%s",
-        task_id, course_id, len(chunks), current_user["id"],
+        "batch_generate_scripts accepted: task=%s course=%s chunks=%d auto_audio=%s by user=%s",
+        task_id, course_id, len(chunks), body.auto_audio, current_user["id"],
     )
 
     return LectureScriptGenerateStartResponse(
@@ -676,3 +717,28 @@ def batch_generate_audio(
         total_chunks=len(chunks),
         status="pending",
     )
+
+
+# ---------------------------------------------------------------------------
+# 5. コース単位のアクティブタスク照会 (Issue #139)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/courses/{course_id}/tasks/active")
+def get_course_active_task(
+    course_id: str,
+    current_user: dict = Depends(_require_teacher),
+) -> dict | None:
+    """コースに紐づく進行中タスク (pending/processing) のうち最新1件を返す。
+
+    重複実行防止およびリロード後のポーリング再開に使用する。
+    進行中タスクが無い場合は null を返す。
+    """
+    course_data = get_viewable_course_data(current_user["id"], course_id)
+    if not course_data:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    task = get_active_task_for_course(course_id)
+    if not task:
+        return None
+    return BackgroundTaskOut(**task).model_dump()

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -436,6 +436,7 @@ class LectureScriptChunkOut(BaseModel):
 class LectureScriptGenerateRequest(BaseModel):
     """バッチスクリプト生成リクエスト。"""
     override: bool = False  # 既存スクリプトを上書きするか
+    auto_audio: bool = False  # スクリプト生成完了後、自動で音声生成タスクを起動するか (Issue #139)
 
 
 class LectureScriptGenerateStartResponse(BaseModel):

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -126,6 +126,37 @@ def get_background_task(task_id: str) -> dict | None:
     finally:
         session.close()
 
+
+def get_active_task_for_course(course_id: str) -> dict | None:
+    """指定コースに紐づく進行中 (pending/processing) タスクを最新1件返す (Issue #139)。"""
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT id, task_type, status, result_data, error_message, created_at, updated_at
+                FROM background_tasks
+                WHERE status IN ('pending', 'processing')
+                  AND result_data IS NOT NULL
+                  AND result_data->>'course_id' = :course_id
+                ORDER BY created_at DESC
+                LIMIT 1
+            """),
+            {"course_id": course_id},
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "task_id": row[0],
+            "task_type": row[1],
+            "status": row[2],
+            "result_data": row[3],
+            "error_message": row[4],
+            "created_at": row[5].isoformat() if row[5] else "",
+            "updated_at": row[6].isoformat() if row[6] else "",
+        }
+    finally:
+        session.close()
+
 # ---------------------------------------------------------------------------
 # Course CRUD helpers
 # ---------------------------------------------------------------------------

--- a/backend/core/lecture.py
+++ b/backend/core/lecture.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 
 from core.llm import generate_text, get_llm_params
 
@@ -79,6 +80,14 @@ _SPOKEN_TEXT_PROMPT = """あなたは大学院レベルの学習を支援する�
 _FORMULA_REQUIRED_KEYS = {"latex", "spoken", "is_display"}
 _MAX_LLM_ATTEMPTS = 3
 _LATEX_EXTRACTION_ERROR = "[LaTeX extraction error: manual completion required]"
+# 429 / ResourceExhausted 時のリトライ待機秒数 (指数バックオフ)
+_RATE_LIMIT_BACKOFF_SECONDS = [30, 90]
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """例外が API レート制限 (429/ResourceExhausted) かどうかを判定する。"""
+    s = str(exc).lower()
+    return "429" in s or "resource exhausted" in s or "resource_exhausted" in s
 
 
 def _parse_spoken_text_response(raw: str) -> dict:
@@ -183,10 +192,19 @@ def generate_spoken_text_and_formulas(
             )
         except Exception as exc:
             last_exc = exc
-            logger.warning(
-                "spoken_text generation attempt %d/%d failed: %s",
-                attempt, _MAX_LLM_ATTEMPTS, exc, exc_info=True,
-            )
+            if _is_rate_limit_error(exc) and attempt < _MAX_LLM_ATTEMPTS:
+                wait_sec = _RATE_LIMIT_BACKOFF_SECONDS[attempt - 1]
+                logger.warning(
+                    "spoken_text generation attempt %d/%d rate-limited (429). "
+                    "Waiting %ds before retry. chunk_index=%d",
+                    attempt, _MAX_LLM_ATTEMPTS, wait_sec, chunk_index,
+                )
+                time.sleep(wait_sec)
+            else:
+                logger.warning(
+                    "spoken_text generation attempt %d/%d failed: %s",
+                    attempt, _MAX_LLM_ATTEMPTS, exc, exc_info=True,
+                )
 
     logger.error(
         "spoken_text generation failed after %d attempts, using fallback. Last error: %s",

--- a/backend/tests/test_lecture_studio.py
+++ b/backend/tests/test_lecture_studio.py
@@ -58,6 +58,21 @@ class TestLectureStudioSchemas:
         req = LectureScriptGenerateRequest(override=True)
         assert req.override is True
 
+    def test_lecture_script_generate_request_auto_audio_default(self):
+        """Issue #139: auto_audio デフォルトは False。"""
+        from schemas import LectureScriptGenerateRequest
+
+        req = LectureScriptGenerateRequest()
+        assert req.auto_audio is False
+
+    def test_lecture_script_generate_request_auto_audio_true(self):
+        """Issue #139: auto_audio=True でパイプライン連鎖モードを指定可能。"""
+        from schemas import LectureScriptGenerateRequest
+
+        req = LectureScriptGenerateRequest(override=True, auto_audio=True)
+        assert req.auto_audio is True
+        assert req.override is True
+
     def test_lecture_script_generate_response(self):
         from schemas import LectureScriptGenerateResponse
 

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -935,12 +935,127 @@
           content: "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + data.id + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。",
         });
         renderCourseChat();
+
+        // Issue #139: 登録成功後、自動で原稿・音声生成パイプラインをキックする
+        if (data && data.id) {
+          kickAutoPipeline(data.id, data.title || draft.title);
+        }
       })
       .catch(function () {
         btn.disabled = false;
         btn.textContent = "承認してコースを登録";
         showUploadStatus("コースの登録に失敗しました。", "error");
       });
+  }
+
+  // ── Auto Pipeline (Issue #139) ─────────────────────────────────────
+  // コース登録直後に原稿→音声を連鎖的に自動生成し、進捗をチャットに通知する。
+  function kickAutoPipeline(courseId, courseTitle) {
+    var pipelineMsg = {
+      role: "assistant",
+      content: "コース登録完了。引き続き原稿と音声の自動生成を開始しました。（進捗: 0%）",
+    };
+    state.chatMessages.push(pipelineMsg);
+    renderCourseChat();
+
+    function setPipelineStatus(text) {
+      pipelineMsg.content = text;
+      renderCourseChat();
+    }
+
+    apiFetch("/admin/courses/" + courseId + "/lecture-scripts/generate", {
+      method: "POST",
+      body: JSON.stringify({ override: false, auto_audio: true }),
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          return res.json().then(function (errBody) {
+            var msg = (errBody && errBody.detail) || "原稿生成を開始できませんでした";
+            throw new Error(msg);
+          }, function () {
+            throw new Error("原稿生成を開始できませんでした");
+          });
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        var scriptTaskId = data.task_id;
+        var totalChunks = data.total_chunks || 0;
+        setPipelineStatus(
+          "コース「" + courseTitle + "」の原稿生成を開始しました。（0 / " + totalChunks + " チャンク）"
+        );
+        _pollPipelineTask(courseId, scriptTaskId, "script", totalChunks, setPipelineStatus);
+      })
+      .catch(function (err) {
+        setPipelineStatus(
+          "コース登録は完了しましたが、原稿生成の開始に失敗しました: " +
+          (err.message || "不明なエラー") +
+          "\n\n「Lecture Studio」タブから手動で実行してください。"
+        );
+      });
+  }
+
+  function _pollPipelineTask(courseId, taskId, phase, totalChunks, setStatus) {
+    var retryCount = 0;
+    var maxRetries = 5;
+    var intervalMs = 3000;
+    var phaseLabel = phase === "audio" ? "音声生成" : "原稿生成";
+
+    function poll() {
+      apiFetch("/admin/tasks/" + taskId)
+        .then(function (res) {
+          if (!res.ok) throw new Error("Status check failed");
+          return res.json();
+        })
+        .then(function (task) {
+          retryCount = 0;
+          var rd = task.result_data || {};
+          var progress = rd.progress || 0;
+          var generated = rd.generated || 0;
+          var skipped = rd.skipped || 0;
+          var errors = rd.errors || 0;
+          var processed = generated + skipped + errors;
+
+          if (task.status === "completed") {
+            clearInterval(timer);
+            if (phase === "script" && rd.next_task_id) {
+              // チェイン先の音声タスクに移行
+              setStatus(
+                "原稿生成完了（" + generated + "件生成 / " + skipped + "件スキップ）。音声生成を開始しました。（進捗: 0%）"
+              );
+              _pollPipelineTask(courseId, rd.next_task_id, "audio", totalChunks, setStatus);
+            } else {
+              setStatus(
+                "自動生成が完了しました。" + phaseLabel + ": " + generated + "件生成 / " +
+                skipped + "件スキップ" + (errors > 0 ? " / " + errors + "件エラー" : "") +
+                "\n\nLecture Studio タブから内容を確認できます。"
+              );
+            }
+          } else if (task.status === "failed") {
+            clearInterval(timer);
+            setStatus(
+              phaseLabel + "に失敗しました: " + (task.error_message || "不明なエラー") +
+              "\n\nLecture Studio タブから手動で再実行してください。"
+            );
+          } else {
+            setStatus(
+              phaseLabel + "中... (" + processed + " / " + totalChunks + " — " + progress + "%)"
+            );
+          }
+        })
+        .catch(function () {
+          retryCount++;
+          if (retryCount >= maxRetries) {
+            clearInterval(timer);
+            setStatus(
+              phaseLabel + "の進捗確認に失敗しました。Lecture Studio タブで最新の状態を確認してください。"
+            );
+          }
+        });
+    }
+
+    var timer = setInterval(poll, intervalMs);
+    poll();
   }
 
   // ── Course Import (Issue #50) ───────────────────────────────────────
@@ -1984,10 +2099,50 @@
         lsState.selectedChunkId = null;
         lsRenderChunkList();
         lsClearEditor();
+        // Issue #139: 進行中タスクがあればポーリング状態に復帰
+        lsCheckActiveTask(courseId);
       })
       .catch(function () {
         listEl.innerHTML = '<div style="padding:16px;color:var(--color-text-danger);font-size:13px">読み込みに失敗しました</div>';
       });
+  }
+
+  // Issue #139: コースに進行中のタスクがあれば、ボタンを無効化しポーリングを復帰させる
+  function lsCheckActiveTask(courseId) {
+    apiFetch("/admin/courses/" + courseId + "/tasks/active")
+      .then(function (res) {
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then(function (task) {
+        if (!task || !task.task_id) return;
+        // コース選択が切り替わっていたら無視
+        if (lsState.courseId !== courseId) return;
+
+        var rd = task.result_data || {};
+        var totalChunks = rd.total_chunks || 0;
+
+        if (task.task_type === "audio_generation") {
+          lsState.generating = true;
+          document.getElementById("ls-generate-all-btn").disabled = true;
+          document.getElementById("ls-audio-all-btn").disabled = true;
+          lsShowProgress(
+            "音声生成が進行中です... (進捗: " + (rd.progress || 0) + "%)",
+            "info"
+          );
+          _lsPollAudioTask(task.task_id, totalChunks);
+        } else if (task.task_type === "script_generation") {
+          lsState.generating = true;
+          document.getElementById("ls-generate-all-btn").disabled = true;
+          document.getElementById("ls-audio-all-btn").disabled = true;
+          lsShowProgress(
+            "スクリプト生成が進行中です... (進捗: " + (rd.progress || 0) + "%)",
+            "info"
+          );
+          _lsPollGenerateTask(task.task_id, totalChunks);
+        }
+      })
+      .catch(function () { /* ignore */ });
   }
 
   function lsRenderChunkList() {
@@ -2004,8 +2159,11 @@
       return;
     }
 
-    generateAllBtn.disabled = false;
-    audioAllBtn.disabled = false;
+    // Issue #139: 進行中タスクがある場合はボタン有効化を抑制（呼び出し側で制御）
+    if (!lsState.generating) {
+      generateAllBtn.disabled = false;
+      audioAllBtn.disabled = false;
+    }
     var html = "";
     lsState.chunks.forEach(function (c, i) {
       var active = c.chunk_id === lsState.selectedChunkId ? " active" : "";
@@ -2117,6 +2275,7 @@
   function lsBatchGenerate() {
     lsState.generating = true;
     document.getElementById("ls-generate-all-btn").disabled = true;
+    document.getElementById("ls-audio-all-btn").disabled = true;
     lsShowProgress("スクリプト生成を開始しています...", "info");
 
     apiFetch("/admin/courses/" + lsState.courseId + "/lecture-scripts/generate", {
@@ -2144,6 +2303,7 @@
         lsShowProgress("生成に失敗しました: " + (err.message || "不明なエラー"), "error");
         lsState.generating = false;
         document.getElementById("ls-generate-all-btn").disabled = false;
+        document.getElementById("ls-audio-all-btn").disabled = false;
       });
   }
 
@@ -2169,18 +2329,42 @@
 
           if (task.status === "completed") {
             clearInterval(timer);
+            // Issue #139: 自動パイプラインの場合は音声タスクへチェイン
+            if (rd.next_task_id) {
+              lsShowProgress(
+                "原稿生成完了 (" + generated + "件生成 / " + skipped + "件スキップ)。続いて音声生成を開始します...",
+                "info"
+              );
+              // チャンクリストを更新（spoken_text が埋まった状態を反映）
+              apiFetch("/admin/courses/" + lsState.courseId + "/lecture-scripts")
+                .then(function (res) { return res.ok ? res.json() : []; })
+                .then(function (chunks) {
+                  if (lsState.courseId) {
+                    lsState.chunks = chunks;
+                    lsRenderChunkList();
+                    // ボタンは音声生成中のため再度無効化
+                    document.getElementById("ls-generate-all-btn").disabled = true;
+                    document.getElementById("ls-audio-all-btn").disabled = true;
+                  }
+                })
+                .catch(function () {});
+              _lsPollAudioTask(rd.next_task_id, totalChunks);
+              return;
+            }
             lsShowProgress(
               "生成完了: " + generated + "件生成 / " + skipped + "件スキップ (全" + totalChunks + "件)",
               "success"
             );
             lsState.generating = false;
             document.getElementById("ls-generate-all-btn").disabled = false;
+            document.getElementById("ls-audio-all-btn").disabled = false;
             lsLoadScripts(lsState.courseId);
           } else if (task.status === "failed") {
             clearInterval(timer);
             lsShowProgress("生成に失敗しました: " + (task.error_message || "不明なエラー"), "error");
             lsState.generating = false;
             document.getElementById("ls-generate-all-btn").disabled = false;
+            document.getElementById("ls-audio-all-btn").disabled = false;
           } else {
             // pending / processing
             lsShowProgress(
@@ -2196,6 +2380,7 @@
             lsShowProgress("進捗確認に失敗しました。ページをリロードして状況を確認してください。", "error");
             lsState.generating = false;
             document.getElementById("ls-generate-all-btn").disabled = false;
+            document.getElementById("ls-audio-all-btn").disabled = false;
           }
         });
     }
@@ -2206,6 +2391,7 @@
 
   function lsBatchAudio() {
     lsState.generating = true;
+    document.getElementById("ls-generate-all-btn").disabled = true;
     document.getElementById("ls-audio-all-btn").disabled = true;
     lsShowProgress("音声生成を開始しています...", "info");
 
@@ -2233,6 +2419,7 @@
       .catch(function (err) {
         lsShowProgress("音声生成に失敗しました: " + (err.message || "不明なエラー"), "error");
         lsState.generating = false;
+        document.getElementById("ls-generate-all-btn").disabled = false;
         document.getElementById("ls-audio-all-btn").disabled = false;
       });
   }
@@ -2267,12 +2454,14 @@
               errors > 0 ? "error" : "success"
             );
             lsState.generating = false;
+            document.getElementById("ls-generate-all-btn").disabled = false;
             document.getElementById("ls-audio-all-btn").disabled = false;
             lsLoadScripts(lsState.courseId);
           } else if (task.status === "failed") {
             clearInterval(timer);
             lsShowProgress("音声生成に失敗しました: " + (task.error_message || "不明なエラー"), "error");
             lsState.generating = false;
+            document.getElementById("ls-generate-all-btn").disabled = false;
             document.getElementById("ls-audio-all-btn").disabled = false;
           } else {
             // pending / processing
@@ -2288,6 +2477,7 @@
             clearInterval(timer);
             lsShowProgress("進捗確認に失敗しました。ページをリロードして状況を確認してください。", "error");
             lsState.generating = false;
+            document.getElementById("ls-generate-all-btn").disabled = false;
             document.getElementById("ls-audio-all-btn").disabled = false;
           }
         });


### PR DESCRIPTION
## Summary
Implements an automatic pipeline that chains script generation directly to audio generation upon course registration, with real-time progress tracking in the chat interface and recovery of in-progress tasks on page reload.

## Key Changes

### Frontend (admin.js)
- **Auto-pipeline on course registration**: After successful course creation, automatically triggers script generation with `auto_audio=true` flag to enable chaining to audio generation
- **Pipeline progress tracking**: New `kickAutoPipeline()` function initiates the generation chain and displays real-time progress in the course chat
- **Task polling**: New `_pollPipelineTask()` function polls task status and handles transitions between script and audio generation phases
- **Active task recovery**: New `lsCheckActiveTask()` function detects in-progress tasks when loading the Lecture Studio tab and resumes polling to prevent duplicate execution
- **Button state management**: Ensures both "Generate All" and "Audio All" buttons are properly disabled during generation and re-enabled on completion/failure
- **Chained generation in Lecture Studio**: Modified `_lsPollGenerateTask()` to detect `next_task_id` and automatically transition to audio generation polling

### Backend (lecture_studio.py)
- **Auto-audio parameter**: Extended `batch_generate_scripts()` to accept `auto_audio` flag from request body
- **Pipeline chaining logic**: Modified `_batch_generate_worker()` to automatically create and start an audio generation task upon script completion when `auto_audio=True`
- **Task linking**: Completion result includes `next_task_id` and `next_task_type` to inform frontend of the chained task
- **Active task endpoint**: New `GET /courses/{course_id}/tasks/active` endpoint returns the most recent pending/processing task for a course (used for recovery on page reload)

### Backend (services.py)
- **Active task query**: New `get_active_task_for_course()` function queries the database for in-progress tasks linked to a specific course

### Backend (schemas.py)
- **Request schema update**: Added `auto_audio: bool = False` field to `LectureScriptGenerateRequest` to control pipeline chaining

### Tests (test_lecture_studio.py)
- Added test cases for `auto_audio` parameter default and explicit True value

## Implementation Details
- Uses UUID-based task IDs for reliable task tracking
- Polling interval: 3 seconds with 5-retry limit for robustness
- Progress messages include chunk counts and percentages for user visibility
- Graceful fallback to manual execution if auto-pipeline fails
- Task state persists in database, allowing recovery after page reload
- Both script and audio generation buttons are disabled during any generation phase to prevent concurrent operations

https://claude.ai/code/session_01QepVdg3DnH8m332SueybBP