### PR TITLE
Separate master course from personal learning layer (Issue #145)

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -16,8 +16,10 @@ from schemas import (
     LearningChatRequest,
     LearningChatResponse,
     LearningCourseDetail,
+    LearningCourseLayeredResponse,
     LearningCourseOut,
     LearningProgress,
+    PersonalLayer,
 )
 from services import (
     calculate_progress,
@@ -26,6 +28,7 @@ from services import (
     enroll_user_in_course,
     get_course_data,
     get_editable_course_data,
+    get_personal_layer,
     get_user_group_ids,
     log_unanswered_query,
     persist_chat_history,
@@ -275,17 +278,25 @@ def list_courses(
     return unique_courses
 
 
-@router.get("/courses/{course_id}", response_model=LearningCourseDetail)
+@router.get("/courses/{course_id}", response_model=LearningCourseLayeredResponse)
 def get_course(
     course_id: str,
     current_user: dict = Depends(_get_current_user),
-) -> LearningCourseDetail:
-    """コースの詳細データを返す。"""
+) -> LearningCourseLayeredResponse:
+    """コースの詳細データをレイヤー分離形式で返す（Issue #145）。
+
+    マスター教材（不変）と個人レイヤー（誤解・注釈）を分離して返す。
+    オーナー（教員）も一般学生と同じ学習体験を得る。
+    """
     data = get_course_data(current_user["id"], course_id)
     if not data:
         raise HTTPException(status_code=404, detail="Course not found")
 
-    return LearningCourseDetail(**data)
+    personal = get_personal_layer(current_user["id"], course_id)
+    return LearningCourseLayeredResponse(
+        master_course=LearningCourseDetail(**data),
+        personal_layer=PersonalLayer(**personal),
+    )
 
 
 @router.put("/courses/{course_id}", response_model=LearningCourseDetail)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -164,6 +164,25 @@ class LearningCourseDetail(BaseModel):
     progress: dict | None = None
 
 
+class PersonalLayer(BaseModel):
+    """ユーザー固有の学習レイヤー（Issue #145）。
+
+    マスターコースとは分離して管理される個人データ。
+    """
+    misconceptions_by_topic: dict = {}
+    chat_anchors: dict = {}
+
+
+class LearningCourseLayeredResponse(BaseModel):
+    """レイヤー型コース詳細レスポンス（Issue #145）。
+
+    マスター教材と個人レイヤーを分離して返すことで、
+    教材の純粋性を保ちながら個人の学習コンテキストをフロントエンドで管理できる。
+    """
+    master_course: LearningCourseDetail
+    personal_layer: PersonalLayer
+
+
 class LearningSession(BaseModel):
     date: str
     topic: str

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -259,8 +259,8 @@ def enroll_user_in_course(user_id: str, course_id: str) -> None:
     try:
         session.execute(
             sa_text("""
-                INSERT INTO learning_states (user_id, course_id)
-                VALUES (CAST(:user_id AS uuid), :course_id)
+                INSERT INTO learning_states (id, user_id, course_id)
+                VALUES (gen_random_uuid(), CAST(:user_id AS uuid), :course_id)
                 ON CONFLICT (user_id, course_id) DO NOTHING
             """),
             {"user_id": user_id, "course_id": course_id},
@@ -289,8 +289,8 @@ def record_personal_misconception(
     try:
         session.execute(
             sa_text("""
-                INSERT INTO learning_states (user_id, course_id)
-                VALUES (CAST(:user_id AS uuid), :course_id)
+                INSERT INTO learning_states (id, user_id, course_id)
+                VALUES (gen_random_uuid(), CAST(:user_id AS uuid), :course_id)
                 ON CONFLICT (user_id, course_id) DO NOTHING
             """),
             {"user_id": user_id, "course_id": course_id},

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -163,14 +163,12 @@ def get_active_task_for_course(course_id: str) -> dict | None:
 
 
 def get_course_data(user_id: str, course_id: str) -> dict | None:
-    """LearningCourse データを取得する（オーナー or 受講者）。
+    """LearningCourse のマスターデータを返す（オーナー or 受講者）。
 
-    Issue #133: 受講時のクローン作成を廃止し、「1 つの不変なマスターコース」 +
-    「ユーザーごとの学習状態（learning_states）」の構成に変更。
-    - オーナー本人はそのままマスターデータを返す。
-    - 受講者（learning_states に行がある）はマスターデータに
-      personal_graph の差分（誤解など）をマージして返す。
-    - それ以外は None を返す（アクセス不可）。
+    Issue #145: オーナー特例を削除。教員であっても自身の learning_states を通じて
+    アクセスし、一般学生と同じ学習体験を得る。
+    - オーナーが learning_states を持っていない場合は自動作成する。
+    - マスターデータのみを返す（個人レイヤーは get_personal_layer() で別途取得）。
     """
     session = _pg_session()
     try:
@@ -189,12 +187,14 @@ def get_course_data(user_id: str, course_id: str) -> dict | None:
         owner_id = record[1]
 
         if str(owner_id) == str(user_id):
+            # Issue #145: オーナーも learning_states を保持する（自動作成）
+            enroll_user_in_course(user_id, course_id)
             return data
 
-        # 受講者: learning_states.personal_graph をマージする
+        # 受講者チェック
         state_row = session.execute(
             sa_text("""
-                SELECT personal_graph FROM learning_states
+                SELECT 1 FROM learning_states
                 WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
                 LIMIT 1
             """),
@@ -203,16 +203,35 @@ def get_course_data(user_id: str, course_id: str) -> dict | None:
         if not state_row:
             return None
 
-        personal_raw = state_row[0] if state_row[0] is not None else {}
-        personal = personal_raw if isinstance(personal_raw, dict) else json.loads(personal_raw)
-        misconceptions_by_topic = personal.get("misconceptions_by_topic", {}) or {}
-        for topic in data.get("topics", []):
-            tid = topic.get("id", "")
-            per_topic = misconceptions_by_topic.get(tid, [])
-            if per_topic:
-                base = topic.get("misconceptions", []) or []
-                topic["misconceptions"] = (per_topic + base)[:5]
         return data
+    finally:
+        session.close()
+
+
+def get_personal_layer(user_id: str, course_id: str) -> dict:
+    """ユーザー固有の学習レイヤーデータを返す。
+
+    Issue #145: マスターコースとは分離して管理される個人データ。
+    - misconceptions_by_topic: トピックIDをキーとした誤解リスト
+    - chat_anchors: チャット履歴から生成された注釈データ（将来拡張用）
+    """
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT personal_graph FROM learning_states
+                WHERE user_id = CAST(:user_id AS uuid) AND course_id = :course_id
+                LIMIT 1
+            """),
+            {"user_id": user_id, "course_id": course_id},
+        ).fetchone()
+        if not row or not row[0]:
+            return {"misconceptions_by_topic": {}, "chat_anchors": {}}
+        personal = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+        return {
+            "misconceptions_by_topic": personal.get("misconceptions_by_topic", {}) or {},
+            "chat_anchors": personal.get("chat_anchors", {}) or {},
+        }
     finally:
         session.close()
 
@@ -780,9 +799,10 @@ def calculate_progress(user_id: str, course_id: str, course_data: dict) -> dict:
     mastered = sum(1 for c in concepts if c.get("status") == "mastered")
     learning = sum(1 for c in concepts if c.get("status") == "learning")
 
-    total_misconceptions = 0
-    for t in topics:
-        total_misconceptions += len(t.get("misconceptions", []))
+    # Issue #145: 個人誤解は personal_graph から取得（マスターデータには含まれない）
+    personal = get_personal_layer(user_id, course_id)
+    by_topic = personal.get("misconceptions_by_topic", {}) or {}
+    total_misconceptions = sum(len(v) for v in by_topic.values())
 
     sessions_list = []
     pg_session = _pg_session()
@@ -1046,18 +1066,9 @@ def detect_and_record_misconception(
             user_id, course_id,
         )
 
-    # UI 更新用レスポンス: course_data をコピーして当該 topic に今回の誤解を混ぜる
-    updated_topics = [dict(t) for t in course_data.get("topics", [])]
-    for t in updated_topics:
-        if t.get("id") == topic_id:
-            merged = [misconception] + list(t.get("misconceptions", []) or [])
-            t["misconceptions"] = merged[:5]
-            break
-
-    return {
-        "topics": updated_topics,
-        "concepts": course_data.get("concepts", []),
-    }
+    # Issue #145: 個人レイヤー更新をそのまま返す（マスターデータは不変）
+    personal = get_personal_layer(user_id, course_id)
+    return {"personal_layer": personal}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_course_data_isolation.py
+++ b/backend/tests/test_course_data_isolation.py
@@ -249,6 +249,13 @@ def client_and_users(monkeypatch):
     monkeypatch.setattr("routes.lecture.get_course_data", _fake_get_course_data)
     monkeypatch.setattr("services.get_course_data", _fake_get_course_data)
 
+    # --- get_personal_layer の差し替え（Issue #145） ---
+    # レイヤー型レスポンスの個人レイヤー部分は空で返す（隔離テスト目的では不要）
+    def _fake_get_personal_layer(user_id, course_id):
+        return {"misconceptions_by_topic": {}, "chat_anchors": {}}
+
+    monkeypatch.setattr("routes.learning.get_personal_layer", _fake_get_personal_layer)
+
     # --- 権限チェックの差し替え（実際のDBへの接続を回避する） ---
     monkeypatch.setattr("routes.admin.user_can_edit_course", lambda uid, cid: True)
     monkeypatch.setattr("routes.lecture_studio.user_can_edit_course", lambda uid, cid: True, raising=False)
@@ -471,7 +478,12 @@ class TestLearningCourseIsolation:
         )
         assert resp.status_code == 200, resp.text
 
-        detail = resp.json()
+        # Issue #145: レスポンスは {master_course: {...}, personal_layer: {...}} 形式
+        response_data = resp.json()
+        assert "master_course" in response_data, f"master_course key missing: {response_data}"
+        assert "personal_layer" in response_data
+        detail = response_data["master_course"]
+
         assert detail["id"] == COURSE_A_ID
         assert detail["title"] == "コースA"
 
@@ -487,7 +499,7 @@ class TestLearningCourseIsolation:
         assert source_material_ids == {MATERIAL_A_ID}
         assert MATERIAL_B_ID not in source_material_ids
 
-        # 念のためレスポンス全体を文字列化し、コースBの文字列が一切出現しないこと
+        # 念のためマスターコース部分を文字列化し、コースBの文字列が一切出現しないこと
         blob = str(detail)
         assert COURSE_B_ID not in blob
         assert "コースB" not in blob
@@ -503,7 +515,12 @@ class TestLearningCourseIsolation:
         )
         assert resp.status_code == 200, resp.text
 
-        detail = resp.json()
+        # Issue #145: レスポンスは {master_course: {...}, personal_layer: {...}} 形式
+        response_data = resp.json()
+        assert "master_course" in response_data
+        assert "personal_layer" in response_data
+        detail = response_data["master_course"]
+
         assert detail["id"] == COURSE_B_ID
         assert detail["title"] == "コースB"
 
@@ -564,10 +581,14 @@ class TestLearningCourseIsolation:
         assert first.status_code == 200
         assert second.status_code == 200
 
-        a_topics = {t["id"] for t in first.json().get("topics", [])}
-        b_topics = {t["id"] for t in second.json().get("topics", [])}
-        a_materials = {s["material_id"] for s in first.json().get("sources", [])}
-        b_materials = {s["material_id"] for s in second.json().get("sources", [])}
+        # Issue #145: レスポンスは {master_course: {...}, personal_layer: {...}} 形式
+        first_master = first.json()["master_course"]
+        second_master = second.json()["master_course"]
+
+        a_topics = {t["id"] for t in first_master.get("topics", [])}
+        b_topics = {t["id"] for t in second_master.get("topics", [])}
+        a_materials = {s["material_id"] for s in first_master.get("sources", [])}
+        b_materials = {s["material_id"] for s in second_master.get("sources", [])}
 
         assert a_topics.isdisjoint(b_topics)
         assert a_materials.isdisjoint(b_materials)

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -1865,3 +1865,28 @@ body {
   color: var(--color-text-secondary);
   font-style: italic;
 }
+
+/* Issue #145: 個人レイヤー注釈スタイル */
+.mc-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: #fcebeb;
+  color: #791f1f;
+  margin-left: 5px;
+  vertical-align: middle;
+}
+
+.mc-layer-note {
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+  margin-bottom: 6px;
+  font-style: italic;
+}
+
+.mc-annotation {
+  border-left: 3px solid #E24B4A;
+  padding-left: 8px;
+}

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -11,7 +11,8 @@
     username: localStorage.getItem("eg_username") || null,
     role: null,
     courseId: localStorage.getItem("eg_course") || null,
-    course: null, // loaded course data
+    course: null,        // master_course（不変の教材データ）
+    personalLayer: null, // personal_layer（個人の誤解・注釈データ）
     currentTopicId: null,
     chatMessages: [], // {role, content}
     sending: false,
@@ -134,7 +135,18 @@
   async function loadCourse(courseId) {
     try {
       const res = await apiFetch("/learning/courses/" + courseId);
-      if (res.ok) return await res.json();
+      if (res.ok) {
+        const data = await res.json();
+        // Issue #145: レイヤー型レスポンスを展開する
+        if (data && data.master_course) {
+          return {
+            master: data.master_course,
+            personal: data.personal_layer || { misconceptions_by_topic: {}, chat_anchors: {} },
+          };
+        }
+        // 旧形式フォールバック
+        return { master: data, personal: { misconceptions_by_topic: {}, chat_anchors: {} } };
+      }
     } catch (_) { /* ignore */ }
     return null;
   }
@@ -187,8 +199,17 @@
         const tStatus = t.status || "locked";
         const cls = tActive ? "ni sub act" : tStatus === "locked" ? "ni sub lk" : "ni sub";
         const dotCls = tStatus === "completed" ? "dot-g" : tStatus === "in_progress" ? "dot-b" : "dot-x";
+
+        // Issue #145: 個人誤解がある場合は注釈マーカーを表示
+        const personalLayer = state.personalLayer || {};
+        const misconsByTopic = personalLayer.misconceptions_by_topic || {};
+        const misconsCount = (misconsByTopic[t.id] || []).length;
+        const annotationBadge = misconsCount > 0
+          ? '<span class="mc-badge" title="' + misconsCount + '件の誤解が記録されています">⚑ ' + misconsCount + '</span>'
+          : "";
+
         html += '<div class="' + cls + '" data-topic="' + t.id + '" style="padding-left:36px">';
-        html += escHtml(t.title);
+        html += escHtml(t.title) + annotationBadge;
         html += '<span class="dot ' + dotCls + '" style="margin-left:auto"></span></div>';
       });
     });
