### PR TITLE
Fix settings patching for top-level dependencies module import

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,6 +33,13 @@ def _override_settings(monkeypatch):
         monkeypatch.setattr("api.dependencies._get_settings", _getter)
     except BaseException:
         pass  # api.dependencies が利用不可の環境（CI等）ではスキップ
+    # test_error_logs.py がモジュールレベルで routes.error_logs をインポートするため、
+    # 収集時に dependencies が top-level モジュールとして読み込まれる場合がある。
+    # その場合、api.dependencies とは別オブジェクトになるため個別にパッチする。
+    try:
+        monkeypatch.setattr("dependencies._get_settings", _getter)
+    except BaseException:
+        pass  # dependencies が未インポートの場合はスキップ
 
     yield
 


### PR DESCRIPTION
## Summary
Added additional patching logic to handle cases where the `dependencies` module is imported at the top level during test collection, ensuring settings are properly mocked in all scenarios.

## Key Changes
- Added a secondary `monkeypatch.setattr()` call to patch `dependencies._get_settings` directly
- This handles the case where `test_error_logs.py` imports `routes.error_logs` at module level, causing `dependencies` to be loaded as a top-level module separate from `api.dependencies`
- Wrapped the new patching in a try-except block to gracefully skip if the module hasn't been imported yet

## Implementation Details
The fix addresses a test isolation issue where the `dependencies` module can be imported independently during test collection, creating a separate object from `api.dependencies`. Without this additional patch, settings mocking would only apply to `api.dependencies._get_settings`, leaving the top-level `dependencies._get_settings` unpatched and potentially causing test failures or inconsistent behavior.

https://claude.ai/code/session_01DdZyaNmssVQ7AG9q9yG8E5