### PR TITLE
Refactor groups UI from side-by-side to accordion layout

### DIFF
--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -364,19 +364,10 @@
 
         <div id="groups-status" class="upload-status" style="display:none"></div>
 
-        <!-- Group list + details -->
-        <div style="display:flex;gap:16px">
-          <div style="flex:0 0 260px">
-            <h4 style="font-size:13px;margin:0 0 8px 0;color:var(--color-text-secondary)">所属グループ</h4>
-            <div id="groups-list" style="border:1px solid var(--color-border);border-radius:4px;overflow:hidden">
-              <div style="padding:12px;color:var(--color-text-tertiary);font-size:13px">読み込み中...</div>
-            </div>
-          </div>
-          <div style="flex:1">
-            <div id="groups-detail">
-              <p style="color:var(--color-text-tertiary);font-size:13px">グループを選択してください</p>
-            </div>
-          </div>
+        <!-- Group list (accordion) -->
+        <h4 style="font-size:13px;margin:0 0 8px 0;color:var(--color-text-secondary)">所属グループ</h4>
+        <div id="groups-list" style="display:flex;flex-direction:column;gap:8px">
+          <div style="padding:12px;color:var(--color-text-tertiary);font-size:13px">読み込み中...</div>
         </div>
       </div>
     </div>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -3522,17 +3522,24 @@
     _groupsState.list.forEach(function (g) {
       var badge = g.my_role === "admin" ? '<span style="color:var(--color-text-success);font-size:11px;margin-left:4px">(admin)</span>' : "";
       var isSelected = g.id === _groupsState.selectedId;
+      var cardStyle = isSelected
+        ? "border:2px solid var(--color-text-success);border-radius:8px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.12);margin-bottom:0"
+        : "border:1px solid var(--color-border);border-radius:6px;overflow:hidden;opacity:0.8";
       var headerBg = isSelected ? "var(--color-bg-tertiary)" : "var(--color-bg-secondary)";
       var bodyDisplay = isSelected ? "block" : "none";
       var toggleIcon = isSelected ? "▲" : "▼";
+      var accentBar = isSelected
+        ? '<div style="height:3px;background:var(--color-text-success)"></div>'
+        : "";
       html +=
-        '<div style="border:1px solid var(--color-border);border-radius:6px;overflow:hidden">' +
+        '<div style="' + cardStyle + '">' +
+          accentBar +
           '<div class="groups-item" data-gid="' + escHtml(g.id) + '" style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px;cursor:pointer;background:' + headerBg + '">' +
             '<div>' +
-              '<div style="font-size:13px;font-weight:500">' + escHtml(g.name) + badge + "</div>" +
+              '<div style="font-size:13px;font-weight:' + (isSelected ? "600" : "500") + '">' + escHtml(g.name) + badge + "</div>" +
               '<div style="font-size:11px;color:var(--color-text-tertiary)">メンバー ' + (g.member_count || 0) + "人</div>" +
             "</div>" +
-            '<span style="font-size:10px;color:var(--color-text-tertiary)">' + toggleIcon + "</span>" +
+            '<span style="font-size:10px;color:' + (isSelected ? "var(--color-text-success)" : "var(--color-text-tertiary)") + '">' + toggleIcon + "</span>" +
           "</div>" +
           '<div id="groups-body-' + escHtml(g.id) + '" style="display:' + bodyDisplay + ";padding:16px;border-top:1px solid var(--color-border)\">" +
             (isSelected ? '<div style="font-size:13px;color:var(--color-text-tertiary)">読み込み中...</div>' : "") +

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -3521,10 +3521,22 @@
     var html = "";
     _groupsState.list.forEach(function (g) {
       var badge = g.my_role === "admin" ? '<span style="color:var(--color-text-success);font-size:11px;margin-left:4px">(admin)</span>' : "";
-      var on = g.id === _groupsState.selectedId ? 'background:var(--color-bg-tertiary);' : "";
-      html += '<div data-gid="' + escHtml(g.id) + '" class="groups-item" style="padding:8px 12px;cursor:pointer;border-bottom:1px solid var(--color-border);' + on + '">' +
-        '<div style="font-size:13px">' + escHtml(g.name) + badge + '</div>' +
-        '<div style="font-size:11px;color:var(--color-text-tertiary)">メンバー ' + (g.member_count || 0) + "人</div>" +
+      var isSelected = g.id === _groupsState.selectedId;
+      var headerBg = isSelected ? "var(--color-bg-tertiary)" : "var(--color-bg-secondary)";
+      var bodyDisplay = isSelected ? "block" : "none";
+      var toggleIcon = isSelected ? "▲" : "▼";
+      html +=
+        '<div style="border:1px solid var(--color-border);border-radius:6px;overflow:hidden">' +
+          '<div class="groups-item" data-gid="' + escHtml(g.id) + '" style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px;cursor:pointer;background:' + headerBg + '">' +
+            '<div>' +
+              '<div style="font-size:13px;font-weight:500">' + escHtml(g.name) + badge + "</div>" +
+              '<div style="font-size:11px;color:var(--color-text-tertiary)">メンバー ' + (g.member_count || 0) + "人</div>" +
+            "</div>" +
+            '<span style="font-size:10px;color:var(--color-text-tertiary)">' + toggleIcon + "</span>" +
+          "</div>" +
+          '<div id="groups-body-' + escHtml(g.id) + '" style="display:' + bodyDisplay + ";padding:16px;border-top:1px solid var(--color-border)\">" +
+            (isSelected ? '<div style="font-size:13px;color:var(--color-text-tertiary)">読み込み中...</div>' : "") +
+          "</div>" +
         "</div>";
     });
     el.innerHTML = html;
@@ -3546,12 +3558,15 @@
       })
       .then(renderGroupDetail)
       .catch(function () {
-        document.getElementById("groups-detail").innerHTML =
-          '<p style="color:var(--color-text-tertiary)">取得に失敗しました</p>';
+        var body = document.getElementById("groups-body-" + groupId);
+        if (body) body.innerHTML = '<p style="color:var(--color-text-tertiary)">取得に失敗しました</p>';
       });
   }
 
   function renderGroupDetail(g) {
+    var bodyEl = document.getElementById("groups-body-" + g.id);
+    if (!bodyEl) return;
+
     var isAdmin = g.my_role === "admin";
     var members = (g.members || []).map(function (m) {
       var actions = "";
@@ -3591,8 +3606,7 @@
         "</div>";
     }
 
-    document.getElementById("groups-detail").innerHTML =
-      '<h3 style="margin:0 0 4px 0">' + escHtml(g.name) + "</h3>" +
+    bodyEl.innerHTML =
       '<p style="color:var(--color-text-secondary);font-size:13px;margin:0 0 8px 0">' + escHtml(g.description || "") + "</p>" +
       inviteCodeBlock +
       '<h4 style="font-size:13px;margin:16px 0 8px 0">メンバー (' + (g.members || []).length + ")</h4>" +
@@ -3602,27 +3616,27 @@
       dangerZone;
 
     if (isAdmin) {
-      var rot = document.getElementById("groups-rotate-btn");
+      var rot = bodyEl.querySelector("#groups-rotate-btn");
       if (rot) rot.addEventListener("click", function () { rotateInviteCode(g.id); });
-      var invBtn = document.getElementById("groups-invite-btn");
+      var invBtn = bodyEl.querySelector("#groups-invite-btn");
       if (invBtn) invBtn.addEventListener("click", function () {
-        var u = document.getElementById("groups-invite-username").value.trim();
+        var u = bodyEl.querySelector("#groups-invite-username").value.trim();
         if (!u) return;
         inviteUser(g.id, u);
       });
-      var del = document.getElementById("groups-delete-btn");
+      var del = bodyEl.querySelector("#groups-delete-btn");
       if (del) del.addEventListener("click", function () {
         if (!confirm("グループ「" + g.name + "」を削除します。よろしいですか？")) return;
         deleteGroup(g.id);
       });
-      var removeBtns = document.querySelectorAll(".groups-remove-btn");
+      var removeBtns = bodyEl.querySelectorAll(".groups-remove-btn");
       for (var i = 0; i < removeBtns.length; i++) {
         removeBtns[i].addEventListener("click", function () {
           removeMember(g.id, this.getAttribute("data-uid"));
         });
       }
     } else {
-      var leave = document.querySelector(".groups-leave-btn");
+      var leave = bodyEl.querySelector(".groups-leave-btn");
       if (leave) leave.addEventListener("click", function () {
         if (!confirm("グループを退会しますか？")) return;
         removeMember(g.id, _meUserId());
@@ -3697,7 +3711,8 @@
       })
       .then(function () {
         setGroupsStatus("ユーザー「" + username + "」を招待しました。", "success");
-        document.getElementById("groups-invite-username").value = "";
+        var invInput = document.getElementById("groups-invite-username");
+        if (invInput) invInput.value = "";
         selectGroup(gid);
       })
       .catch(function (e) { setGroupsStatus("招待失敗: " + (e.detail || "不明なエラー"), "error"); });
@@ -3719,8 +3734,6 @@
         if (!res.ok) return res.json().then(function (d) { throw d; });
         setGroupsStatus("グループを削除しました。", "success");
         _groupsState.selectedId = null;
-        document.getElementById("groups-detail").innerHTML =
-          '<p style="color:var(--color-text-tertiary)">グループを選択してください</p>';
         loadGroups();
       })
       .catch(function (e) { setGroupsStatus("削除失敗: " + (e.detail || "不明なエラー"), "error"); });


### PR DESCRIPTION
## Summary
Converted the group management interface from a two-column layout (list + details side-by-side) to an accordion-style expandable list, improving space efficiency and mobile responsiveness.

## Key Changes
- **Layout restructuring**: Changed from a flex layout with separate list and detail panels to a single accordion-style list where each group item expands to show details
- **Visual improvements**: 
  - Added toggle icons (▲/▼) to indicate expanded/collapsed state
  - Applied distinct background colors for selected vs. unselected items
  - Added border-radius and improved spacing for better visual hierarchy
- **DOM structure changes**:
  - Removed the separate `#groups-detail` container
  - Created dynamic `#groups-body-{groupId}` containers for each group's expandable content
  - Each group now has a collapsible header with name and member count
- **Event handling updates**:
  - Updated all event listeners to query within the specific group body element instead of document-wide
  - Changed from `document.getElementById()` to scoped `bodyEl.querySelector()` for better encapsulation
  - Added null checks for dynamically created elements
- **HTML cleanup**: Removed the two-column wrapper div and consolidated the layout into a single flex column

## Implementation Details
- Group details are now rendered inline within each group's expandable body section
- The accordion state is managed by the `display` CSS property (block/none) based on selection
- All form inputs and buttons are now scoped to their parent group body to prevent conflicts when multiple groups are rendered
- Loading state ("読み込み中...") is shown only in the expanded group's body

https://claude.ai/code/session_018zTfobJX2Txf62vGtwyYmF