### PR TITLE
Mock permission checks in course data isolation tests

### DIFF
--- a/backend/tests/test_course_data_isolation.py
+++ b/backend/tests/test_course_data_isolation.py
@@ -249,6 +249,11 @@ def client_and_users(monkeypatch):
     monkeypatch.setattr("routes.lecture.get_course_data", _fake_get_course_data)
     monkeypatch.setattr("services.get_course_data", _fake_get_course_data)
 
+    # --- 権限チェックの差し替え（実際のDBへの接続を回避する） ---
+    monkeypatch.setattr("routes.admin.user_can_edit_course", lambda uid, cid: True)
+    monkeypatch.setattr("routes.lecture_studio.user_can_edit_course", lambda uid, cid: True, raising=False)
+    monkeypatch.setattr("routes.learning.user_can_view_course", lambda uid, cid: True, raising=False)
+
     # --- _get_course_chunks の差し替え ---------------------------------------------
     def _fake_get_course_chunks(course_data):
         """course_data["sources"][*]["material_id"] を解釈して対応チャンクだけを返す。"""


### PR DESCRIPTION
## Summary
Added mocking of permission check functions in the course data isolation test fixture to avoid actual database connections during testing.

## Key Changes
- Mocked `user_can_edit_course` in `routes.admin` and `routes.lecture_studio` modules to always return `True`
- Mocked `user_can_view_course` in `routes.learning` module to always return `True`
- These mocks prevent the test from making real database calls while validating user permissions

## Implementation Details
- Used `monkeypatch.setattr()` to replace permission check functions with lambda functions that return `True`
- Applied `raising=False` parameter to some mocks to suppress errors if the attribute doesn't exist
- Placed mocks in the test fixture setup alongside other fake implementations (`_fake_get_course_data`, `_fake_get_course_chunks`)
- This approach maintains test isolation and improves test reliability by removing external dependencies

https://claude.ai/code/session_017gCno51nrMPcYmfQrRZUC5