### PR TITLE
Add topic material content retrieval endpoint (Issue #151)

### DIFF
--- a/backend/api/routes/learning.py
+++ b/backend/api/routes/learning.py
@@ -20,12 +20,15 @@ from schemas import (
     LearningCourseOut,
     LearningProgress,
     PersonalLayer,
+    TopicMaterialChunk,
+    TopicMaterialResponse,
 )
 from services import (
     calculate_progress,
     check_prerequisites,
     detect_and_record_misconception,
     enroll_user_in_course,
+    fetch_topic_material_chunks,
     get_course_data,
     get_editable_course_data,
     get_personal_layer,
@@ -420,6 +423,54 @@ def enroll_course(
         current_user["id"], course_id,
     )
     return LearningCourseOut(id=course_id, title=title or "")
+
+
+# ---------------------------------------------------------------------------
+# Topic Material
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/courses/{course_id}/topics/{topic_id}/material",
+    response_model=TopicMaterialResponse,
+)
+def get_topic_material(
+    course_id: str,
+    topic_id: str,
+    current_user: dict = Depends(_get_current_user),
+) -> TopicMaterialResponse:
+    """トピックに紐づく教材チャンク（本文テキスト＋出典）を返す。
+
+    コース sources に material_id が登録されている場合はそこから優先的に
+    ベクトル検索し、未登録の場合はシステム全域のチャンクを対象とする。
+    """
+    course_data = get_course_data(current_user["id"], course_id)
+    if not course_data:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    topic_info = next(
+        (t for t in course_data.get("topics", []) if t.get("id") == topic_id),
+        None,
+    )
+    if topic_info is None:
+        raise HTTPException(status_code=404, detail="Topic not found")
+
+    raw_chunks = fetch_topic_material_chunks(current_user["id"], course_id, topic_id)
+
+    return TopicMaterialResponse(
+        topic_id=topic_id,
+        topic_title=topic_info.get("title", topic_id),
+        chunks=[
+            TopicMaterialChunk(
+                id=c["id"],
+                text=c["text"],
+                source_title=c["source_title"],
+                source_file=c.get("source_file", ""),
+                score=c.get("score", 0.0),
+            )
+            for c in raw_chunks
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -198,6 +198,24 @@ class LearningProgress(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Topic Material
+# ---------------------------------------------------------------------------
+
+class TopicMaterialChunk(BaseModel):
+    id: str
+    text: str
+    source_title: str
+    source_file: str = ""
+    score: float = 0.0
+
+
+class TopicMaterialResponse(BaseModel):
+    topic_id: str
+    topic_title: str
+    chunks: list[TopicMaterialChunk]
+
+
+# ---------------------------------------------------------------------------
 # Chat
 # ---------------------------------------------------------------------------
 

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -738,6 +738,95 @@ def search_relevant_chunks_with_scores(
         return [], []
 
 
+def fetch_topic_material_chunks(
+    user_id: str,
+    course_id: str,
+    topic_id: str,
+    top_k: int = 5,
+) -> list[dict]:
+    """トピックに紐づく教材チャンクをベクトル検索で取得する。
+
+    コースに material_id が紐づく sources があればそれを優先し、
+    なければシステム全域のチャンクからトピックタイトル＋概念で検索する。
+    """
+    course_data = get_course_data(user_id, course_id)
+    if not course_data:
+        return []
+
+    topic_info = next(
+        (t for t in course_data.get("topics", []) if t.get("id") == topic_id),
+        None,
+    )
+    if not topic_info:
+        return []
+
+    topic_title = topic_info.get("title", topic_id)
+    concept_names = [
+        c.get("name", "") if isinstance(c, dict) else str(c)
+        for c in course_data.get("concepts", [])
+    ]
+    query = topic_title
+    if concept_names:
+        query += " " + " ".join(concept_names[:5])
+
+    material_ids = [
+        s["material_id"]
+        for s in course_data.get("sources", [])
+        if s.get("material_id")
+    ]
+
+    if material_ids:
+        try:
+            query_vector = embed_text(query)
+        except Exception as exc:
+            logger.warning("Embedding failed for topic material: %s", exc)
+            return []
+
+        session = _pg_session()
+        try:
+            dim = get_embedding_dim()
+            mid_ph = ", ".join(f":mid_{i}" for i in range(len(material_ids)))
+            params: dict = {"query_vector": str(query_vector), "limit": top_k}
+            for i, mid in enumerate(material_ids):
+                params[f"mid_{i}"] = mid
+
+            rows = session.execute(
+                sa_text(f"""
+                    SELECT c.id, c.text,
+                           COALESCE(d.title, '') AS source_title,
+                           COALESCE(d.filename, '') AS source_file,
+                           1 - (c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))) AS score
+                    FROM chunks c
+                    LEFT JOIN documents d ON c.document_id = d.id
+                    WHERE c.material_id IN ({mid_ph})
+                      AND c.embedding IS NOT NULL
+                    ORDER BY c.embedding::halfvec({dim}) <=> CAST(:query_vector AS halfvec({dim}))
+                    LIMIT :limit
+                """),
+                params,
+            ).fetchall()
+            return [
+                {
+                    "id": str(row[0]),
+                    "text": row[1],
+                    "source_title": row[2] or row[3] or "不明な教材",
+                    "source_file": row[3] or "",
+                    "score": float(row[4]),
+                }
+                for row in rows
+                if row[1]
+            ]
+        except Exception as exc:
+            logger.warning("Topic material chunk search failed: %s", exc)
+            return []
+        finally:
+            session.close()
+
+    # material_id 未登録の場合はシステム全域から検索
+    results = search_chunks_with_metadata(query, top_k=top_k)
+    return [r for r in results if r.get("score", 0.0) >= 0.25]
+
+
 def search_chunks_with_metadata(
     query: str,
     top_k: int = 8,

--- a/backend/tests/test_topic_material.py
+++ b/backend/tests/test_topic_material.py
@@ -1,0 +1,288 @@
+"""Issue #151: 学習パス選択時の教材コンテンツ取得テスト。
+
+テスト対象:
+  - `backend/api/routes/learning.py` — GET /api/learning/courses/{course_id}/topics/{topic_id}/material
+  - `backend/api/services.py`        — fetch_topic_material_chunks
+  - `backend/api/schemas.py`         — TopicMaterialChunk, TopicMaterialResponse
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = PROJECT_ROOT / "backend"
+LEARNING_PY = BACKEND_DIR / "api" / "routes" / "learning.py"
+SERVICES_PY = BACKEND_DIR / "api" / "services.py"
+SCHEMAS_PY = BACKEND_DIR / "api" / "schemas.py"
+
+
+# ---------------------------------------------------------------------------
+# 1. スキーマの定義確認
+# ---------------------------------------------------------------------------
+
+
+class TestTopicMaterialSchemas:
+    """TopicMaterialChunk / TopicMaterialResponse が schemas.py に定義されていること。"""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.src = SCHEMAS_PY.read_text(encoding="utf-8")
+
+    def test_topic_material_chunk_defined(self):
+        assert re.search(r"class\s+TopicMaterialChunk\s*\(", self.src), \
+            "TopicMaterialChunk が schemas.py に定義されていない"
+
+    def test_topic_material_response_defined(self):
+        assert re.search(r"class\s+TopicMaterialResponse\s*\(", self.src), \
+            "TopicMaterialResponse が schemas.py に定義されていない"
+
+    def test_chunk_has_text_field(self):
+        m = re.search(r"class\s+TopicMaterialChunk\b.*?(?=\n(?:class |#)\b)", self.src, re.DOTALL)
+        assert m, "TopicMaterialChunk 本体が抽出できない"
+        body = m.group(0)
+        assert "text" in body
+
+    def test_chunk_has_source_title_field(self):
+        m = re.search(r"class\s+TopicMaterialChunk\b.*?(?=\n(?:class |#)\b)", self.src, re.DOTALL)
+        assert m
+        body = m.group(0)
+        assert "source_title" in body
+
+    def test_response_has_chunks_field(self):
+        m = re.search(r"class\s+TopicMaterialResponse\b.*?(?=\n(?:class |#)\b)", self.src, re.DOTALL)
+        assert m, "TopicMaterialResponse 本体が抽出できない"
+        body = m.group(0)
+        assert "chunks" in body
+
+    def test_response_has_topic_id_and_title(self):
+        m = re.search(r"class\s+TopicMaterialResponse\b.*?(?=\n(?:class |#)\b)", self.src, re.DOTALL)
+        assert m
+        body = m.group(0)
+        assert "topic_id" in body
+        assert "topic_title" in body
+
+
+# ---------------------------------------------------------------------------
+# 2. サービス関数の定義確認
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTopicMaterialChunksDefinition:
+    """fetch_topic_material_chunks が services.py に定義されていること。"""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.src = SERVICES_PY.read_text(encoding="utf-8")
+
+    def test_function_defined(self):
+        assert re.search(
+            r"def\s+fetch_topic_material_chunks\s*\(",
+            self.src,
+        ), "fetch_topic_material_chunks が services.py に定義されていない"
+
+    def test_accepts_user_id_course_id_topic_id(self):
+        m = re.search(
+            r"def\s+fetch_topic_material_chunks\s*\(.*?\)\s*(?:->.*?)?:",
+            self.src,
+            re.DOTALL,
+        )
+        assert m
+        sig = m.group(0)
+        assert "user_id" in sig
+        assert "course_id" in sig
+        assert "topic_id" in sig
+
+    def test_uses_get_course_data(self):
+        m = re.search(
+            r"def\s+fetch_topic_material_chunks\b.*?(?=\ndef |\nclass |\Z)",
+            self.src,
+            re.DOTALL,
+        )
+        assert m
+        body = m.group(0)
+        assert "get_course_data" in body
+
+    def test_searches_material_ids_from_sources(self):
+        m = re.search(
+            r"def\s+fetch_topic_material_chunks\b.*?(?=\ndef |\nclass |\Z)",
+            self.src,
+            re.DOTALL,
+        )
+        assert m
+        body = m.group(0)
+        assert "material_id" in body
+
+    def test_returns_list_of_dicts(self):
+        m = re.search(
+            r"def\s+fetch_topic_material_chunks\b.*?(?=\ndef |\nclass |\Z)",
+            self.src,
+            re.DOTALL,
+        )
+        assert m
+        body = m.group(0)
+        assert "return [" in body or "return []" in body
+
+
+# ---------------------------------------------------------------------------
+# 3. エンドポイントの定義確認
+# ---------------------------------------------------------------------------
+
+
+class TestTopicMaterialEndpoint:
+    """GET /api/learning/courses/{course_id}/topics/{topic_id}/material が定義されていること。"""
+
+    @pytest.fixture(autouse=True)
+    def _load(self):
+        self.src = LEARNING_PY.read_text(encoding="utf-8")
+
+    def test_route_path_defined(self):
+        assert '"/courses/{course_id}/topics/{topic_id}/material"' in self.src, \
+            "material エンドポイントのルートパスが learning.py に存在しない"
+
+    def test_response_model_is_topic_material_response(self):
+        assert "TopicMaterialResponse" in self.src, \
+            "TopicMaterialResponse が learning.py で使われていない"
+
+    def test_imports_fetch_topic_material_chunks(self):
+        assert "fetch_topic_material_chunks" in self.src, \
+            "fetch_topic_material_chunks が learning.py にインポートされていない"
+
+    def test_imports_topic_material_chunk(self):
+        assert "TopicMaterialChunk" in self.src, \
+            "TopicMaterialChunk が learning.py にインポートされていない"
+
+    def test_returns_404_when_course_not_found(self):
+        m = re.search(
+            r"def\s+get_topic_material\b.*?(?=\n@router|\nclass |\Z)",
+            self.src,
+            re.DOTALL,
+        )
+        assert m, "get_topic_material 関数本体が抽出できない"
+        body = m.group(0)
+        assert "404" in body
+
+    def test_returns_404_when_topic_not_found(self):
+        m = re.search(
+            r"def\s+get_topic_material\b.*?(?=\n@router|\nclass |\Z)",
+            self.src,
+            re.DOTALL,
+        )
+        assert m
+        body = m.group(0)
+        # 2か所 404 があることを確認（course not found / topic not found）
+        assert body.count("404") >= 2
+
+
+# ---------------------------------------------------------------------------
+# 4. fetch_topic_material_chunks のロジックテスト（モック）
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTopicMaterialChunksLogic:
+    """fetch_topic_material_chunks の振る舞いをモックでテストする。"""
+
+    @pytest.fixture(autouse=True)
+    def _patch_session(self):
+        """DB セッションをモックアウトし外部依存を排除する。"""
+        with patch("api.services._pg_session") as mock_pg:
+            self.mock_session = MagicMock()
+            mock_pg.return_value = self.mock_session
+            yield
+
+    def _make_course_data(self, material_id: str | None = "mat1") -> dict:
+        sources = [{"title": "テスト教材", "material_id": material_id}] if material_id else []
+        return {
+            "id": "course1",
+            "title": "テストコース",
+            "topics": [
+                {"id": "topic1", "title": "波動関数", "chapter_index": 0, "status": "in_progress"},
+            ],
+            "concepts": [{"name": "シュレーディンガー方程式"}],
+            "sources": sources,
+        }
+
+    def test_returns_empty_when_course_not_found(self):
+        with patch("api.services.get_course_data", return_value=None):
+            from api.services import fetch_topic_material_chunks
+            result = fetch_topic_material_chunks("user1", "course1", "topic1")
+        assert result == []
+
+    def test_returns_empty_when_topic_not_found(self):
+        course_data = self._make_course_data()
+        with patch("api.services.get_course_data", return_value=course_data):
+            from api.services import fetch_topic_material_chunks
+            result = fetch_topic_material_chunks("user1", "course1", "nonexistent_topic")
+        assert result == []
+
+    def test_uses_material_ids_from_sources(self):
+        """course.sources に material_id があれば DB 検索を試みること。"""
+        course_data = self._make_course_data(material_id="mat1")
+
+        fake_row = (
+            "chunk-uuid-1",
+            "波動関数とは確率振幅の関数である。",
+            "量子力学教科書",
+            "quantum.pdf",
+            0.85,
+        )
+        self.mock_session.execute.return_value.fetchall.return_value = [fake_row]
+
+        with patch("api.services.get_course_data", return_value=course_data):
+            with patch("api.services.embed_text", return_value=[0.1] * 10):
+                with patch("api.services.get_embedding_dim", return_value=10):
+                    from api.services import fetch_topic_material_chunks
+                    result = fetch_topic_material_chunks("user1", "course1", "topic1")
+
+        assert len(result) == 1
+        assert result[0]["text"] == "波動関数とは確率振幅の関数である。"
+        assert result[0]["source_title"] == "量子力学教科書"
+        assert result[0]["score"] == pytest.approx(0.85)
+
+    def test_returns_list_with_required_keys(self):
+        """結果 dict に id / text / source_title / score が含まれること。"""
+        course_data = self._make_course_data(material_id="mat1")
+
+        fake_row = ("cid", "教材テキスト", "書籍A", "a.pdf", 0.7)
+        self.mock_session.execute.return_value.fetchall.return_value = [fake_row]
+
+        with patch("api.services.get_course_data", return_value=course_data):
+            with patch("api.services.embed_text", return_value=[0.1] * 10):
+                with patch("api.services.get_embedding_dim", return_value=10):
+                    from api.services import fetch_topic_material_chunks
+                    result = fetch_topic_material_chunks("user1", "course1", "topic1")
+
+        assert result
+        chunk = result[0]
+        for key in ("id", "text", "source_title", "score"):
+            assert key in chunk, f"キー '{key}' が結果に含まれていない"
+
+    def test_fallback_to_system_wide_search_when_no_material_ids(self):
+        """course.sources に material_id がない場合、システム全域検索にフォールバックすること。"""
+        course_data = self._make_course_data(material_id=None)
+
+        mock_chunks = [
+            {"id": "c1", "text": "フォールバックチャンク", "source_title": "DB", "source_file": "", "score": 0.4},
+        ]
+        with patch("api.services.get_course_data", return_value=course_data):
+            with patch("api.services.search_chunks_with_metadata", return_value=mock_chunks) as mock_search:
+                from api.services import fetch_topic_material_chunks
+                result = fetch_topic_material_chunks("user1", "course1", "topic1")
+
+        mock_search.assert_called_once()
+        assert len(result) == 1
+
+    def test_embedding_failure_returns_empty(self):
+        """embed_text が失敗した場合は空リストを返すこと（クラッシュしないこと）。"""
+        course_data = self._make_course_data(material_id="mat1")
+
+        with patch("api.services.get_course_data", return_value=course_data):
+            with patch("api.services.embed_text", side_effect=Exception("embedding error")):
+                from api.services import fetch_topic_material_chunks
+                result = fetch_topic_material_chunks("user1", "course1", "topic1")
+
+        assert result == []

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -243,6 +243,57 @@ body {
   align-self: flex-start;
 }
 
+/* Topic Material Section */
+.material-section {
+  background: var(--color-background-secondary, #f8f9fa);
+  border: 1px solid var(--color-border-secondary, #dee2e6);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.material-header {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-secondary, #6c757d);
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-border-secondary, #dee2e6);
+}
+
+.material-chunk {
+  margin-bottom: 10px;
+}
+
+.material-chunk:last-of-type {
+  margin-bottom: 0;
+}
+
+.material-source {
+  font-size: 11px;
+  color: var(--color-text-tertiary, #9ca3af);
+  margin-bottom: 4px;
+}
+
+.material-text {
+  font-size: 13px;
+  line-height: 1.65;
+  color: var(--color-text-primary, #1a1a1a);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.material-divider {
+  text-align: center;
+  font-size: 11px;
+  color: var(--color-text-tertiary, #9ca3af);
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--color-border-secondary, #dee2e6);
+}
+
 /* Correction block */
 .corr {
   border-left: 2px solid #e24b4a;

--- a/frontend/public/js/app.js
+++ b/frontend/public/js/app.js
@@ -15,6 +15,7 @@
     personalLayer: null, // personal_layer（個人の誤解・注釈データ）
     currentTopicId: null,
     chatMessages: [], // {role, content}
+    topicMaterial: null, // 教材コンテンツ {topic_id, topic_title, chunks}
     sending: false,
   };
 
@@ -274,6 +275,20 @@
     }
 
     let html = "";
+
+    // 教材コンテンツをチャットの上部に表示
+    if (state.topicMaterial && state.topicMaterial.chunks && state.topicMaterial.chunks.length > 0) {
+      html += '<div class="material-section">';
+      html += '<div class="material-header">📚 ' + escHtml(state.topicMaterial.topic_title) + ' — 教材本文</div>';
+      state.topicMaterial.chunks.forEach(function (chunk) {
+        html += '<div class="material-chunk">';
+        html += '<div class="material-source">[出典: ' + escHtml(chunk.source_title) + ']</div>';
+        html += '<div class="material-text">' + escHtml(chunk.text) + '</div>';
+        html += '</div>';
+      });
+      html += '<div class="material-divider">— AIへの質問はこちらからどうぞ —</div>';
+      html += '</div>';
+    }
 
     // 初期状態（チャット履歴なし）ならサジェストUIを表示
     if (state.chatMessages.length === 0 && !state.sending) {
@@ -562,18 +577,36 @@
     }
   }
 
+  // ── Topic Material ─────────────────────────────────────────────────
+  async function loadTopicMaterial(courseId, topicId) {
+    try {
+      const res = await apiFetch("/learning/courses/" + courseId + "/topics/" + topicId + "/material");
+      if (res.ok) {
+        state.topicMaterial = await res.json();
+      } else {
+        state.topicMaterial = null;
+      }
+    } catch (err) {
+      state.topicMaterial = null;
+    }
+  }
+
   // ── Topic Selection ────────────────────────────────────────────────
   async function selectTopic(topicId) {
     state.currentTopicId = topicId;
     state.chatMessages = [];
+    state.topicMaterial = null;
     renderSidebar();
     renderChat();
     renderRightPanel();
     updateNextTopicBtn();
 
-    // Load chat history
+    // Load chat history and material content in parallel
     if (state.courseId && topicId) {
-      const history = await loadChatHistory(state.courseId, topicId);
+      const [history] = await Promise.all([
+        loadChatHistory(state.courseId, topicId),
+        loadTopicMaterial(state.courseId, topicId),
+      ]);
       state.chatMessages = history;
       renderChat();
     }
@@ -848,7 +881,11 @@
 
     renderSidebar();
     if (state.currentTopicId) {
-      state.chatMessages = await loadChatHistory(state.courseId, state.currentTopicId);
+      const [history] = await Promise.all([
+        loadChatHistory(state.courseId, state.currentTopicId),
+        loadTopicMaterial(state.courseId, state.currentTopicId),
+      ]);
+      state.chatMessages = history;
     }
     renderChat();
     renderRightPanel();


### PR DESCRIPTION
## Summary
Implements a new endpoint to retrieve educational material content associated with learning topics. When a user selects a topic in a course, the system now fetches and displays relevant material chunks (text excerpts with source attribution) from the course's registered materials or system-wide knowledge base.

## Key Changes

### Backend
- **New endpoint**: `GET /api/learning/courses/{course_id}/topics/{topic_id}/material`
  - Returns topic-specific material chunks with text content and source attribution
  - Validates course and topic existence, returning 404 if not found
  
- **New service function**: `fetch_topic_material_chunks(user_id, course_id, topic_id)`
  - Performs vector similarity search on material chunks
  - Prioritizes course-registered materials (via `material_id` in sources)
  - Falls back to system-wide chunk search if no materials are registered
  - Handles embedding failures gracefully by returning empty results
  
- **New schemas**: `TopicMaterialChunk` and `TopicMaterialResponse`
  - `TopicMaterialChunk`: Contains chunk id, text, source title, source file, and similarity score
  - `TopicMaterialResponse`: Wraps topic metadata with list of material chunks

### Frontend
- **Material content display**: Renders educational material above the chat interface
  - Shows topic title and material source attribution
  - Displays chunk text with proper formatting
  - Includes visual separator before chat input area
  
- **Parallel loading**: Loads chat history and material content concurrently when topic is selected
  - Improves perceived performance by fetching both resources in parallel
  
- **CSS styling**: Added `.material-section`, `.material-chunk`, `.material-source`, `.material-text`, and `.material-divider` classes for consistent material presentation

### Testing
- Comprehensive test suite (`test_topic_material.py`) covering:
  - Schema definition validation
  - Service function signature and behavior
  - Endpoint route and response model configuration
  - Logic tests with mocked database and embedding calls
  - Edge cases (missing course/topic, embedding failures, fallback search)

## Implementation Details
- Material search uses vector embeddings with halfvec distance metric for efficient similarity matching
- Query combines topic title with course concepts for better relevance
- Graceful degradation: embedding errors or database issues return empty results rather than crashing
- Score threshold (0.25) applied to fallback system-wide search results to filter low-relevance chunks

https://claude.ai/code/session_01MMxHMWZeB9YouSnnb3guia