### PR TITLE
Add nginx proxy routes for Courses and Documents APIs

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -70,4 +70,24 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 120s;
     }
+
+    # Courses API → api-server (エクスポートバンドル等)
+    location /api/courses/ {
+        proxy_pass http://api-server:8001/api/courses/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
+
+    # Documents API → api-server (エクスポートバンドル等)
+    location /api/documents/ {
+        proxy_pass http://api-server:8001/api/documents/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+    }
 }


### PR DESCRIPTION
## Summary
Added two new nginx proxy routes to forward API requests for courses and documents to the api-server backend service.

## Key Changes
- Added `/api/courses/` location block that proxies requests to `http://api-server:8001/api/courses/`
- Added `/api/documents/` location block that proxies requests to `http://api-server:8001/api/documents/`
- Both routes include standard proxy headers (Host, X-Real-IP, X-Forwarded-For, X-Forwarded-Proto) and a 120s read timeout

## Implementation Details
- Both new location blocks follow the same configuration pattern as existing proxy routes in the nginx config
- The routes support export bundle functionality (as indicated by the Japanese comments: エクスポートバンドル等)
- Proxy headers are properly configured to preserve client information and protocol details for the backend service

https://claude.ai/code/session_01EqwtJKav73dK79wcyrtP5F