### PR TITLE
Remove unnecessary type casting in SQL queries

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -117,7 +117,7 @@ def _load_course_documents(session: Any, course_id: str) -> list[dict]:
         sa_text("""
             SELECT DISTINCT d.id, d.title, d.status, d.created_at
             FROM documents d
-            JOIN chunks c ON c.document_id = d.id::text
+            JOIN chunks c ON c.document_id = d.id
             JOIN theory_claims tc ON tc.chunk_id = c.id
             WHERE tc.document_id IN (
                 SELECT id::text FROM documents
@@ -129,7 +129,7 @@ def _load_course_documents(session: Any, course_id: str) -> list[dict]:
             SELECT DISTINCT d.id, d.title, d.status, d.created_at
             FROM documents d
             JOIN theory_components tc ON tc.course_id = :course_id
-            JOIN chunks c ON c.document_id = d.id::text
+            JOIN chunks c ON c.document_id = d.id
             WHERE tc.primary_chunk_id = c.id
         """),
         {"course_id": course_id},
@@ -156,7 +156,7 @@ def _load_claims_for_course(session: Any, course_id: str) -> list[dict]:
             FROM theory_claims tc
             JOIN chunks c ON c.id = tc.chunk_id
             WHERE c.document_id IN (
-                SELECT DISTINCT c2.document_id::text
+                SELECT DISTINCT c2.document_id
                 FROM chunks c2
                 JOIN theory_components tcomp2 ON tcomp2.primary_chunk_id = c2.id
                 WHERE tcomp2.course_id = :course_id


### PR DESCRIPTION
## Summary
This PR removes unnecessary `::text` type casts in SQL JOIN and WHERE clauses in the export routes module. These casts were redundant as the columns being compared are already of compatible types.

## Key Changes
- Removed `::text` cast from `d.id` in JOIN condition with chunks table (2 occurrences)
- Removed `::text` cast from `c2.document_id` in subquery WHERE clause
- All changes maintain the same query logic and results while improving query clarity

## Implementation Details
The removed casts were unnecessary because:
- `d.id` (document ID) and `c.document_id` (chunk's document reference) are already compatible types
- `c2.document_id` is already the correct type for comparison in the subquery

These changes improve SQL readability without altering query behavior or performance.

https://claude.ai/code/session_01VDoNh3j6pDPSsssUAXjYr5