### PR TITLE
Add domain cartridge loader and particle physics cartridge (Issue #176)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,13 @@ CORS_ORIGINS=*
 
 # Admin エラー解析画面で保持・返却するログ最大件数
 ADMIN_ERROR_LOG_MAX_ITEMS=1000
+
+
+# --- Domain Cartridge ---
+# 使用するデフォルトのドメインカートリッジ
+# 現時点では particle_physics のみを想定
+EPISTEME_DEFAULT_CARTRIDGE_ID=particle_physics
+
+# カートリッジ定義ディレクトリを変更したい場合のみ指定
+# 未指定時は backend/cartridges を使用
+# EPISTEME_CARTRIDGES_DIR=/app/cartridges

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -2052,6 +2052,8 @@ def approve_schema_proposal_with_scope(
 # ---------------------------------------------------------------------------
 from routes.lecture_studio import router as _lecture_studio_router  # noqa: E402
 from routes.theory_components import router as _theory_components_router  # noqa: E402
+from routes.cartridges import router as _cartridges_router  # noqa: E402
 
 router.include_router(_lecture_studio_router)
 router.include_router(_theory_components_router)
+router.include_router(_cartridges_router)

--- a/backend/api/routes/cartridges.py
+++ b/backend/api/routes/cartridges.py
@@ -1,0 +1,105 @@
+"""Domain cartridge endpoints (Issue #176)。
+
+`backend/cartridges/` 配下に格納されたカートリッジ定義を読み取り専用で公開する。
+書き込みは MVP では不要。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from core.cartridges import (
+    CartridgeSummary,
+    DomainCartridge,
+    list_cartridges,
+    load_cartridge,
+)
+from dependencies import _require_teacher
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/cartridges", tags=["Admin"])
+
+
+def _summary_to_dict(summary: CartridgeSummary) -> dict:
+    return {
+        "cartridge_id": summary.cartridge_id,
+        "name": summary.name,
+        "version": summary.version,
+        "description": summary.description,
+        "target_domain": list(summary.target_domain),
+    }
+
+
+def _load_or_404(cartridge_id: str) -> DomainCartridge:
+    try:
+        return load_cartridge(cartridge_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"cartridge '{cartridge_id}' not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("")
+def list_available_cartridges(current_user: dict = Depends(_require_teacher)) -> list[dict]:
+    """利用可能なカートリッジのサマリ一覧を返す。"""
+    return [_summary_to_dict(summary) for summary in list_cartridges()]
+
+
+@router.get("/{cartridge_id}")
+def get_cartridge(cartridge_id: str, current_user: dict = Depends(_require_teacher)) -> dict:
+    """カートリッジ全体 (manifest + ontology + 各種定義) を返す。"""
+    cartridge = _load_or_404(cartridge_id)
+    return cartridge.to_dict()
+
+
+@router.get("/{cartridge_id}/ontology")
+def get_cartridge_ontology(
+    cartridge_id: str, current_user: dict = Depends(_require_teacher)
+) -> dict:
+    """カートリッジの ontology 部分のみを返す。"""
+    cartridge = _load_or_404(cartridge_id)
+    return {
+        "concept_types": list(cartridge.ontology.concept_types),
+        "aliases": list(cartridge.ontology.aliases),
+        "notation_patterns": list(cartridge.ontology.notation_patterns),
+        "extraction_hints": list(cartridge.ontology.extraction_hints),
+        "normalization_rules": list(cartridge.ontology.normalization_rules),
+    }
+
+
+@router.get("/{cartridge_id}/component-types")
+def get_cartridge_component_types(
+    cartridge_id: str, current_user: dict = Depends(_require_teacher)
+) -> dict:
+    cartridge = _load_or_404(cartridge_id)
+    return {"component_types": list(cartridge.component_types)}
+
+
+@router.get("/{cartridge_id}/relation-types")
+def get_cartridge_relation_types(
+    cartridge_id: str, current_user: dict = Depends(_require_teacher)
+) -> dict:
+    cartridge = _load_or_404(cartridge_id)
+    return {"relation_types": list(cartridge.relation_types)}
+
+
+@router.get("/{cartridge_id}/maturity-levels")
+def get_cartridge_maturity_levels(
+    cartridge_id: str, current_user: dict = Depends(_require_teacher)
+) -> dict:
+    cartridge = _load_or_404(cartridge_id)
+    return {
+        "maturity_levels": list(cartridge.maturity_levels),
+        "maturity_sources": list(cartridge.maturity_sources),
+    }
+
+
+@router.get("/{cartridge_id}/support-statuses")
+def get_cartridge_support_statuses(
+    cartridge_id: str, current_user: dict = Depends(_require_teacher)
+) -> dict:
+    cartridge = _load_or_404(cartridge_id)
+    return {"support_statuses": list(cartridge.support_statuses)}

--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -217,6 +217,20 @@ def _json_obj(value: object) -> dict:
     return {}
 
 
+def _normalize_rewrite_result(parsed: object, studio_view: str) -> dict:
+    """LLM の rewrite 応答を dict に正規化する。
+
+    LLM が JSON オブジェクトではなくトップレベル配列で返してくることがある。
+    studio_view="theory" の場合のみ、その配列を ``theory_components`` として扱う。
+    それ以外は空 dict を返してフォールバック値で穴埋めする。
+    """
+    if isinstance(parsed, dict):
+        return parsed
+    if isinstance(parsed, list) and studio_view == "theory":
+        return {"theory_components": parsed}
+    return {}
+
+
 def _extract_document_dsl(knowledge_graph: dict) -> str:
     abstract = knowledge_graph.get("abstract_structure")
     if isinstance(abstract, dict):
@@ -976,7 +990,7 @@ def rewrite_lecture_script(
             lines = cleaned.split("\n")
             lines = [ln for ln in lines if not ln.strip().startswith("```")]
             cleaned = "\n".join(lines)
-        result = json.loads(cleaned, strict=False)
+        result = _normalize_rewrite_result(json.loads(cleaned, strict=False), studio_view)
         theory_components = result.get("theory_components", [])
         display_text = result.get("display_text") or current_display
         spoken_text = result.get("spoken_text", current_spoken)

--- a/backend/cartridges/particle_physics/cartridge.json
+++ b/backend/cartridges/particle_physics/cartridge.json
@@ -1,0 +1,36 @@
+{
+  "cartridge_id": "particle_physics",
+  "name": "Particle Physics Cartridge",
+  "version": "0.1.0",
+  "description": "素粒子物理・理論物理文献から理論コンポーネントを抽出・検証するためのドメイン定義。",
+  "target_domain": [
+    "particle_physics",
+    "quantum_field_theory",
+    "flavor_physics",
+    "effective_field_theory"
+  ],
+  "default_language": "ja",
+  "source_policy": {
+    "allow_domain_inference": true,
+    "require_support_status": true,
+    "require_maturity_level": true,
+    "require_maturity_source": true,
+    "require_teacher_review_for": [
+      "domain_inferred",
+      "design_inferred",
+      "invalid_or_caution_conditions",
+      "validation_rules",
+      "maturity_level_if_llm_proposed"
+    ]
+  },
+  "files": {
+    "ontology": "ontology.json",
+    "component_types": "component_types.json",
+    "relation_types": "relation_types.json",
+    "maturity_levels": "maturity_levels.json",
+    "support_statuses": "support_statuses.json",
+    "extraction_prompt": "extraction_prompt.md",
+    "review_prompt": "review_prompt.md",
+    "validation_rules": "validation_rules.json"
+  }
+}

--- a/backend/cartridges/particle_physics/component_types.json
+++ b/backend/cartridges/particle_physics/component_types.json
@@ -1,0 +1,70 @@
+{
+  "component_types": [
+    {
+      "id": "DomainConceptComponent",
+      "origin": "domain",
+      "description": "分野内で共有される基本概念。",
+      "default_maturity_level": "canonical"
+    },
+    {
+      "id": "DomainTheoryComponent",
+      "origin": "domain",
+      "description": "分野内で標準的に共有される理論。",
+      "default_maturity_level": "canonical"
+    },
+    {
+      "id": "DomainMethodComponent",
+      "origin": "domain",
+      "description": "分野内で広く使われる解析・計算手法。",
+      "default_maturity_level": "standard_method"
+    },
+    {
+      "id": "DomainAssumptionComponent",
+      "origin": "domain",
+      "description": "分野で一般的に使われる近似・仮定。",
+      "default_maturity_level": "standard_method"
+    },
+    {
+      "id": "DomainObservableComponent",
+      "origin": "domain",
+      "description": "分野で共有される観測量定義。",
+      "default_maturity_level": "canonical"
+    },
+    {
+      "id": "PaperClaimComponent",
+      "origin": "paper",
+      "description": "個別論文に由来する主張。",
+      "default_maturity_level": "paper_claim"
+    },
+    {
+      "id": "PaperHypothesisComponent",
+      "origin": "paper",
+      "description": "個別論文に由来する仮説的主張。",
+      "default_maturity_level": "paper_hypothesis"
+    },
+    {
+      "id": "PaperRelationComponent",
+      "origin": "paper",
+      "description": "個別論文で提示・利用される関係式。",
+      "default_maturity_level": "paper_claim"
+    },
+    {
+      "id": "PaperCorrectionComponent",
+      "origin": "paper",
+      "description": "個別論文で導入・評価された補正項。",
+      "default_maturity_level": "model_dependent_result"
+    },
+    {
+      "id": "PaperUncertaintyComponent",
+      "origin": "paper",
+      "description": "個別論文で扱われる不確実性。",
+      "default_maturity_level": "model_dependent_result"
+    },
+    {
+      "id": "PaperEvidenceComponent",
+      "origin": "paper",
+      "description": "個別論文に含まれる数値結果・図表・実験結果。",
+      "default_maturity_level": "paper_claim"
+    }
+  ]
+}

--- a/backend/cartridges/particle_physics/examples/hqet_domain_component.json
+++ b/backend/cartridges/particle_physics/examples/hqet_domain_component.json
@@ -1,0 +1,58 @@
+{
+  "component_id": "domain.hqet",
+  "name": "Heavy Quark Effective Theory (HQET)",
+  "component_type": "DomainTheoryComponent",
+  "domain": "particle_physics",
+  "origin": "domain",
+  "maturity_level": "canonical",
+  "maturity_source": "curated_registry",
+  "maturity_rationale": "教科書・標準理論レベルで定着している重クォーク有効理論。",
+  "review_status": "teacher_approved",
+  "source": {
+    "document_id": "",
+    "pages": [],
+    "sections": [],
+    "equations": [],
+    "chunks": []
+  },
+  "description": {
+    "value": "重クォーク質量 m_Q → ∞ の極限で QCD を展開する有効場理論。重い b/c クォークを含むハドロン物理の解析で標準的に用いられる。",
+    "support_status": "domain_inferred",
+    "review_status": "teacher_approved"
+  },
+  "inputs": [
+    {"label": "QCD Lagrangian", "type": "Theory", "required": true},
+    {"label": "heavy quark limit", "type": "Approximation", "required": true}
+  ],
+  "outputs": [
+    {"label": "Isgur-Wise function", "type": "Parameter"},
+    {"label": "1/m_Q expansion", "type": "Approximation"}
+  ],
+  "preconditions": [
+    {"label": "重クォーク質量が ΛQCD より十分大きい", "support_status": "domain_inferred"}
+  ],
+  "constraints": [
+    {"label": "1/m_Q^2 以上の補正は別途評価する", "support_status": "domain_inferred"}
+  ],
+  "cautions": [
+    {"label": "軽いクォーク系 (u, d, s) には適用できない", "support_status": "domain_inferred"}
+  ],
+  "dependencies": [
+    {"component_id": "domain.qcd", "relation": "REQUIRES"}
+  ],
+  "internal_flow": [],
+  "connectors": {
+    "requires_before_use": ["domain.qcd"],
+    "can_accept": ["Theory", "Approximation"],
+    "can_output_to": ["Parameter", "Theory"],
+    "may_conflict_with": []
+  },
+  "blackbox_policy": {
+    "io_summary": "QCD と heavy quark limit から Isgur-Wise 関数と 1/m_Q 展開を導く。",
+    "expand_when_unlearned": true,
+    "requires_source_display": false
+  },
+  "unit_test_targets": [],
+  "integration_test_targets": [],
+  "review_notes": []
+}

--- a/backend/cartridges/particle_physics/examples/jhep_b_to_c_sum_rule_component.json
+++ b/backend/cartridges/particle_physics/examples/jhep_b_to_c_sum_rule_component.json
@@ -1,0 +1,63 @@
+{
+  "component_id": "paper.b_to_c_sum_rule.r_d_consistency",
+  "name": "b → c τν 過程における R_D / R_D* / R_Λc の整合性チェック",
+  "component_type": "PaperRelationComponent",
+  "domain": "particle_physics",
+  "origin": "paper",
+  "maturity_level": "paper_claim",
+  "maturity_source": "cartridge_default",
+  "maturity_rationale": "JHEP 論文中で提示された関係式に基づき、PaperRelationComponent の default を採用。",
+  "review_status": "teacher_review_required",
+  "source": {
+    "document_id": "jhep_b_to_c_sum_rule_2024",
+    "pages": [3, 4, 5],
+    "sections": ["Section 3", "Section 4"],
+    "equations": ["Eq. (3.4)", "Eq. (4.7)"],
+    "chunks": []
+  },
+  "description": {
+    "value": "B → D τν, B → D* τν, Λb → Λc τν の各崩壊比 (R_D, R_D*, R_Λc) を、新物理 Wilson 係数 (C_VL, C_SL, C_T) を媒介変数として整合的に表現する関係式。",
+    "support_status": "source_backed",
+    "review_status": "teacher_review_required"
+  },
+  "inputs": [
+    {"label": "C_VL", "type": "Parameter", "required": true, "description": "ベクトル左巻き Wilson 係数"},
+    {"label": "C_SL", "type": "Parameter", "required": false, "description": "スカラー左巻き Wilson 係数"},
+    {"label": "C_T", "type": "Parameter", "required": false, "description": "テンソル Wilson 係数"},
+    {"label": "form factors", "type": "Parameter", "required": true, "description": "B → D, B → D*, Λb → Λc の遷移形状因子"}
+  ],
+  "outputs": [
+    {"label": "R_D", "type": "Observable", "description": "Br(B → Dτν)/Br(B → Dℓν)"},
+    {"label": "R_D*", "type": "Observable", "description": "Br(B → D*τν)/Br(B → D*ℓν)"},
+    {"label": "R_Λc", "type": "Observable", "description": "Br(Λb → Λcτν)/Br(Λb → Λcℓν)"}
+  ],
+  "preconditions": [
+    {"label": "標準模型を出発点とする", "support_status": "source_backed"},
+    {"label": "新物理は (V-A) 構造の演算子を主として含む", "support_status": "source_inferred"}
+  ],
+  "constraints": [
+    {"label": "form factor の不確実性を別途扱う", "support_status": "source_backed"}
+  ],
+  "cautions": [
+    {"label": "form factor のパラメータ化に依存する", "support_status": "domain_inferred"}
+  ],
+  "dependencies": [
+    {"component_id": "domain.hqet", "relation": "REQUIRES"},
+    {"component_id": "domain.standard_model", "relation": "ASSUMES"}
+  ],
+  "internal_flow": [],
+  "connectors": {
+    "requires_before_use": ["domain.hqet"],
+    "can_accept": ["Parameter"],
+    "can_output_to": ["Observable"],
+    "may_conflict_with": ["paper.alternative_rd_explanation"]
+  },
+  "blackbox_policy": {
+    "io_summary": "Wilson係数と形状因子を入力として R_D / R_D* / R_Λc の整合関係を返す。",
+    "expand_when_unlearned": true,
+    "requires_source_display": true
+  },
+  "unit_test_targets": ["R_D の値域チェック", "R_D* の値域チェック"],
+  "integration_test_targets": ["R_Λc を含む 3 観測量の同時フィット"],
+  "review_notes": []
+}

--- a/backend/cartridges/particle_physics/extraction_prompt.md
+++ b/backend/cartridges/particle_physics/extraction_prompt.md
@@ -1,0 +1,113 @@
+# 素粒子物理カートリッジ — 抽出プロンプト
+
+あなたは素粒子物理・理論物理学の文献から、理論コンポーネント候補を抽出するアシスタントです。
+
+## 抽出対象
+
+ソース本文・既存DSL・variables・graph_elements を入力として、
+ドメイン知識由来 (Domain*Component) と論文由来 (Paper*Component) を区別したコンポーネントを抽出してください。
+
+## 重要な制約
+
+1. **ドメイン由来と論文由来の区別**
+   - その論文に明示されている内容 → `Paper*Component` のいずれか
+   - 分野で標準的に共有されている知識 → `Domain*Component` のいずれか
+2. **support_status と maturity_level の混同を避ける**
+   - `support_status` は根拠の種類 (例: source_backed, domain_inferred)
+   - `maturity_level` は知識の確立度 (例: canonical, paper_claim)
+3. **maturity_level の暫定提案**
+   - LLM が判断した場合は必ず `maturity_source = "llm_proposed"` を付与
+   - 必ず `maturity_rationale` も併せて返す
+4. **review_status の付与**
+   - 確定値として保存できないものは `teacher_review_required`
+5. **JSONのみを出力**
+
+## 出力フォーマット
+
+```json
+{
+  "components": [
+    {
+      "component_id": "",
+      "name": "",
+      "component_type": "PaperClaimComponent | DomainTheoryComponent | ...",
+      "domain": "particle_physics",
+      "origin": "domain | paper",
+      "maturity_level": "",
+      "maturity_source": "llm_proposed | cartridge_default",
+      "maturity_rationale": "",
+      "review_status": "teacher_review_required",
+      "source": {
+        "document_id": "",
+        "pages": [],
+        "sections": [],
+        "equations": [],
+        "chunks": []
+      },
+      "description": {
+        "value": "",
+        "support_status": "source_backed | source_inferred | domain_inferred | design_inferred",
+        "review_status": "teacher_review_required"
+      },
+      "inputs": [],
+      "outputs": [],
+      "preconditions": [],
+      "constraints": [],
+      "cautions": [],
+      "dependencies": [],
+      "internal_flow": [],
+      "connectors": {
+        "requires_before_use": [],
+        "can_accept": [],
+        "can_output_to": [],
+        "may_conflict_with": []
+      },
+      "blackbox_policy": {
+        "io_summary": "",
+        "expand_when_unlearned": true,
+        "requires_source_display": true
+      },
+      "unit_test_targets": [],
+      "integration_test_targets": [],
+      "review_notes": []
+    }
+  ]
+}
+```
+
+## 入力テンプレート
+
+```
+ソース本文:
+{source_text}
+
+既存DSL:
+{smiles_dsl}
+
+variables:
+{variables}
+
+ancestors:
+{ancestors}
+
+graph_elements:
+{graph_elements}
+
+ontology (concept_types):
+{ontology_concept_types}
+
+component_types:
+{component_types}
+
+relation_types:
+{relation_types}
+
+maturity_levels:
+{maturity_levels}
+
+support_statuses:
+{support_statuses}
+
+curated_components:
+{curated_components}
+```

--- a/backend/cartridges/particle_physics/maturity_levels.json
+++ b/backend/cartridges/particle_physics/maturity_levels.json
@@ -1,0 +1,62 @@
+{
+  "maturity_levels": [
+    {
+      "id": "canonical",
+      "label_ja": "標準知識",
+      "description": "教科書・標準理論レベルで定着している知識。"
+    },
+    {
+      "id": "standard_method",
+      "label_ja": "標準手法",
+      "description": "分野内で広く使われる解析手法・計算手法。"
+    },
+    {
+      "id": "reviewed_consensus",
+      "label_ja": "レビュー済み合意",
+      "description": "レビュー論文や複数研究で支持される知識。"
+    },
+    {
+      "id": "paper_claim",
+      "label_ja": "論文主張",
+      "description": "単一論文に基づく主張。"
+    },
+    {
+      "id": "paper_hypothesis",
+      "label_ja": "論文仮説",
+      "description": "論文中で提示された仮説・解釈。"
+    },
+    {
+      "id": "model_dependent_result",
+      "label_ja": "モデル依存結果",
+      "description": "特定モデル・近似・パラメータ化に依存する結果。"
+    },
+    {
+      "id": "experimental_report",
+      "label_ja": "実験報告",
+      "description": "実験結果・測定値・観測報告。"
+    },
+    {
+      "id": "speculative",
+      "label_ja": "探索的仮説",
+      "description": "先端的・未検証・探索的な仮説。"
+    },
+    {
+      "id": "contested",
+      "label_ja": "議論あり",
+      "description": "分野内で議論がある、または結果が一致していない知識。"
+    },
+    {
+      "id": "deprecated",
+      "label_ja": "非推奨・旧知識",
+      "description": "古くなった、または現在では採用されにくい知識。"
+    }
+  ],
+  "maturity_sources": [
+    {"id": "cartridge_default", "label_ja": "カートリッジ既定値"},
+    {"id": "curated_registry", "label_ja": "登録済みレジストリ"},
+    {"id": "llm_proposed", "label_ja": "LLM暫定提案"},
+    {"id": "teacher_reviewed", "label_ja": "教員レビュー済み"},
+    {"id": "external_registry", "label_ja": "外部レジストリ"},
+    {"id": "unknown", "label_ja": "不明"}
+  ]
+}

--- a/backend/cartridges/particle_physics/ontology.json
+++ b/backend/cartridges/particle_physics/ontology.json
@@ -1,0 +1,83 @@
+{
+  "concept_types": [
+    {
+      "id": "Theory",
+      "label_ja": "理論",
+      "label_en": "Theory",
+      "examples": ["Standard Model", "HQET", "QCD"]
+    },
+    {
+      "id": "Approximation",
+      "label_ja": "近似",
+      "label_en": "Approximation",
+      "examples": ["heavy quark limit", "zero-recoil limit"]
+    },
+    {
+      "id": "Observable",
+      "label_ja": "観測量",
+      "label_en": "Observable",
+      "examples": ["R_D", "R_D*", "R_Λc", "branching ratio"]
+    },
+    {
+      "id": "CorrectionTerm",
+      "label_ja": "補正項",
+      "label_en": "Correction Term",
+      "examples": ["δR", "higher-order contribution"]
+    },
+    {
+      "id": "UncertaintySource",
+      "label_ja": "不確実性源",
+      "label_en": "Uncertainty Source",
+      "examples": ["form factor uncertainty", "experimental uncertainty"]
+    },
+    {
+      "id": "Operator",
+      "label_ja": "演算子",
+      "label_en": "Operator",
+      "examples": ["O_VL", "O_SL", "O_T"]
+    },
+    {
+      "id": "Parameter",
+      "label_ja": "パラメータ",
+      "label_en": "Parameter",
+      "examples": ["Wilson coefficient", "form factor", "Isgur-Wise function"]
+    },
+    {
+      "id": "DecayProcess",
+      "label_ja": "崩壊過程",
+      "label_en": "Decay Process",
+      "examples": ["B → Dτν", "Λb → Λcτν"]
+    }
+  ],
+  "aliases": [
+    {
+      "canonical": "Heavy Quark Effective Theory",
+      "aliases": ["HQET", "heavy quark effective theory"]
+    },
+    {
+      "canonical": "Standard Model",
+      "aliases": ["SM", "standard model"]
+    }
+  ],
+  "notation_patterns": [
+    {
+      "id": "observable_ratio_r",
+      "pattern": "R_[A-Za-z0-9*Λ_]+",
+      "concept_type": "Observable"
+    },
+    {
+      "id": "wilson_coefficient",
+      "pattern": "C_[A-Za-z0-9]+",
+      "concept_type": "Parameter"
+    }
+  ],
+  "extraction_hints": [
+    "Theory と Approximation は明示的に区別する。Heavy Quark Effective Theory は Theory、heavy quark limit は Approximation。",
+    "Observable と Parameter を混同しないように注意する。R_D は Observable、Wilson Coefficient C_VL は Parameter。",
+    "DecayProcess は最終状態粒子まで含めて特定する。"
+  ],
+  "normalization_rules": [
+    {"id": "lowercase_alias", "description": "alias 一致は大文字小文字を区別しない"},
+    {"id": "canonical_first", "description": "canonical 名で正規化したうえで保存する"}
+  ]
+}

--- a/backend/cartridges/particle_physics/relation_types.json
+++ b/backend/cartridges/particle_physics/relation_types.json
@@ -1,0 +1,19 @@
+{
+  "relation_types": [
+    {"id": "REQUIRES", "label_ja": "必要とする"},
+    {"id": "ASSUMES", "label_ja": "仮定する"},
+    {"id": "PRODUCES", "label_ja": "出力する"},
+    {"id": "APPROXIMATES", "label_ja": "近似する"},
+    {"id": "CORRECTS", "label_ja": "補正する"},
+    {"id": "RELATES", "label_ja": "関係づける"},
+    {"id": "CHECKS_CONSISTENCY_OF", "label_ja": "整合性を検査する"},
+    {"id": "UNCERTAIN_DUE_TO", "label_ja": "不確実性の原因を持つ"},
+    {"id": "CONFLICTS_WITH", "label_ja": "矛盾する"},
+    {"id": "REFINES", "label_ja": "精緻化する"},
+    {"id": "CHALLENGES", "label_ja": "異議を唱える"},
+    {"id": "SUPPORTS", "label_ja": "支持する"},
+    {"id": "CONTRADICTS", "label_ja": "反証・矛盾する"},
+    {"id": "EXTENDS", "label_ja": "拡張する"},
+    {"id": "LIMITS", "label_ja": "適用範囲を制限する"}
+  ]
+}

--- a/backend/cartridges/particle_physics/review_prompt.md
+++ b/backend/cartridges/particle_physics/review_prompt.md
@@ -1,0 +1,44 @@
+# 素粒子物理カートリッジ — レビュープロンプト
+
+あなたは素粒子物理学・理論物理学の専門家として、理論コンポーネント候補をレビューするアシスタントです。
+
+## レビュー観点
+
+1. **origin と component_type が整合しているか**
+   - origin = paper の場合、component_type は Paper*Component であるべき
+   - origin = domain の場合、component_type は Domain*Component であるべき
+
+2. **support_status は根拠と合っているか**
+   - source_backed の場合、ソース本文に明示的な引用が存在するか
+   - domain_inferred の場合、分野で共有された知識として妥当か
+
+3. **maturity_level は妥当か**
+   - canonical を主張するには教科書・標準理論レベルの定着が必要
+   - paper_hypothesis の根拠は単一論文の主張・解釈で十分
+
+4. **maturity_source の扱い**
+   - llm_proposed の値は確定値として扱わない
+   - 教員レビュー後は teacher_reviewed に昇格させてよい
+
+5. **inputs/outputs/dependencies の接続検証**
+   - inputs/outputs の type が ontology の concept_types に含まれるか
+   - dependencies が他コンポーネントの outputs と接続可能か
+
+6. **invalid_or_caution_conditions の網羅性**
+   - 適用範囲・限界・禁止事項が明示されているか
+
+## 出力フォーマット
+
+```json
+{
+  "review_results": [
+    {
+      "component_id": "",
+      "verdict": "approved | needs_revision | rejected",
+      "review_notes": [],
+      "suggested_maturity_level": "",
+      "suggested_review_status": "teacher_approved | teacher_review_required | rejected"
+    }
+  ]
+}
+```

--- a/backend/cartridges/particle_physics/support_statuses.json
+++ b/backend/cartridges/particle_physics/support_statuses.json
@@ -1,0 +1,39 @@
+{
+  "support_statuses": [
+    {
+      "id": "source_backed",
+      "label_ja": "出典明示",
+      "description": "対象ソースに明示されている。"
+    },
+    {
+      "id": "source_inferred",
+      "label_ja": "出典から推論",
+      "description": "対象ソースから自然に推論できる。"
+    },
+    {
+      "id": "domain_inferred",
+      "label_ja": "ドメイン知識で補完",
+      "description": "一般的な分野知識に基づき補完した。"
+    },
+    {
+      "id": "design_inferred",
+      "label_ja": "仕様設計で補完",
+      "description": "接続・検証可能なコンポーネント仕様にするため補完した。"
+    },
+    {
+      "id": "teacher_review_required",
+      "label_ja": "教員確認待ち",
+      "description": "教育・研究利用の前に専門家確認が必要。"
+    },
+    {
+      "id": "teacher_approved",
+      "label_ja": "教員承認済み",
+      "description": "教員または専門家が承認済み。"
+    },
+    {
+      "id": "rejected",
+      "label_ja": "却下",
+      "description": "レビューにより却下された。"
+    }
+  ]
+}

--- a/backend/cartridges/particle_physics/validation_rules.json
+++ b/backend/cartridges/particle_physics/validation_rules.json
@@ -1,0 +1,36 @@
+{
+  "validation_rules": [
+    {
+      "id": "component_type_must_be_known",
+      "description": "component_type は component_types.json の id に含まれていなければならない。"
+    },
+    {
+      "id": "maturity_level_must_be_known",
+      "description": "maturity_level は maturity_levels.json の id に含まれていなければならない。"
+    },
+    {
+      "id": "maturity_source_required",
+      "description": "maturity_level が設定されている場合、maturity_source も必ず付ける。"
+    },
+    {
+      "id": "support_status_required",
+      "description": "description.support_status は support_statuses.json の id に含まれていなければならない。"
+    },
+    {
+      "id": "origin_consistency",
+      "description": "origin = paper の場合は Paper*Component、domain の場合は Domain*Component を使う。"
+    },
+    {
+      "id": "llm_proposed_requires_review",
+      "description": "maturity_source = llm_proposed の場合、review_status は teacher_review_required でなければならない。"
+    },
+    {
+      "id": "input_output_types_known",
+      "description": "inputs/outputs の type は ontology.concept_types に含まれることが望ましい (warning レベル)。"
+    },
+    {
+      "id": "source_backed_requires_quote",
+      "description": "support_status = source_backed の場合、source_refs に quote が必要。"
+    }
+  ]
+}

--- a/backend/core/cartridges.py
+++ b/backend/core/cartridges.py
@@ -17,11 +17,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+
+from core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -30,15 +31,23 @@ logger = logging.getLogger(__name__)
 # Path resolution
 # ---------------------------------------------------------------------------
 
-_DEFAULT_CARTRIDGE_ID = "particle_physics"
+_FALLBACK_CARTRIDGE_ID = "particle_physics"
+
+
+def _default_cartridge_id() -> str:
+    """Settings.default_cartridge_id を返す。未設定・空文字時は particle_physics にフォールバック。"""
+    settings = get_settings()
+    value = (getattr(settings, "default_cartridge_id", "") or "").strip()
+    return value or _FALLBACK_CARTRIDGE_ID
 
 
 def _cartridges_root() -> Path:
     """`backend/cartridges/` の絶対パスを返す。
 
-    環境変数 ``EPISTEME_CARTRIDGES_DIR`` で上書きできる(テスト用)。
+    ``Settings.cartridges_dir`` で上書きできる。未設定時は ``backend/cartridges``。
     """
-    override = os.getenv("EPISTEME_CARTRIDGES_DIR")
+    settings = get_settings()
+    override = (getattr(settings, "cartridges_dir", "") or "").strip()
     if override:
         return Path(override).resolve()
     # backend/core/cartridges.py → backend/
@@ -330,14 +339,18 @@ def _cached_load(cartridge_id: str, root: str) -> DomainCartridge:
 
 
 def load_cartridge(cartridge_id: str | None = None) -> DomainCartridge:
-    """カートリッジを読み込む。``cartridge_id`` 省略時はデフォルト(particle_physics)。"""
-    target = cartridge_id or _DEFAULT_CARTRIDGE_ID
+    """カートリッジを読み込む。
+
+    ``cartridge_id`` 省略時は ``Settings.default_cartridge_id`` を使用する。
+    ``Settings.default_cartridge_id`` が未設定・空文字の場合は particle_physics にフォールバックする。
+    """
+    target = (cartridge_id or "").strip() or _default_cartridge_id()
     root = str(_cartridges_root())
     return _cached_load(target, root)
 
 
 def get_default_cartridge() -> DomainCartridge:
-    return load_cartridge(_DEFAULT_CARTRIDGE_ID)
+    return load_cartridge()
 
 
 def list_cartridges() -> list[CartridgeSummary]:

--- a/backend/core/cartridges.py
+++ b/backend/core/cartridges.py
@@ -1,0 +1,424 @@
+"""ドメインカートリッジローダー (Issue #176)。
+
+`backend/cartridges/<cartridge_id>/` 配下の JSON / Markdown 一式を読み込み、
+抽出・正規化・検証・UI表示・接続検証で参照できる形に統合する。
+
+設計上の重要事項:
+
+- 本モジュールは FastAPI / SQLAlchemy / OpenAI など外部依存を持たないこと。
+  単体テストおよび CI で外部サービスなしに動作する必要がある。
+- カートリッジ定義は読み取り専用としてキャッシュする。書き込みは行わない。
+- 将来的に他分野カートリッジを追加できるようディレクトリ走査でリストする。
+- 「素粒子物理学に限定した有効性検証」を優先するため、現時点では
+  particle_physics 以外のカートリッジは存在しなくてよい。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CARTRIDGE_ID = "particle_physics"
+
+
+def _cartridges_root() -> Path:
+    """`backend/cartridges/` の絶対パスを返す。
+
+    環境変数 ``EPISTEME_CARTRIDGES_DIR`` で上書きできる(テスト用)。
+    """
+    override = os.getenv("EPISTEME_CARTRIDGES_DIR")
+    if override:
+        return Path(override).resolve()
+    # backend/core/cartridges.py → backend/
+    return Path(__file__).resolve().parent.parent / "cartridges"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CartridgeSummary:
+    cartridge_id: str
+    name: str
+    version: str
+    description: str
+    target_domain: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Ontology:
+    concept_types: tuple[dict[str, Any], ...]
+    aliases: tuple[dict[str, Any], ...]
+    notation_patterns: tuple[dict[str, Any], ...]
+    extraction_hints: tuple[str, ...]
+    normalization_rules: tuple[dict[str, Any], ...]
+
+    @property
+    def concept_type_ids(self) -> tuple[str, ...]:
+        return tuple(str(c.get("id", "")) for c in self.concept_types if c.get("id"))
+
+
+@dataclass(frozen=True)
+class DomainCartridge:
+    cartridge_id: str
+    name: str
+    version: str
+    description: str
+    target_domain: tuple[str, ...]
+    default_language: str
+    source_policy: dict[str, Any]
+    ontology: Ontology
+    component_types: tuple[dict[str, Any], ...]
+    relation_types: tuple[dict[str, Any], ...]
+    maturity_levels: tuple[dict[str, Any], ...]
+    maturity_sources: tuple[dict[str, Any], ...]
+    support_statuses: tuple[dict[str, Any], ...]
+    validation_rules: tuple[dict[str, Any], ...]
+    extraction_prompt: str
+    review_prompt: str
+    examples: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    raw_manifest: dict[str, Any] = field(default_factory=dict)
+
+    # Convenience accessors -------------------------------------------------
+
+    @property
+    def component_type_ids(self) -> tuple[str, ...]:
+        return tuple(str(c.get("id", "")) for c in self.component_types if c.get("id"))
+
+    @property
+    def relation_type_ids(self) -> tuple[str, ...]:
+        return tuple(str(r.get("id", "")) for r in self.relation_types if r.get("id"))
+
+    @property
+    def maturity_level_ids(self) -> tuple[str, ...]:
+        return tuple(str(m.get("id", "")) for m in self.maturity_levels if m.get("id"))
+
+    @property
+    def maturity_source_ids(self) -> tuple[str, ...]:
+        return tuple(str(m.get("id", "")) for m in self.maturity_sources if m.get("id"))
+
+    @property
+    def support_status_ids(self) -> tuple[str, ...]:
+        return tuple(str(s.get("id", "")) for s in self.support_statuses if s.get("id"))
+
+    def component_type(self, component_type_id: str) -> dict[str, Any] | None:
+        for entry in self.component_types:
+            if str(entry.get("id")) == component_type_id:
+                return dict(entry)
+        return None
+
+    def default_maturity_for(self, component_type_id: str) -> str | None:
+        entry = self.component_type(component_type_id)
+        if not entry:
+            return None
+        value = entry.get("default_maturity_level")
+        return str(value) if value else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cartridge_id": self.cartridge_id,
+            "name": self.name,
+            "version": self.version,
+            "description": self.description,
+            "target_domain": list(self.target_domain),
+            "default_language": self.default_language,
+            "source_policy": self.source_policy,
+            "ontology": {
+                "concept_types": list(self.ontology.concept_types),
+                "aliases": list(self.ontology.aliases),
+                "notation_patterns": list(self.ontology.notation_patterns),
+                "extraction_hints": list(self.ontology.extraction_hints),
+                "normalization_rules": list(self.ontology.normalization_rules),
+            },
+            "component_types": list(self.component_types),
+            "relation_types": list(self.relation_types),
+            "maturity_levels": list(self.maturity_levels),
+            "maturity_sources": list(self.maturity_sources),
+            "support_statuses": list(self.support_statuses),
+            "validation_rules": list(self.validation_rules),
+            "extraction_prompt": self.extraction_prompt,
+            "review_prompt": self.review_prompt,
+            "examples": list(self.examples),
+        }
+
+
+# ---------------------------------------------------------------------------
+# IO helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> Any:
+    if not path.exists():
+        raise FileNotFoundError(f"Cartridge file not found: {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _tuple_of_dicts(value: Any) -> tuple[dict[str, Any], ...]:
+    return tuple(item for item in _ensure_list(value) if isinstance(item, dict))
+
+
+def _tuple_of_strings(value: Any) -> tuple[str, ...]:
+    return tuple(str(item) for item in _ensure_list(value) if isinstance(item, str))
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def _load_examples(directory: Path) -> tuple[dict[str, Any], ...]:
+    examples_dir = directory / "examples"
+    if not examples_dir.is_dir():
+        return ()
+    items: list[dict[str, Any]] = []
+    for entry in sorted(examples_dir.glob("*.json")):
+        try:
+            data = _read_json(entry)
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to parse example file: %s", entry, exc_info=True)
+            continue
+        if isinstance(data, dict):
+            items.append(data)
+    return tuple(items)
+
+
+def _load_manifest(directory: Path) -> dict[str, Any]:
+    manifest_path = directory / "cartridge.json"
+    manifest = _read_json(manifest_path)
+    if not isinstance(manifest, dict):
+        raise ValueError(f"cartridge.json must be a JSON object: {manifest_path}")
+    return manifest
+
+
+def _load_one(directory: Path) -> DomainCartridge:
+    manifest = _load_manifest(directory)
+    files = manifest.get("files") or {}
+
+    def _resolve(filename_key: str, default: str) -> Path:
+        return directory / str(files.get(filename_key, default))
+
+    ontology_raw = _read_json(_resolve("ontology", "ontology.json"))
+    component_types_raw = _read_json(_resolve("component_types", "component_types.json"))
+    relation_types_raw = _read_json(_resolve("relation_types", "relation_types.json"))
+    maturity_raw = _read_json(_resolve("maturity_levels", "maturity_levels.json"))
+    support_raw = _read_json(_resolve("support_statuses", "support_statuses.json"))
+    validation_raw = _read_json(_resolve("validation_rules", "validation_rules.json"))
+    extraction_prompt = _read_text(_resolve("extraction_prompt", "extraction_prompt.md"))
+    review_prompt = _read_text(_resolve("review_prompt", "review_prompt.md"))
+
+    ontology = Ontology(
+        concept_types=_tuple_of_dicts(ontology_raw.get("concept_types") if isinstance(ontology_raw, dict) else None),
+        aliases=_tuple_of_dicts(ontology_raw.get("aliases") if isinstance(ontology_raw, dict) else None),
+        notation_patterns=_tuple_of_dicts(
+            ontology_raw.get("notation_patterns") if isinstance(ontology_raw, dict) else None
+        ),
+        extraction_hints=_tuple_of_strings(
+            ontology_raw.get("extraction_hints") if isinstance(ontology_raw, dict) else None
+        ),
+        normalization_rules=_tuple_of_dicts(
+            ontology_raw.get("normalization_rules") if isinstance(ontology_raw, dict) else None
+        ),
+    )
+
+    cartridge = DomainCartridge(
+        cartridge_id=str(manifest.get("cartridge_id") or directory.name),
+        name=str(manifest.get("name") or directory.name),
+        version=str(manifest.get("version") or "0.0.0"),
+        description=str(manifest.get("description") or ""),
+        target_domain=_tuple_of_strings(manifest.get("target_domain")),
+        default_language=str(manifest.get("default_language") or "ja"),
+        source_policy=dict(manifest.get("source_policy") or {}),
+        ontology=ontology,
+        component_types=_tuple_of_dicts(
+            component_types_raw.get("component_types") if isinstance(component_types_raw, dict) else None
+        ),
+        relation_types=_tuple_of_dicts(
+            relation_types_raw.get("relation_types") if isinstance(relation_types_raw, dict) else None
+        ),
+        maturity_levels=_tuple_of_dicts(
+            maturity_raw.get("maturity_levels") if isinstance(maturity_raw, dict) else None
+        ),
+        maturity_sources=_tuple_of_dicts(
+            maturity_raw.get("maturity_sources") if isinstance(maturity_raw, dict) else None
+        ),
+        support_statuses=_tuple_of_dicts(
+            support_raw.get("support_statuses") if isinstance(support_raw, dict) else None
+        ),
+        validation_rules=_tuple_of_dicts(
+            validation_raw.get("validation_rules") if isinstance(validation_raw, dict) else None
+        ),
+        extraction_prompt=extraction_prompt,
+        review_prompt=review_prompt,
+        examples=_load_examples(directory),
+        raw_manifest=manifest,
+    )
+
+    _validate_internal_consistency(cartridge)
+    return cartridge
+
+
+def _validate_internal_consistency(cartridge: DomainCartridge) -> None:
+    """カートリッジ内の ID 重複・不整合を最低限チェックする。"""
+    seen_ids: dict[str, set[str]] = {}
+    for label, ids in (
+        ("component_types", cartridge.component_type_ids),
+        ("relation_types", cartridge.relation_type_ids),
+        ("maturity_levels", cartridge.maturity_level_ids),
+        ("maturity_sources", cartridge.maturity_source_ids),
+        ("support_statuses", cartridge.support_status_ids),
+        ("concept_types", cartridge.ontology.concept_type_ids),
+    ):
+        bucket = seen_ids.setdefault(label, set())
+        for entry_id in ids:
+            if entry_id in bucket:
+                raise ValueError(
+                    f"Cartridge '{cartridge.cartridge_id}' has duplicate id '{entry_id}' in {label}"
+                )
+            bucket.add(entry_id)
+
+    # component_type の default_maturity_level が maturity_levels に存在するか確認
+    valid_maturity = set(cartridge.maturity_level_ids)
+    for entry in cartridge.component_types:
+        default = entry.get("default_maturity_level")
+        if default and default not in valid_maturity:
+            raise ValueError(
+                f"Cartridge '{cartridge.cartridge_id}': component_type '{entry.get('id')}' "
+                f"has unknown default_maturity_level '{default}'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=8)
+def _cached_load(cartridge_id: str, root: str) -> DomainCartridge:
+    directory = Path(root) / cartridge_id
+    if not directory.is_dir():
+        raise FileNotFoundError(f"Cartridge directory not found: {directory}")
+    return _load_one(directory)
+
+
+def load_cartridge(cartridge_id: str | None = None) -> DomainCartridge:
+    """カートリッジを読み込む。``cartridge_id`` 省略時はデフォルト(particle_physics)。"""
+    target = cartridge_id or _DEFAULT_CARTRIDGE_ID
+    root = str(_cartridges_root())
+    return _cached_load(target, root)
+
+
+def get_default_cartridge() -> DomainCartridge:
+    return load_cartridge(_DEFAULT_CARTRIDGE_ID)
+
+
+def list_cartridges() -> list[CartridgeSummary]:
+    """利用可能なカートリッジのサマリ一覧を返す。"""
+    root = _cartridges_root()
+    if not root.is_dir():
+        return []
+    summaries: list[CartridgeSummary] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        manifest_path = entry / "cartridge.json"
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = _read_json(manifest_path)
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to parse cartridge manifest: %s", manifest_path, exc_info=True)
+            continue
+        if not isinstance(manifest, dict):
+            continue
+        summaries.append(
+            CartridgeSummary(
+                cartridge_id=str(manifest.get("cartridge_id") or entry.name),
+                name=str(manifest.get("name") or entry.name),
+                version=str(manifest.get("version") or "0.0.0"),
+                description=str(manifest.get("description") or ""),
+                target_domain=_tuple_of_strings(manifest.get("target_domain")),
+            )
+        )
+    return summaries
+
+
+def clear_cache() -> None:
+    """テスト用キャッシュクリア。"""
+    _cached_load.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Maturity resolution helper
+# ---------------------------------------------------------------------------
+
+
+def resolve_maturity(
+    component: dict[str, Any],
+    cartridge: DomainCartridge,
+    curated_registry: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """コンポーネントに maturity_level / maturity_source を付与する。
+
+    決定順序 (Issue #176 §11):
+
+    1. curated registry に同名コンポーネントがあれば、その値を採用 (curated_registry)
+    2. component_type.default_maturity_level があれば採用 (cartridge_default)
+    3. origin == "paper" なら paper_claim にフォールバック (cartridge_default)
+    4. それ以外は unknown
+    """
+    updated = dict(component)
+    canonical = str(updated.get("name") or updated.get("component_id") or "").strip()
+    registry = curated_registry or {}
+
+    if canonical and canonical in registry:
+        ref = registry[canonical] or {}
+        level = ref.get("maturity_level")
+        if level:
+            updated["maturity_level"] = str(level)
+            updated["maturity_source"] = "curated_registry"
+            return updated
+
+    component_type = str(updated.get("component_type") or "")
+    default = cartridge.default_maturity_for(component_type)
+    if default:
+        updated["maturity_level"] = default
+        updated["maturity_source"] = "cartridge_default"
+        return updated
+
+    if str(updated.get("origin") or "") == "paper":
+        updated["maturity_level"] = "paper_claim"
+        updated["maturity_source"] = "cartridge_default"
+        return updated
+
+    updated["maturity_level"] = "unknown"
+    updated["maturity_source"] = "unknown"
+    return updated

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -155,6 +155,18 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("GOOGLE_CLOUD_LOCATION"),
     )
 
+    # --- Domain Cartridge ---
+    # 使用するデフォルトカートリッジID。未指定時は particle_physics。
+    default_cartridge_id: str = Field(
+        default="particle_physics",
+        validation_alias=AliasChoices("EPISTEME_DEFAULT_CARTRIDGE_ID"),
+    )
+    # カートリッジ定義ディレクトリを上書きしたい場合のみ指定。未指定時は backend/cartridges。
+    cartridges_dir: str = Field(
+        default="",
+        validation_alias=AliasChoices("EPISTEME_CARTRIDGES_DIR"),
+    )
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/tests/api/test_cartridges_api.py
+++ b/backend/tests/api/test_cartridges_api.py
@@ -1,0 +1,128 @@
+"""カートリッジAPI (Issue #176) の結合テスト。"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HAS_FASTAPI = True
+try:
+    from fastapi.testclient import TestClient  # noqa: F401
+except ImportError:
+    _HAS_FASTAPI = False
+
+_skip_no_fastapi = pytest.mark.skipif(
+    not _HAS_FASTAPI, reason="FastAPI not installed (run inside Docker for full API tests)"
+)
+
+
+@pytest.fixture
+def client():
+    if not _HAS_FASTAPI:
+        pytest.skip("FastAPI not installed")
+    backend_dir = str(Path(__file__).resolve().parents[2])
+    api_dir = str(Path(__file__).resolve().parents[2] / "api")
+    if backend_dir not in sys.path:
+        sys.path.insert(0, backend_dir)
+    if api_dir not in sys.path:
+        sys.path.insert(0, api_dir)
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def teacher_headers():
+    import jwt
+
+    payload = {
+        "sub": "test-teacher-id",
+        "role": "TEACHER",
+        "username": "teacher1",
+        "email": "teacher1@test.com",
+    }
+    token = jwt.encode(payload, "test-secret-key", algorithm="HS256")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@_skip_no_fastapi
+class TestCartridgesAPI:
+    def test_list_cartridges_returns_particle_physics(self, client, teacher_headers):
+        resp = client.get("/api/admin/cartridges", headers=teacher_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        ids = [item["cartridge_id"] for item in data]
+        assert "particle_physics" in ids
+
+    def test_get_particle_physics_full(self, client, teacher_headers):
+        resp = client.get("/api/admin/cartridges/particle_physics", headers=teacher_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cartridge_id"] == "particle_physics"
+        assert "ontology" in data
+        assert "component_types" in data
+        assert "maturity_levels" in data
+        assert any(c["id"] == "Theory" for c in data["ontology"]["concept_types"])
+
+    def test_get_ontology_endpoint(self, client, teacher_headers):
+        resp = client.get(
+            "/api/admin/cartridges/particle_physics/ontology", headers=teacher_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data["concept_types"], list)
+        ids = [c["id"] for c in data["concept_types"]]
+        assert "Theory" in ids
+        assert "Observable" in ids
+
+    def test_get_component_types(self, client, teacher_headers):
+        resp = client.get(
+            "/api/admin/cartridges/particle_physics/component-types", headers=teacher_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [c["id"] for c in data["component_types"]]
+        assert "PaperClaimComponent" in ids
+        assert "DomainTheoryComponent" in ids
+
+    def test_get_maturity_levels(self, client, teacher_headers):
+        resp = client.get(
+            "/api/admin/cartridges/particle_physics/maturity-levels", headers=teacher_headers
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        level_ids = [m["id"] for m in data["maturity_levels"]]
+        source_ids = [m["id"] for m in data["maturity_sources"]]
+        assert "paper_claim" in level_ids
+        assert "canonical" in level_ids
+        assert "llm_proposed" in source_ids
+        assert "teacher_reviewed" in source_ids
+
+    def test_get_support_statuses(self, client, teacher_headers):
+        resp = client.get(
+            "/api/admin/cartridges/particle_physics/support-statuses", headers=teacher_headers
+        )
+        assert resp.status_code == 200
+        ids = [s["id"] for s in resp.json()["support_statuses"]]
+        assert "source_backed" in ids
+        assert "domain_inferred" in ids
+
+    def test_get_relation_types(self, client, teacher_headers):
+        resp = client.get(
+            "/api/admin/cartridges/particle_physics/relation-types", headers=teacher_headers
+        )
+        assert resp.status_code == 200
+        ids = [r["id"] for r in resp.json()["relation_types"]]
+        assert "REQUIRES" in ids
+
+    def test_unknown_cartridge_returns_404(self, client, teacher_headers):
+        resp = client.get("/api/admin/cartridges/no_such", headers=teacher_headers)
+        assert resp.status_code == 404
+
+    def test_unauthorized_without_token(self, client):
+        resp = client.get("/api/admin/cartridges")
+        assert resp.status_code in (401, 403)

--- a/backend/tests/core/test_cartridges.py
+++ b/backend/tests/core/test_cartridges.py
@@ -14,12 +14,16 @@ from core.cartridges import (
     load_cartridge,
     resolve_maturity,
 )
+from core.config import get_settings
 
 
 @pytest.fixture(autouse=True)
 def _reset_cache():
+    """各テスト前後に設定キャッシュとカートリッジキャッシュをクリアする。"""
+    get_settings.cache_clear()
     clear_cache()
     yield
+    get_settings.cache_clear()
     clear_cache()
 
 
@@ -207,46 +211,81 @@ def test_resolve_maturity_unknown_when_no_signals():
 
 
 # ---------------------------------------------------------------------------
-# Internal consistency (negative cases via custom dir override)
+# Settings integration (Issue #176 follow-up)
 # ---------------------------------------------------------------------------
 
 
-def test_duplicate_ids_raise(tmp_path, monkeypatch):
-    cart_dir = tmp_path / "broken"
-    cart_dir.mkdir()
-    (cart_dir / "cartridge.json").write_text(
-        '{"cartridge_id": "broken", "name": "broken", "version": "0.0.1", "files": {}}',
-        encoding="utf-8",
-    )
-    (cart_dir / "ontology.json").write_text('{"concept_types": []}', encoding="utf-8")
-    (cart_dir / "component_types.json").write_text(
-        '{"component_types": [{"id": "Dup"}, {"id": "Dup"}]}', encoding="utf-8"
-    )
-    (cart_dir / "relation_types.json").write_text('{"relation_types": []}', encoding="utf-8")
-    (cart_dir / "maturity_levels.json").write_text('{"maturity_levels": []}', encoding="utf-8")
-    (cart_dir / "support_statuses.json").write_text('{"support_statuses": []}', encoding="utf-8")
-    (cart_dir / "validation_rules.json").write_text('{"validation_rules": []}', encoding="utf-8")
-    (cart_dir / "extraction_prompt.md").write_text("", encoding="utf-8")
-    (cart_dir / "review_prompt.md").write_text("", encoding="utf-8")
+def test_settings_default_cartridge_id_field(monkeypatch):
+    """Settings に EPISTEME_DEFAULT_CARTRIDGE_ID が読み込まれること。"""
+    monkeypatch.setenv("EPISTEME_DEFAULT_CARTRIDGE_ID", "particle_physics")
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.default_cartridge_id == "particle_physics"
 
+
+def test_settings_cartridges_dir_field(monkeypatch, tmp_path):
+    """Settings に EPISTEME_CARTRIDGES_DIR が読み込まれること。"""
     monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path))
-    cartridge_loader.clear_cache()
-    with pytest.raises(ValueError, match="duplicate id"):
-        load_cartridge("broken")
-    cartridge_loader.clear_cache()
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.cartridges_dir == str(tmp_path)
 
 
-def test_unknown_default_maturity_raises(tmp_path, monkeypatch):
-    cart_dir = tmp_path / "unknown_maturity"
-    cart_dir.mkdir()
+def test_load_cartridge_uses_settings_default_cartridge_id(monkeypatch):
+    """EPISTEME_DEFAULT_CARTRIDGE_ID が load_cartridge() のデフォルトに反映されること。"""
+    monkeypatch.setenv("EPISTEME_DEFAULT_CARTRIDGE_ID", "particle_physics")
+    get_settings.cache_clear()
+    clear_cache()
+    cart = load_cartridge()
+    assert cart.cartridge_id == "particle_physics"
+
+
+def test_load_cartridge_falls_back_when_env_unset(monkeypatch):
+    """EPISTEME_DEFAULT_CARTRIDGE_ID 未設定時は particle_physics にフォールバックすること。"""
+    monkeypatch.delenv("EPISTEME_DEFAULT_CARTRIDGE_ID", raising=False)
+    get_settings.cache_clear()
+    clear_cache()
+    cart = load_cartridge()
+    assert cart.cartridge_id == "particle_physics"
+
+
+def test_load_cartridge_falls_back_when_env_empty(monkeypatch):
+    """EPISTEME_DEFAULT_CARTRIDGE_ID が空文字の場合も particle_physics にフォールバックすること。"""
+    monkeypatch.setenv("EPISTEME_DEFAULT_CARTRIDGE_ID", "")
+    get_settings.cache_clear()
+    clear_cache()
+    cart = load_cartridge()
+    assert cart.cartridge_id == "particle_physics"
+
+
+def test_cartridges_dir_from_settings(tmp_path, monkeypatch):
+    """EPISTEME_CARTRIDGES_DIR を Settings 経由で設定できること。"""
+    # particle_physics カートリッジを tmp_path にコピーして読み込めることを確認
+    import shutil
+    real_root = Path(__file__).resolve().parents[2] / "cartridges"
+    shutil.copytree(str(real_root), str(tmp_path / "copied"), dirs_exist_ok=True)
+
+    monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path / "copied"))
+    get_settings.cache_clear()
+    clear_cache()
+    cart = load_cartridge("particle_physics")
+    assert cart.cartridge_id == "particle_physics"
+
+
+# ---------------------------------------------------------------------------
+# Internal consistency (negative cases via Settings-aware env override)
+# ---------------------------------------------------------------------------
+
+
+def _write_minimal_cartridge(cart_dir: Path, extra_component_types: str = "[]") -> None:
+    """テスト用最小カートリッジファイル一式を書き出す。"""
     (cart_dir / "cartridge.json").write_text(
-        '{"cartridge_id": "unknown_maturity", "name": "x", "version": "0.0.1", "files": {}}',
+        f'{{"cartridge_id": "{cart_dir.name}", "name": "test", "version": "0.0.1", "files": {{}}}}',
         encoding="utf-8",
     )
     (cart_dir / "ontology.json").write_text('{"concept_types": []}', encoding="utf-8")
     (cart_dir / "component_types.json").write_text(
-        '{"component_types": [{"id": "X", "default_maturity_level": "no_such"}]}',
-        encoding="utf-8",
+        f'{{"component_types": {extra_component_types}}}', encoding="utf-8"
     )
     (cart_dir / "relation_types.json").write_text('{"relation_types": []}', encoding="utf-8")
     (cart_dir / "maturity_levels.json").write_text(
@@ -257,8 +296,26 @@ def test_unknown_default_maturity_raises(tmp_path, monkeypatch):
     (cart_dir / "extraction_prompt.md").write_text("", encoding="utf-8")
     (cart_dir / "review_prompt.md").write_text("", encoding="utf-8")
 
+
+def test_duplicate_ids_raise(tmp_path, monkeypatch):
+    cart_dir = tmp_path / "broken"
+    cart_dir.mkdir()
+    _write_minimal_cartridge(cart_dir, '[{"id": "Dup"}, {"id": "Dup"}]')
+
     monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path))
-    cartridge_loader.clear_cache()
+    get_settings.cache_clear()
+    clear_cache()
+    with pytest.raises(ValueError, match="duplicate id"):
+        load_cartridge("broken")
+
+
+def test_unknown_default_maturity_raises(tmp_path, monkeypatch):
+    cart_dir = tmp_path / "unknown_maturity"
+    cart_dir.mkdir()
+    _write_minimal_cartridge(cart_dir, '[{"id": "X", "default_maturity_level": "no_such"}]')
+
+    monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path))
+    get_settings.cache_clear()
+    clear_cache()
     with pytest.raises(ValueError, match="unknown default_maturity_level"):
         load_cartridge("unknown_maturity")
-    cartridge_loader.clear_cache()

--- a/backend/tests/core/test_cartridges.py
+++ b/backend/tests/core/test_cartridges.py
@@ -1,0 +1,264 @@
+"""カートリッジローダーの単体テスト (Issue #176)。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core import cartridges as cartridge_loader
+from core.cartridges import (
+    DomainCartridge,
+    clear_cache,
+    list_cartridges,
+    load_cartridge,
+    resolve_maturity,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Required files
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_FILES = (
+    "cartridge.json",
+    "ontology.json",
+    "component_types.json",
+    "relation_types.json",
+    "maturity_levels.json",
+    "support_statuses.json",
+    "extraction_prompt.md",
+    "review_prompt.md",
+    "validation_rules.json",
+)
+
+
+def _cartridge_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "cartridges" / "particle_physics"
+
+
+def test_required_files_exist():
+    base = _cartridge_dir()
+    for name in REQUIRED_FILES:
+        path = base / name
+        assert path.exists(), f"missing required cartridge file: {name}"
+
+
+def test_examples_directory_exists():
+    examples_dir = _cartridge_dir() / "examples"
+    assert examples_dir.is_dir()
+    assert any(examples_dir.glob("*.json")), "examples directory should contain at least one JSON example"
+
+
+# ---------------------------------------------------------------------------
+# load_cartridge
+# ---------------------------------------------------------------------------
+
+
+def test_load_particle_physics_cartridge():
+    cart = load_cartridge("particle_physics")
+    assert isinstance(cart, DomainCartridge)
+    assert cart.cartridge_id == "particle_physics"
+    assert cart.version
+    assert "particle_physics" in cart.target_domain
+
+
+def test_default_cartridge_is_particle_physics():
+    default = load_cartridge()
+    assert default.cartridge_id == "particle_physics"
+
+
+def test_concept_types_contain_theory():
+    cart = load_cartridge("particle_physics")
+    assert "Theory" in cart.ontology.concept_type_ids
+    assert "Observable" in cart.ontology.concept_type_ids
+
+
+def test_component_types_have_default_maturity():
+    cart = load_cartridge("particle_physics")
+    types_by_id = {entry["id"]: entry for entry in cart.component_types}
+    assert "PaperClaimComponent" in types_by_id
+    assert types_by_id["PaperClaimComponent"]["default_maturity_level"] == "paper_claim"
+    assert types_by_id["DomainTheoryComponent"]["default_maturity_level"] == "canonical"
+
+
+def test_paper_claim_in_maturity_levels():
+    cart = load_cartridge("particle_physics")
+    assert "paper_claim" in cart.maturity_level_ids
+    assert "canonical" in cart.maturity_level_ids
+
+
+def test_maturity_sources_include_llm_proposed():
+    cart = load_cartridge("particle_physics")
+    assert "llm_proposed" in cart.maturity_source_ids
+    assert "teacher_reviewed" in cart.maturity_source_ids
+
+
+def test_support_status_ids_unique_and_complete():
+    cart = load_cartridge("particle_physics")
+    ids = list(cart.support_status_ids)
+    assert "source_backed" in ids
+    assert "domain_inferred" in ids
+    assert len(ids) == len(set(ids))
+
+
+def test_relation_type_ids_no_duplicates():
+    cart = load_cartridge("particle_physics")
+    ids = list(cart.relation_type_ids)
+    assert "REQUIRES" in ids
+    assert len(ids) == len(set(ids))
+
+
+def test_extraction_prompt_loaded():
+    cart = load_cartridge("particle_physics")
+    assert cart.extraction_prompt
+    assert "理論コンポーネント" in cart.extraction_prompt
+
+
+def test_examples_loaded():
+    cart = load_cartridge("particle_physics")
+    assert len(cart.examples) >= 2
+    component_ids = {ex.get("component_id") for ex in cart.examples}
+    assert "domain.hqet" in component_ids
+
+
+# ---------------------------------------------------------------------------
+# list_cartridges
+# ---------------------------------------------------------------------------
+
+
+def test_list_cartridges_includes_particle_physics():
+    summaries = list_cartridges()
+    ids = [s.cartridge_id for s in summaries]
+    assert "particle_physics" in ids
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_cartridge_raises_filenotfound():
+    with pytest.raises(FileNotFoundError):
+        load_cartridge("does_not_exist")
+
+
+def test_to_dict_round_trip():
+    cart = load_cartridge("particle_physics")
+    payload = cart.to_dict()
+    assert payload["cartridge_id"] == "particle_physics"
+    assert isinstance(payload["component_types"], list)
+    assert payload["ontology"]["concept_types"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_maturity
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_maturity_uses_curated_registry_first():
+    cart = load_cartridge("particle_physics")
+    component = {
+        "name": "Heavy Quark Effective Theory",
+        "component_type": "DomainTheoryComponent",
+        "origin": "domain",
+    }
+    registry = {
+        "Heavy Quark Effective Theory": {"maturity_level": "reviewed_consensus"},
+    }
+    resolved = resolve_maturity(component, cart, curated_registry=registry)
+    assert resolved["maturity_level"] == "reviewed_consensus"
+    assert resolved["maturity_source"] == "curated_registry"
+
+
+def test_resolve_maturity_falls_back_to_component_type_default():
+    cart = load_cartridge("particle_physics")
+    component = {
+        "name": "Some Paper Claim",
+        "component_type": "PaperClaimComponent",
+        "origin": "paper",
+    }
+    resolved = resolve_maturity(component, cart)
+    assert resolved["maturity_level"] == "paper_claim"
+    assert resolved["maturity_source"] == "cartridge_default"
+
+
+def test_resolve_maturity_paper_origin_without_type():
+    cart = load_cartridge("particle_physics")
+    component = {"name": "x", "origin": "paper"}
+    resolved = resolve_maturity(component, cart)
+    assert resolved["maturity_level"] == "paper_claim"
+    assert resolved["maturity_source"] == "cartridge_default"
+
+
+def test_resolve_maturity_unknown_when_no_signals():
+    cart = load_cartridge("particle_physics")
+    resolved = resolve_maturity({"name": "x"}, cart)
+    assert resolved["maturity_level"] == "unknown"
+    assert resolved["maturity_source"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Internal consistency (negative cases via custom dir override)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_ids_raise(tmp_path, monkeypatch):
+    cart_dir = tmp_path / "broken"
+    cart_dir.mkdir()
+    (cart_dir / "cartridge.json").write_text(
+        '{"cartridge_id": "broken", "name": "broken", "version": "0.0.1", "files": {}}',
+        encoding="utf-8",
+    )
+    (cart_dir / "ontology.json").write_text('{"concept_types": []}', encoding="utf-8")
+    (cart_dir / "component_types.json").write_text(
+        '{"component_types": [{"id": "Dup"}, {"id": "Dup"}]}', encoding="utf-8"
+    )
+    (cart_dir / "relation_types.json").write_text('{"relation_types": []}', encoding="utf-8")
+    (cart_dir / "maturity_levels.json").write_text('{"maturity_levels": []}', encoding="utf-8")
+    (cart_dir / "support_statuses.json").write_text('{"support_statuses": []}', encoding="utf-8")
+    (cart_dir / "validation_rules.json").write_text('{"validation_rules": []}', encoding="utf-8")
+    (cart_dir / "extraction_prompt.md").write_text("", encoding="utf-8")
+    (cart_dir / "review_prompt.md").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path))
+    cartridge_loader.clear_cache()
+    with pytest.raises(ValueError, match="duplicate id"):
+        load_cartridge("broken")
+    cartridge_loader.clear_cache()
+
+
+def test_unknown_default_maturity_raises(tmp_path, monkeypatch):
+    cart_dir = tmp_path / "unknown_maturity"
+    cart_dir.mkdir()
+    (cart_dir / "cartridge.json").write_text(
+        '{"cartridge_id": "unknown_maturity", "name": "x", "version": "0.0.1", "files": {}}',
+        encoding="utf-8",
+    )
+    (cart_dir / "ontology.json").write_text('{"concept_types": []}', encoding="utf-8")
+    (cart_dir / "component_types.json").write_text(
+        '{"component_types": [{"id": "X", "default_maturity_level": "no_such"}]}',
+        encoding="utf-8",
+    )
+    (cart_dir / "relation_types.json").write_text('{"relation_types": []}', encoding="utf-8")
+    (cart_dir / "maturity_levels.json").write_text(
+        '{"maturity_levels": [{"id": "canonical"}]}', encoding="utf-8"
+    )
+    (cart_dir / "support_statuses.json").write_text('{"support_statuses": []}', encoding="utf-8")
+    (cart_dir / "validation_rules.json").write_text('{"validation_rules": []}', encoding="utf-8")
+    (cart_dir / "extraction_prompt.md").write_text("", encoding="utf-8")
+    (cart_dir / "review_prompt.md").write_text("", encoding="utf-8")
+
+    monkeypatch.setenv("EPISTEME_CARTRIDGES_DIR", str(tmp_path))
+    cartridge_loader.clear_cache()
+    with pytest.raises(ValueError, match="unknown default_maturity_level"):
+        load_cartridge("unknown_maturity")
+    cartridge_loader.clear_cache()

--- a/backend/tests/test_lecture_studio.py
+++ b/backend/tests/test_lecture_studio.py
@@ -314,6 +314,50 @@ class TestRewritePromptTemplate:
 
 
 # ---------------------------------------------------------------------------
+# Rewrite result normalization (regression for theory-tab AttributeError)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeRewriteResult:
+    """`_normalize_rewrite_result` の挙動を検証する。
+
+    LLM が JSON オブジェクトではなくトップレベル配列を返すケースで
+    `AttributeError: 'list' object has no attribute 'get'` が出ていた回帰を防ぐ。
+    """
+
+    def _normalize(self, parsed, studio_view):
+        from routes.lecture_studio import _normalize_rewrite_result
+
+        return _normalize_rewrite_result(parsed, studio_view)
+
+    def test_dict_input_returned_as_is(self):
+        payload = {"theory_components": [{"id": "c1"}], "spoken_text": "x"}
+        assert self._normalize(payload, "theory") == payload
+
+    def test_list_in_theory_view_wrapped_as_theory_components(self):
+        payload = [{"id": "c1", "summary": "a"}, {"id": "c2"}]
+        result = self._normalize(payload, "theory")
+        assert result == {"theory_components": payload}
+
+    def test_list_in_non_theory_view_returns_empty(self):
+        result = self._normalize([{"id": "c1"}], "edit")
+        assert result == {}
+
+    def test_invalid_input_returns_empty(self):
+        assert self._normalize("string", "theory") == {}
+        assert self._normalize(None, "edit") == {}
+        assert self._normalize(42, "audio") == {}
+
+    def test_normalized_dict_supports_get(self):
+        """正規化後は必ず .get() できる(本番のリグレッション再現テスト)。"""
+        result = self._normalize([{"id": "c1"}], "theory")
+        # 以下が AttributeError なく動くことが本テストの主旨
+        assert result.get("theory_components") == [{"id": "c1"}]
+        assert result.get("display_text") is None
+        assert result.get("spoken_text", "fallback") == "fallback"
+
+
+# ---------------------------------------------------------------------------
 # Chunk status logic tests
 # ---------------------------------------------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-${MINIO_ROOT_PASSWORD}}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       CORS_ORIGINS: ${CORS_ORIGINS:-*}
+      # Domain cartridge
+      EPISTEME_DEFAULT_CARTRIDGE_ID: ${EPISTEME_DEFAULT_CARTRIDGE_ID:-particle_physics}
+      EPISTEME_CARTRIDGES_DIR: ${EPISTEME_CARTRIDGES_DIR:-}
     # ローカルの .gcp/ をコンテナに読み取り専用でマウントする。
     # ファイルが存在しない場合は空ディレクトリとしてマウントされる（エラーにはならない）。
     # サービスアカウントキーを使う場合: .gcp/credentials.json に配置する。


### PR DESCRIPTION
## Summary

Implements a domain cartridge loading system for managing domain-specific knowledge definitions. Introduces the particle physics cartridge as the first concrete implementation, enabling extraction, normalization, validation, and UI display of domain knowledge components.

## Key Changes

### Core Cartridge Loader (`backend/core/cartridges.py`)
- **New module** with zero external dependencies (FastAPI, SQLAlchemy, OpenAI) for unit testing and CI compatibility
- **Data classes**: `CartridgeSummary`, `Ontology`, and `DomainCartridge` for structured cartridge representation
- **Public API**:
  - `load_cartridge(cartridge_id)` - Load a specific cartridge with LRU caching
  - `get_default_cartridge()` - Load particle_physics cartridge
  - `list_cartridges()` - Discover available cartridges by directory traversal
  - `resolve_maturity()` - Resolve component maturity levels with fallback chain (curated registry → component type default → origin-based default → unknown)
- **Validation**: Internal consistency checks for duplicate IDs and unknown default maturity levels
- **File resolution**: Configurable via `EPISTEME_CARTRIDGES_DIR` environment variable for testing

### Particle Physics Cartridge (`backend/cartridges/particle_physics/`)
Complete domain definition including:
- **cartridge.json** - Manifest with metadata, target domains, and source policy
- **ontology.json** - 8 concept types (Theory, Observable, Parameter, etc.), aliases, notation patterns, extraction hints, and normalization rules
- **component_types.json** - 11 component types distinguishing domain vs. paper origins with default maturity levels
- **relation_types.json** - 11 relation types (REQUIRES, ASSUMES, PRODUCES, etc.)
- **maturity_levels.json** - 10 maturity levels (canonical, paper_claim, speculative, etc.) and 6 maturity sources
- **support_statuses.json** - 7 support status types (source_backed, domain_inferred, etc.)
- **validation_rules.json** - 8 validation rules for component consistency
- **extraction_prompt.md** - Detailed LLM prompt for component extraction with JSON output format
- **review_prompt.md** - Expert review prompt for component validation
- **examples/** - 2 example components (HQET domain theory, B→Dτν relation)

### API Endpoints (`backend/api/routes/cartridges.py`)
- `GET /api/admin/cartridges` - List available cartridges
- `GET /api/admin/cartridges/{cartridge_id}` - Get full cartridge definition
- `GET /api/admin/cartridges/{cartridge_id}/ontology` - Get ontology only
- `GET /api/admin/cartridges/{cartridge_id}/component-types` - Get component types
- `GET /api/admin/cartridges/{cartridge_id}/relation-types` - Get relation types
- `GET /api/admin/cartridges/{cartridge_id}/maturity-levels` - Get maturity levels and sources
- `GET /api/admin/cartridges/{cartridge_id}/support-statuses` - Get support statuses
All endpoints require teacher role authentication.

### Tests (`backend/tests/`)
- **test_cartridges.py** - 30+ unit tests covering:
  - Required file existence and structure
  - Cartridge loading and caching
  - Concept/component/relation type validation
  - Maturity level resolution with fallback chains
  - Internal consistency validation (duplicate IDs, unknown defaults)
  - Round-trip serialization
- **test_cartridges_api.py** - Integration tests for all API endpoints with FastAPI TestClient

## Notable Implementation Details

- **Read-only design**: Cartridges are loaded and cached; no write operations in MVP
- **Extensible architecture**: Directory traversal enables future cartridges (chemistry, biology, etc.) without code changes
- **Maturity resolution strategy**: Implements 4-level fallback (curated registry → component type default → origin-based default

https://claude.ai/code/session_01R5hHdSrBPa2YGwpCnqzs6D