@@ -401,12 +422,15 @@
       html += "</div></div>";
     }
 
-    // Misconceptions
-    const misconceptions = topic ? (topic.misconceptions || []) : [];
+    // Issue #145: 誤解は personal_layer から取得（マスターデータには含まれない）
+    const personalLayer = state.personalLayer || {};
+    const misconsByTopic = personalLayer.misconceptions_by_topic || {};
+    const misconceptions = topic ? (misconsByTopic[topic.id] || []) : [];
     if (misconceptions.length > 0) {
-      html += '<div class="ps"><h4>指摘された誤解 <span class="mc-bd">' + misconceptions.length + '件</span></h4>';
+      html += '<div class="ps"><h4>あなたの誤解メモ <span class="mc-bd">' + misconceptions.length + '件</span></h4>';
+      html += '<div class="mc-layer-note">過去のチャットで指摘された理解の誤りです。</div>';
       misconceptions.forEach(function (m) {
-        html += '<div class="cc"><div class="lb" style="color:#A32D2D">' + escHtml(m.label || "訂正") + "</div>";
+        html += '<div class="cc mc-annotation"><div class="lb" style="color:#A32D2D">⚑ ' + escHtml(m.label || "訂正") + "</div>";
         html += escHtml(m.wrong) + "<br>→ " + escHtml(m.correct) + "</div>";
       });
       html += "</div>";
@@ -578,9 +602,24 @@
       if (res.ok) {
         const data = await res.json();
         state.chatMessages.push({ role: "assistant", content: data.answer });
-        // Update course data if side-effects returned
+        // Issue #145: 個人レイヤーの更新を反映する
         if (data.course_update) {
-          Object.assign(state.course, data.course_update);
+          if (data.course_update.personal_layer) {
+            // レイヤー型更新: personal_layer をマージする
+            if (!state.personalLayer) {
+              state.personalLayer = { misconceptions_by_topic: {}, chat_anchors: {} };
+            }
+            const newPersonal = data.course_update.personal_layer;
+            if (newPersonal.misconceptions_by_topic) {
+              Object.assign(
+                state.personalLayer.misconceptions_by_topic,
+                newPersonal.misconceptions_by_topic
+              );
+            }
+          } else {
+            // 旧形式フォールバック（topics/concepts の直接更新）
+            Object.assign(state.course, data.course_update);
+          }
           renderSidebar();
           renderRightPanel();
         }
@@ -717,6 +756,7 @@
     state.currentTopicId = null;
     state.chatMessages = [];
     state.course = null;
+    state.personalLayer = null;
 
     // Re-render with clean state
     renderSidebar();
@@ -781,12 +821,16 @@
   }
 
   async function loadAndRenderCourse() {
-    const course = await loadCourse(state.courseId);
-    if (!course) return;
+    const courseData = await loadCourse(state.courseId);
+    if (!courseData) return;
     const progress = await loadProgress(state.courseId);
-    if (progress) course.progress = progress;
 
-    state.course = course;
+    // Issue #145: マスターデータと個人レイヤーを分離して管理する
+    state.course = courseData.master;
+    state.personalLayer = courseData.personal;
+    if (progress) state.course.progress = progress;
+
+    const course = state.course;
 
     // Set initial topic to first in_progress topic
     const inProgress = (course.topics || []).find(function (t) { return t.status === "in_progress"; });


### PR DESCRIPTION
## Summary
Refactors the course data architecture to separate immutable master course materials from user-specific learning data (misconceptions and annotations). This allows course owners to experience the same learning interface as students while maintaining data integrity.

## Key Changes

**Backend (services.py & routes/learning.py):**
- Modified `get_course_data()` to return only master course data; removed personal graph merging logic
- Removed owner special case: owners now must enroll via `learning_states` like regular students
- Created new `get_personal_layer()` function to fetch user-specific misconceptions and chat anchors separately
- Updated `calculate_progress()` to retrieve misconceptions from personal layer instead of master data
- Modified `detect_and_record_misconception()` to return only personal layer updates, keeping master data immutable
- Added new API response model `LearningCourseLayeredResponse` that returns both `master_course` and `personal_layer`
- Updated `/courses/{course_id}` endpoint to return layered response format

**Frontend (app.js & styles.css):**
- Split course state into `state.course` (master data) and `state.personalLayer` (personal data)
- Updated `loadCourse()` to parse and separate layered response format with fallback for legacy format
- Modified misconceptions rendering to pull from `personalLayer.misconceptions_by_topic` instead of master topics
- Added visual indicators: misconception badges on topic titles and annotation styling for personal misconceptions
- Updated chat response handler to merge personal layer updates separately from master data updates
- Added CSS styles for misconception badges (`.mc-badge`), layer notes (`.mc-layer-note`), and annotations (`.mc-annotation`)

**Schemas (schemas.py):**
- Added `PersonalLayer` model with `misconceptions_by_topic` and `chat_anchors` fields
- Added `LearningCourseLayeredResponse` model to structure separated master/personal responses

## Implementation Details
- Master course data is now truly immutable and shared across all users
- Personal misconceptions are stored in `learning_states.personal_graph` and fetched separately
- Course owners are auto-enrolled in their own courses via `enroll_user_in_course()` if not already enrolled
- Frontend gracefully handles both new layered format and legacy format responses
- Misconception UI now clearly indicates these are personal learning notes, not part of the course material

https://claude.ai/code/session_015XdbBXAEwviRpWFFN9bfZa