### PR TITLE
Add system statistics dashboard for SYSTEM_ADMIN (Issue #144)

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1396,6 +1396,113 @@ def list_unanswered_queries(
 
 
 # ---------------------------------------------------------------------------
+# System Statistics (Issue #144)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/system/materials-stats")
+def get_materials_stats(
+    current_user: dict = Depends(_require_system_admin),
+) -> list[dict]:
+    """全教材のパイプライン進捗・利用統計を返す（SYSTEM_ADMIN 専用）。"""
+    session = _pg_session()
+    try:
+        rows = session.execute(
+            sa_text("""
+                WITH ChunkStats AS (
+                    SELECT
+                        document_id,
+                        COUNT(*) AS total_chunks,
+                        COUNT(spoken_text) AS script_chunks
+                    FROM chunks
+                    GROUP BY document_id
+                ),
+                AudioStats AS (
+                    SELECT
+                        c.document_id,
+                        COUNT(a.id) AS audio_chunks
+                    FROM chunks c
+                    LEFT JOIN lecture_audio_cache a ON c.id = a.chunk_id
+                    GROUP BY c.document_id
+                ),
+                CourseDocLinks AS (
+                    SELECT
+                        lc.id AS course_id,
+                        (src->>'material_id') AS material_id
+                    FROM learning_courses lc,
+                    LATERAL jsonb_array_elements(
+                        CASE WHEN jsonb_typeof(lc.data->'sources') = 'array'
+                             THEN lc.data->'sources'
+                             ELSE '[]'::jsonb
+                        END
+                    ) AS src
+                    WHERE src->>'material_id' IS NOT NULL
+                ),
+                EnrolledStats AS (
+                    SELECT
+                        cdl.material_id,
+                        COUNT(DISTINCT ls.user_id) AS enrolled_students
+                    FROM CourseDocLinks cdl
+                    JOIN learning_states ls ON ls.course_id = cdl.course_id
+                    GROUP BY cdl.material_id
+                ),
+                ChatStats AS (
+                    SELECT
+                        cdl.material_id,
+                        COALESCE(SUM(jsonb_array_length(lch.history)), 0) AS chat_count
+                    FROM CourseDocLinks cdl
+                    JOIN learning_chat_history lch ON lch.course_id = cdl.course_id
+                    GROUP BY cdl.material_id
+                )
+                SELECT
+                    d.id::text AS material_id,
+                    d.title,
+                    d.filename,
+                    u.display_name AS uploaded_by,
+                    d.created_at,
+                    COALESCE(d.text_length, 0) AS text_length,
+                    COALESCE(cs.total_chunks, 0) AS chunk_count,
+                    CASE
+                        WHEN COALESCE(cs.total_chunks, 0) = 0 THEN 0.0
+                        ELSE ROUND(cs.script_chunks::numeric / cs.total_chunks * 100, 1)
+                    END AS script_progress,
+                    CASE
+                        WHEN COALESCE(cs.total_chunks, 0) = 0 THEN 0.0
+                        ELSE ROUND(COALESCE(aus.audio_chunks, 0)::numeric / cs.total_chunks * 100, 1)
+                    END AS audio_progress,
+                    COALESCE(es.enrolled_students, 0) AS enrolled_students,
+                    COALESCE(chats.chat_count, 0) AS chat_count
+                FROM documents d
+                LEFT JOIN users u ON u.id = d.uploaded_by
+                LEFT JOIN ChunkStats cs ON cs.document_id = d.id
+                LEFT JOIN AudioStats aus ON aus.document_id = d.id
+                LEFT JOIN EnrolledStats es ON es.material_id = d.source_path
+                LEFT JOIN ChatStats chats ON chats.material_id = d.source_path
+                ORDER BY d.created_at DESC
+            """),
+        ).fetchall()
+    finally:
+        session.close()
+
+    return [
+        {
+            "material_id": r[0],
+            "title": r[1] or "",
+            "filename": r[2] or "",
+            "uploaded_by": r[3] or "",
+            "created_at": r[4].isoformat() if r[4] else "",
+            "text_length": int(r[5]) if r[5] else 0,
+            "chunk_count": int(r[6]) if r[6] else 0,
+            "script_progress": float(r[7]) if r[7] is not None else 0.0,
+            "audio_progress": float(r[8]) if r[8] is not None else 0.0,
+            "enrolled_students": int(r[9]) if r[9] else 0,
+            "chat_count": int(r[10]) if r[10] else 0,
+        }
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
 # User Management
 # ---------------------------------------------------------------------------
 

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -312,7 +312,6 @@
         </table>
       </div>
     </div>
-  </div>
 
     <!-- System Stats tab (Issue #144, SYSTEM_ADMIN only) -->
     <div class="admin-panel" id="tab-system-stats">

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -32,6 +32,7 @@
       <button class="admin-tab" data-tab="stumbles">つまづきデータ</button>
       <button class="admin-tab" data-tab="schema-proposals">スキーマ提案</button>
       <button class="admin-tab" data-tab="groups">グループ管理</button>
+      <button class="admin-tab" data-tab="system-stats" id="tab-btn-system-stats" style="display:none">システム統計</button>
     </div>
 
     <!-- Materials tab -->
@@ -307,6 +308,42 @@
           </thead>
           <tbody id="stumbles-tbody">
             <tr><td colspan="4" style="text-align:center;color:var(--color-text-tertiary)">コースを選択してください</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+    <!-- System Stats tab (Issue #144, SYSTEM_ADMIN only) -->
+    <div class="admin-panel" id="tab-system-stats">
+      <div class="admin-section">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+          <h3 class="admin-section-title" style="margin-bottom:0">全教材・パイプライン統計</h3>
+          <div style="display:flex;gap:8px;align-items:center">
+            <select id="ss-teacher-filter" style="padding:4px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
+              <option value="">全教員</option>
+            </select>
+            <button id="ss-refresh" class="admin-action-btn">更新</button>
+          </div>
+        </div>
+        <p style="font-size:12px;color:var(--color-text-tertiary);margin-bottom:16px">
+          全教材の原稿・音声生成進捗と学生利用状況を一覧できます。
+        </p>
+        <div id="ss-status" class="upload-status" style="display:none"></div>
+        <table class="admin-table" id="ss-table">
+          <thead>
+            <tr>
+              <th class="ss-sortable" data-sort="title" style="cursor:pointer">タイトル &#9651;</th>
+              <th class="ss-sortable" data-sort="uploaded_by" style="cursor:pointer">アップロード者 &#9651;</th>
+              <th class="ss-sortable" data-sort="created_at" style="cursor:pointer">日時 &#9651;</th>
+              <th>原稿生成</th>
+              <th>音声生成</th>
+              <th class="ss-sortable" data-sort="enrolled_students" style="cursor:pointer">受講者数 &#9651;</th>
+              <th class="ss-sortable" data-sort="chat_count" style="cursor:pointer">チャット数 &#9651;</th>
+            </tr>
+          </thead>
+          <tbody id="ss-tbody">
+            <tr><td colspan="7" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>
           </tbody>
         </table>
       </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -1385,6 +1385,9 @@
       teacherTab.dataset.tab = "teachers";
       teacherTab.textContent = "教員管理";
       tabsEl.appendChild(teacherTab);
+
+      var ssTabBtn = document.getElementById("tab-btn-system-stats");
+      if (ssTabBtn) ssTabBtn.style.display = "";
     }
 
     // Show schema evolution tab for TEACHER/SYSTEM_ADMIN
@@ -3133,6 +3136,135 @@
       });
   }
 
+  // ── System Statistics (Issue #144, SYSTEM_ADMIN only) ──────────────
+  var _ssAllStats = [];
+  var _ssSortKey = "created_at";
+  var _ssSortAsc = false;
+
+  function initSystemStats() {
+    if (state.role !== "SYSTEM_ADMIN") return;
+
+    onTabActivate("system-stats", loadSystemStats);
+
+    document.getElementById("ss-refresh").addEventListener("click", loadSystemStats);
+    document.getElementById("ss-teacher-filter").addEventListener("change", renderSystemStats);
+
+    document.getElementById("ss-table").addEventListener("click", function (e) {
+      var th = e.target.closest(".ss-sortable");
+      if (!th) return;
+      var key = th.dataset.sort;
+      if (_ssSortKey === key) {
+        _ssSortAsc = !_ssSortAsc;
+      } else {
+        _ssSortKey = key;
+        _ssSortAsc = key === "title" || key === "uploaded_by";
+      }
+      renderSystemStats();
+    });
+  }
+
+  function loadSystemStats() {
+    var tbody = document.getElementById("ss-tbody");
+    tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--color-text-tertiary)">読み込み中...</td></tr>';
+
+    apiFetch("/admin/system/materials-stats")
+      .then(function (res) { return res.json(); })
+      .then(function (data) {
+        _ssAllStats = data;
+        rebuildTeacherFilter(data);
+        renderSystemStats();
+      })
+      .catch(function () {
+        tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--color-text-danger)">読み込みに失敗しました</td></tr>';
+      });
+  }
+
+  function rebuildTeacherFilter(stats) {
+    var sel = document.getElementById("ss-teacher-filter");
+    var current = sel.value;
+    var teachers = {};
+    stats.forEach(function (s) { if (s.uploaded_by) teachers[s.uploaded_by] = true; });
+    sel.innerHTML = '<option value="">全教員</option>';
+    Object.keys(teachers).sort().forEach(function (name) {
+      var opt = document.createElement("option");
+      opt.value = name;
+      opt.textContent = name;
+      if (name === current) opt.selected = true;
+      sel.appendChild(opt);
+    });
+  }
+
+  function renderSystemStats() {
+    var filter = document.getElementById("ss-teacher-filter").value;
+    var rows = _ssAllStats.filter(function (s) {
+      return !filter || s.uploaded_by === filter;
+    });
+
+    rows.sort(function (a, b) {
+      var av = a[_ssSortKey];
+      var bv = b[_ssSortKey];
+      if (typeof av === "string") av = av.toLowerCase();
+      if (typeof bv === "string") bv = bv.toLowerCase();
+      if (av < bv) return _ssSortAsc ? -1 : 1;
+      if (av > bv) return _ssSortAsc ? 1 : -1;
+      return 0;
+    });
+
+    // Update sort indicators
+    document.querySelectorAll("#ss-table .ss-sortable").forEach(function (th) {
+      var key = th.dataset.sort;
+      th.innerHTML = th.innerHTML.replace(/[△▽]/g, "").trim();
+      if (key === _ssSortKey) {
+        th.innerHTML += " " + (_ssSortAsc ? "&#9651;" : "&#9661;");
+      } else {
+        th.innerHTML += " &#9651;";
+      }
+    });
+
+    var tbody = document.getElementById("ss-tbody");
+    if (!rows.length) {
+      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--color-text-tertiary)">教材がありません</td></tr>';
+      return;
+    }
+
+    var html = "";
+    rows.forEach(function (s) {
+      var createdAt = s.created_at ? new Date(s.created_at).toLocaleString("ja-JP") : "";
+      html += "<tr>" +
+        "<td>" + escHtml(s.title || s.filename || "") + "</td>" +
+        "<td>" + escHtml(s.uploaded_by || "") + "</td>" +
+        "<td style='font-size:11px'>" + escHtml(createdAt) + "</td>" +
+        "<td>" + ssProgressBar(s.script_progress) + "</td>" +
+        "<td>" + ssProgressBar(s.audio_progress) + "</td>" +
+        "<td style='text-align:center'>" + s.enrolled_students + "</td>" +
+        "<td style='text-align:center'>" + s.chat_count + "</td>" +
+        "</tr>";
+    });
+    tbody.innerHTML = html;
+  }
+
+  function ssProgressBar(pct) {
+    var p = Math.round(pct || 0);
+    var color;
+    var label;
+    if (p >= 100) {
+      color = "var(--color-text-success)";
+      label = "完了";
+    } else if (p > 0) {
+      color = "var(--color-text-info)";
+      label = "処理中";
+    } else {
+      color = "var(--color-border)";
+      label = "未着手";
+    }
+    return '<div style="display:flex;align-items:center;gap:6px">' +
+      '<div style="flex:1;height:6px;background:var(--color-bg-tertiary);border-radius:3px;min-width:60px">' +
+        '<div style="height:100%;width:' + p + '%;background:' + color + ';border-radius:3px;transition:width .3s"></div>' +
+      '</div>' +
+      '<span style="font-size:11px;white-space:nowrap;color:' + color + '">' + label + ' ' + p + '%</span>' +
+    '</div>';
+  }
+
   function initApp() {
     // Role-based access control
     if (!setupRoleBasedUI()) return;
@@ -3150,6 +3282,7 @@
     initSchemaEvolution();
     initUserManagement();
     initGroups();
+    initSystemStats();
     initLogout();
     loadMaterials();
 


### PR DESCRIPTION
## Summary
Implements a new "System Statistics" tab in the admin panel that provides SYSTEM_ADMIN users with a comprehensive overview of all materials' pipeline progress and usage statistics.

## Key Changes

**Backend (FastAPI)**
- Added `/admin/system/materials-stats` endpoint that returns aggregated statistics for all documents
- Implements complex SQL query with CTEs to calculate:
  - Script generation progress (percentage of chunks with spoken_text)
  - Audio generation progress (percentage of chunks with cached audio)
  - Enrolled student count per material
  - Chat message count per material
- Returns material metadata (title, filename, uploader, creation date) alongside pipeline metrics

**Frontend (HTML/JavaScript)**
- Added "System Statistics" tab button (hidden by default, shown only for SYSTEM_ADMIN)
- Implemented `initSystemStats()` to initialize the tab with event listeners
- Added `loadSystemStats()` to fetch data from the backend API
- Implemented `renderSystemStats()` with:
  - Teacher filter dropdown (dynamically populated from data)
  - Sortable columns (title, uploader, date, enrolled students, chat count)
  - Visual progress bars for script and audio generation with color-coded status
  - Ascending/descending sort indicators (△/▽)
- Added `ssProgressBar()` helper to render progress indicators with status labels (未着手/処理中/完了)
- Added `rebuildTeacherFilter()` to dynamically populate teacher filter options

**UI/HTML**
- Added new admin panel section with filter controls and refresh button
- Created sortable table with 7 columns: title, uploader, date, script progress, audio progress, enrolled students, chat count
- Styled with existing admin theme variables for consistency

## Notable Implementation Details
- Role-based access control: tab only visible and functional for SYSTEM_ADMIN users
- Efficient SQL aggregation using CTEs and LEFT JOINs to avoid N+1 queries
- Client-side sorting and filtering for responsive UX
- Progress bars use color coding: gray (未着手), blue (処理中), green (完了)
- Timestamps formatted in Japanese locale (ja-JP)
- HTML escaping for security when rendering user-provided content

https://claude.ai/code/session_015CL7AXFAQJ1vp7HHK1Ct8B