### PR TITLE
Handle missing SMILES DSL with fallback placeholder generation

### DIFF
--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -1815,6 +1815,10 @@ def _extract_chunk_structure_metadata(knowledge_graph: object) -> tuple[str | No
     edge_candidates = abstract.get("edges")
     if not isinstance(edge_candidates, list):
         edge_candidates = graph.get("relationships") if isinstance(graph.get("relationships"), list) else []
+
+    if not smiles_dsl and edge_candidates:
+        smiles_dsl = _synthesize_smiles_dsl(edge_candidates) or None
+
     ancestors = _build_ancestors_from_edges(edge_candidates)
 
     return smiles_dsl, variables, ancestors or None
@@ -2186,7 +2190,11 @@ def reanalyze_course_structure_background(
             knowledge_graph = build_knowledge_graph(full_text, title)
             smiles_dsl, variables, ancestors = _extract_chunk_structure_metadata(knowledge_graph)
             if not smiles_dsl:
-                raise RuntimeError("structure analysis completed but did not generate smiles_dsl")
+                # LLM が DSL を生成できなかった場合は題名から最小限のプレースホルダーを生成する
+                smiles_dsl = f"(doc:Resource:{_safe_dsl_value(title)})"
+                logger.warning(
+                    "smiles_dsl not generated for material %s, using placeholder", material_id
+                )
 
             session = _pg_session()
             try:

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -1667,8 +1667,7 @@ def build_knowledge_graph(text: str, title: str) -> dict:
             response_format=PaperStructure,
         )
         graph = _paper_structure_to_knowledge_graph(structure)
-        if graph.get("abstract_structure", {}).get("smiles_dsl"):
-            return graph
+        return graph  # smiles_dsl がなくても返す。呼び出し元で合成・プレースホルダーを処理する
     except Exception as exc:
         logger.warning("Structured knowledge graph extraction failed: %s", exc, exc_info=True)
 


### PR DESCRIPTION
## Summary
Modified the knowledge graph extraction and structure analysis pipeline to gracefully handle cases where the LLM fails to generate SMILES DSL, instead of raising an error. The system now generates a minimal placeholder DSL from the material title when synthesis fails.

## Key Changes
- **Removed conditional return in `build_knowledge_graph()`**: Changed to always return the knowledge graph regardless of whether `smiles_dsl` is present, allowing downstream processing to handle missing DSL
- **Added SMILES DSL synthesis fallback in `_extract_chunk_structure_metadata()`**: When `smiles_dsl` is not extracted but edge candidates exist, attempt to synthesize it using `_synthesize_smiles_dsl()`
- **Replaced error with placeholder generation in `reanalyze_course_structure_background()`**: Instead of raising `RuntimeError` when `smiles_dsl` is missing, generate a minimal placeholder using the format `(doc:Resource:{title})` and log a warning

## Implementation Details
- The placeholder DSL uses `_safe_dsl_value()` to sanitize the title for safe DSL representation
- Warning logs are emitted when fallback mechanisms are triggered to maintain observability
- The changes follow a graceful degradation pattern, allowing the system to continue processing with reduced fidelity rather than failing completely

https://claude.ai/code/session_01FK5m6uzbn9SmCVCQsWUpyf