### PR TITLE
Add NUL character sanitization for theory claims

### DIFF
--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -702,6 +702,40 @@ def _redact_for_log(value: str, limit: int = 700) -> str:
     return text[:limit] + ("..." if len(text) > limit else "")
 
 
+def _strip_nul(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [_strip_nul(item) for item in value]
+    if isinstance(value, dict):
+        return {str(_strip_nul(key)): _strip_nul(val) for key, val in value.items()}
+    return value
+
+
+def _clean_pg_text(value: Any, default: str = "") -> str:
+    return str(value if value is not None else default).replace("\x00", "")
+
+
+def _json_dumps_pg_safe(value: Any, default: Any) -> str:
+    cleaned = _strip_nul(value if value is not None else default)
+    dumped = json.dumps(cleaned, ensure_ascii=False)
+    return dumped.replace("\\u0000", "")
+
+
+def _contains_nul(value: Any) -> bool:
+    if isinstance(value, str):
+        return "\x00" in value
+    if isinstance(value, list):
+        return any(_contains_nul(item) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_nul(k) or _contains_nul(v) for k, v in value.items())
+    return False
+
+
+def _nul_fields(payload: dict) -> list[str]:
+    return [key for key, value in payload.items() if _contains_nul(value)]
+
+
 def _llm_response_debug(raw: str, parsed: dict | None = None) -> dict[str, Any]:
     parsed = parsed if isinstance(parsed, dict) else {}
     return {
@@ -774,10 +808,10 @@ def _normalize_claim_payload(raw: dict, chunk: dict, strict: bool = True) -> dic
     claim_type = str(raw.get("claim_type") or "").strip()
     if claim_type not in _CLAIM_TYPES:
         raise ValueError(f"invalid claim_type: {claim_type}")
-    text = str(raw.get("text") or raw.get("normalized_text") or "").strip()
+    text = _clean_pg_text(raw.get("text") or raw.get("normalized_text") or "").strip()
     if _is_low_value_claim_text(text):
         return None
-    evidence = str(raw.get("evidence_text") or "").strip()
+    evidence = _clean_pg_text(raw.get("evidence_text") or "").strip()
     if not evidence and not strict:
         evidence = text[:360]
     support_status = str(raw.get("support_status") or "").strip()
@@ -791,7 +825,7 @@ def _normalize_claim_payload(raw: dict, chunk: dict, strict: bool = True) -> dic
     for concept in concepts[:8]:
         if not isinstance(concept, dict):
             continue
-        name = str(concept.get("name") or "").strip()
+        name = _clean_pg_text(concept.get("name") or "").strip()
         if not name:
             continue
         normalized_concepts.append({
@@ -807,17 +841,17 @@ def _normalize_claim_payload(raw: dict, chunk: dict, strict: bool = True) -> dic
     scope = _source_scope_for_chunk(chunk, "chunk")
     if isinstance(raw.get("source_scope"), dict):
         scope.update({k: v for k, v in raw["source_scope"].items() if v not in (None, "", [])})
-    return {
+    return _strip_nul({
         "claim_type": claim_type,
         "text": text[:1200],
-        "normalized_text": str(raw.get("normalized_text") or text).strip()[:1200],
+        "normalized_text": _clean_pg_text(raw.get("normalized_text") or text).strip()[:1200],
         "concepts": normalized_concepts,
         "equation": equation,
         "support_status": support_status,
         "evidence_text": evidence[:500],
         "review_status": review_status or "teacher_review_required",
         "source_scope": scope,
-    }
+    })
 
 
 def _fallback_concepts(text: str) -> list[dict]:
@@ -1003,8 +1037,30 @@ def _extract_claim_candidates(chunk: dict) -> list[dict]:
 def _insert_claim(document_id: str, chunk_id: str, payload: dict, user_id: str) -> ClaimOut:
     if payload.get("claim_type") not in _CLAIM_TYPES:
         raise HTTPException(status_code=422, detail="Invalid claim_type")
+    nul_fields = _nul_fields(payload)
+    if nul_fields:
+        logger.warning(
+            "NUL characters detected in claim payload before insert: fields=%s document_id=%s chunk_id=%s",
+            nul_fields,
+            _clean_pg_text(document_id),
+            chunk_id,
+        )
     session = _pg_session()
     try:
+        params = {
+            "document_id": _clean_pg_text(document_id),
+            "chunk_id": chunk_id,
+            "source_scope": _json_dumps_pg_safe(payload.get("source_scope"), {}),
+            "claim_type": _clean_pg_text(payload.get("claim_type") or "diagnostic_claim"),
+            "text": _clean_pg_text(payload.get("text")),
+            "normalized_text": _clean_pg_text(payload.get("normalized_text") or payload.get("text")),
+            "concepts": _json_dumps_pg_safe(payload.get("concepts"), []),
+            "equation": _json_dumps_pg_safe(payload.get("equation"), {}),
+            "support_status": _clean_pg_text(payload.get("support_status") or "source_backed"),
+            "evidence_text": _clean_pg_text(payload.get("evidence_text")),
+            "review_status": _clean_pg_text(payload.get("review_status") or "teacher_review_required"),
+            "created_by": user_id or None,
+        }
         row = session.execute(
             sa_text("""
                 INSERT INTO theory_claims (
@@ -1020,20 +1076,7 @@ def _insert_claim(document_id: str, chunk_id: str, payload: dict, user_id: str) 
                           normalized_text, concepts, equation, support_status, evidence_text,
                           review_status, created_by, created_at, updated_at
             """),
-            {
-                "document_id": document_id,
-                "chunk_id": chunk_id,
-                "source_scope": json.dumps(payload.get("source_scope") or {}, ensure_ascii=False),
-                "claim_type": payload.get("claim_type") or "diagnostic_claim",
-                "text": payload.get("text") or "",
-                "normalized_text": payload.get("normalized_text") or payload.get("text") or "",
-                "concepts": json.dumps(payload.get("concepts") or [], ensure_ascii=False),
-                "equation": json.dumps(payload.get("equation") or {}, ensure_ascii=False),
-                "support_status": payload.get("support_status") or "source_backed",
-                "evidence_text": payload.get("evidence_text") or "",
-                "review_status": payload.get("review_status") or "teacher_review_required",
-                "created_by": user_id or None,
-            },
+            params,
         ).fetchone()
         session.commit()
         return _row_to_claim(row)

--- a/backend/tests/test_theory_components.py
+++ b/backend/tests/test_theory_components.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 import types
 from pathlib import Path
@@ -169,3 +170,102 @@ class TestTheoryComponentFrontend:
         assert ".ls-theory-card" in css
         assert ".ls-theory-chip" in css
         assert ".ls-chunk-theory-state" in css
+
+
+class TestNulCharacterSanitization:
+    """Tests for NUL character removal utilities in theory_components route."""
+
+    def _load_helpers(self):
+        source = (ROOT / "backend" / "api" / "routes" / "theory_components.py").read_text(encoding="utf-8")
+        # exec only the utility functions, not the full module (avoids import of FastAPI deps)
+        ns: dict = {"__builtins__": __builtins__, "json": json}
+        # Extract and exec the four helpers via exec of isolated blocks
+        import re as _re
+        for name in ("_strip_nul", "_clean_pg_text", "_json_dumps_pg_safe", "_contains_nul", "_nul_fields"):
+            pattern = rf"(^def {name}\(.*?)(?=^def |\Z)"
+            match = _re.search(pattern, source, _re.MULTILINE | _re.DOTALL)
+            assert match, f"{name} not found in source"
+            exec(match.group(1), ns)  # noqa: S102
+        return ns
+
+    def test_strip_nul_removes_from_string(self):
+        ns = self._load_helpers()
+        assert ns["_strip_nul"]("hello\x00world") == "helloworld"
+
+    def test_strip_nul_removes_from_nested_list(self):
+        ns = self._load_helpers()
+        result = ns["_strip_nul"]([{"name": "mass\x00"}, {"name": "energy"}])
+        assert result == [{"name": "mass"}, {"name": "energy"}]
+
+    def test_strip_nul_removes_from_nested_dict(self):
+        ns = self._load_helpers()
+        result = ns["_strip_nul"]({"section": "Intro\x00", "page": 1})
+        assert result == {"section": "Intro", "page": 1}
+
+    def test_strip_nul_passthrough_non_string(self):
+        ns = self._load_helpers()
+        assert ns["_strip_nul"](42) == 42
+        assert ns["_strip_nul"](None) is None
+
+    def test_clean_pg_text_removes_nul(self):
+        ns = self._load_helpers()
+        assert ns["_clean_pg_text"]("This is a claim\x00 with nul") == "This is a claim with nul"
+
+    def test_clean_pg_text_handles_none(self):
+        ns = self._load_helpers()
+        assert ns["_clean_pg_text"](None) == ""
+
+    def test_json_dumps_pg_safe_removes_nul_in_string(self):
+        ns = self._load_helpers()
+        result = ns["_json_dumps_pg_safe"]({"latex": "E=mc^2\x00"}, {})
+        parsed = json.loads(result)
+        assert parsed["latex"] == "E=mc^2"
+
+    def test_json_dumps_pg_safe_removes_nul_in_list(self):
+        ns = self._load_helpers()
+        result = ns["_json_dumps_pg_safe"]([{"name": "mass\x00", "role": "variable"}], [])
+        parsed = json.loads(result)
+        assert parsed[0]["name"] == "mass"
+
+    def test_json_dumps_pg_safe_uses_default_on_none(self):
+        ns = self._load_helpers()
+        result = ns["_json_dumps_pg_safe"](None, {})
+        assert json.loads(result) == {}
+
+    def test_contains_nul_detects_in_string(self):
+        ns = self._load_helpers()
+        assert ns["_contains_nul"]("hello\x00") is True
+        assert ns["_contains_nul"]("hello") is False
+
+    def test_contains_nul_detects_in_nested_structures(self):
+        ns = self._load_helpers()
+        assert ns["_contains_nul"]([{"name": "mass\x00"}]) is True
+        assert ns["_contains_nul"]({"section": "clean"}) is False
+
+    def test_nul_fields_returns_affected_field_names(self):
+        ns = self._load_helpers()
+        payload = {
+            "text": "This is a claim\x00 with nul",
+            "normalized_text": "clean",
+            "evidence_text": "Evidence\x00 text",
+            "concepts": [],
+        }
+        fields = ns["_nul_fields"](payload)
+        assert set(fields) == {"text", "evidence_text"}
+
+    def test_nul_fields_empty_when_no_nul(self):
+        ns = self._load_helpers()
+        payload = {"text": "clean", "evidence_text": "also clean", "concepts": []}
+        assert ns["_nul_fields"](payload) == []
+
+    def test_route_source_uses_nul_helpers_in_insert_claim(self):
+        source = _read(ROUTES)
+        assert "_nul_fields(payload)" in source
+        assert "_clean_pg_text(document_id)" in source
+        assert "_json_dumps_pg_safe(payload.get" in source
+
+    def test_route_source_uses_nul_helpers_in_normalize_claim(self):
+        source = _read(ROUTES)
+        assert "_clean_pg_text(raw.get(\"text\")" in source or "_clean_pg_text(raw.get('text')" in source
+        assert "_clean_pg_text(raw.get(\"evidence_text\")" in source or "_clean_pg_text(raw.get('evidence_text')" in source
+        assert "return _strip_nul({" in source


### PR DESCRIPTION
## Summary
This PR adds comprehensive NUL character (`\x00`) sanitization utilities to the theory_components route to prevent database corruption and ensure data integrity when processing claim payloads.

## Key Changes
- **New sanitization helper functions** in `theory_components.py`:
  - `_strip_nul()`: Recursively removes NUL characters from strings, lists, and dicts
  - `_clean_pg_text()`: Converts values to strings and removes NUL characters
  - `_json_dumps_pg_safe()`: JSON serializes data while removing NUL characters
  - `_contains_nul()`: Detects presence of NUL characters in nested structures
  - `_nul_fields()`: Identifies which payload fields contain NUL characters

- **Updated `_normalize_claim_payload()`**:
  - Applies `_clean_pg_text()` to text, evidence, and concept name fields
  - Wraps return value with `_strip_nul()` for comprehensive sanitization

- **Enhanced `_insert_claim()`**:
  - Detects NUL characters in payload and logs warnings with affected field names
  - Applies sanitization to all database parameters before insertion
  - Uses `_clean_pg_text()` for string fields and `_json_dumps_pg_safe()` for JSON fields

- **Comprehensive test coverage** in `test_theory_components.py`:
  - Tests for each sanitization function with various input types
  - Tests for nested structure handling
  - Tests verifying the route implementation uses the helpers correctly

## Implementation Details
- Sanitization is applied at multiple layers: during payload normalization and again before database insertion
- NUL character detection is logged for monitoring and debugging purposes
- The approach handles both direct NUL characters (`\x00`) and escaped Unicode representations (`\u0000`) in JSON
- All helper functions are designed to be safe with `None` values and non-string types

https://claude.ai/code/session_01SjCzrwM71hdx2ZvnD4MkzS