### PR TITLE
Implement document-first analysis pipeline with 8-agent orchestration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,13 +2,17 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY api/requirements.txt .
+COPY backend/api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy core engine and API
-COPY core/ /app/core/
-COPY cartridges/ /app/cartridges/
-COPY api/ /app/
+# Copy core engine, API and agents
+COPY backend/core/ /app/core/
+COPY backend/cartridges/ /app/cartridges/
+COPY backend/api/ /app/
+COPY src/ /app/src/
+
+# Issue #226: agents live at /app/src/episteme_graph/agents
+ENV PYTHONPATH=/app:/app/src
 
 EXPOSE 8001
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -563,6 +563,66 @@ def _run_migrations() -> None:
         """))
         session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_section_assembly_status_course ON section_assembly_status(course_id)"))
         session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_section_assembly_status_status ON section_assembly_status(component_assembly_status)"))
+        # Migration 015: Document-first analysis pipeline (issue #226)
+        session.execute(sa_text("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS section_id      TEXT"))
+        session.execute(sa_text("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS block_ids       JSONB NOT NULL DEFAULT '[]'::jsonb"))
+        session.execute(sa_text("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS source_metadata JSONB NOT NULL DEFAULT '{}'::jsonb"))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_chunks_section ON chunks(section_id)"))
+        session.execute(sa_text("ALTER TABLE theory_components ALTER COLUMN course_id DROP NOT NULL"))
+        session.execute(sa_text("ALTER TABLE theory_components ADD COLUMN IF NOT EXISTS document_id TEXT NOT NULL DEFAULT ''"))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_theory_components_document ON theory_components(document_id)"))
+        session.execute(sa_text("ALTER TABLE theory_component_links ALTER COLUMN course_id DROP NOT NULL"))
+        session.execute(sa_text("ALTER TABLE theory_component_links ADD COLUMN IF NOT EXISTS document_id TEXT NOT NULL DEFAULT ''"))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_theory_component_links_document ON theory_component_links(document_id)"))
+        session.execute(sa_text("ALTER TABLE theory_component_graphs ALTER COLUMN course_id DROP NOT NULL"))
+        session.execute(sa_text("""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'theory_component_graphs_document_uq'
+                ) THEN
+                    ALTER TABLE theory_component_graphs
+                        ADD CONSTRAINT theory_component_graphs_document_uq UNIQUE (document_id);
+                END IF;
+            END $$
+        """))
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS document_embeddings (
+                id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                document_id     TEXT NOT NULL,
+                material_id     TEXT,
+                embedding_type  TEXT NOT NULL,
+                source_version  TEXT NOT NULL DEFAULT 'v1',
+                text            TEXT NOT NULL,
+                embedding       vector(768),
+                metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE(document_id, embedding_type, source_version)
+            )
+        """))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_document_embeddings_document ON document_embeddings(document_id)"))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_document_embeddings_type     ON document_embeddings(embedding_type)"))
+        session.execute(sa_text("""
+            CREATE TABLE IF NOT EXISTS document_analysis_runs (
+                id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+                document_id     TEXT NOT NULL,
+                material_id     TEXT,
+                cartridge_id    TEXT,
+                status          TEXT NOT NULL DEFAULT 'pending'
+                                    CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+                current_stage   TEXT,
+                error_message   TEXT NOT NULL DEFAULT '',
+                stage_outputs   JSONB NOT NULL DEFAULT '{}'::jsonb,
+                started_at      TIMESTAMPTZ,
+                completed_at    TIMESTAMPTZ,
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+        """))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_document_analysis_runs_document ON document_analysis_runs(document_id)"))
+        session.execute(sa_text("CREATE INDEX IF NOT EXISTS idx_document_analysis_runs_status   ON document_analysis_runs(status)"))
         # 既存の cloned_from カラムがあれば、クローンコースとその履歴をハードリセット後にカラム廃止
         session.execute(sa_text("""
             DO $$

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -299,6 +299,92 @@ def upload_material(
     }
 
 
+@router.post("/documents/{document_id}/reanalyze", status_code=202)
+def reanalyze_document(
+    document_id: str,
+    current_user: dict = Depends(_require_teacher),
+) -> dict:
+    """新Agent Pipeline (issue #226) で document を再解析する。
+
+    保存済み PDF を MinIO から取り出し、process_material_background と同じ
+    pipeline をバックグラウンド起動する。旧 course/section/chunk 単位の解析
+    エンドポイントの後継。
+    """
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text(
+                "SELECT id, title, filename, source_path FROM documents "
+                "WHERE id = CAST(:id AS uuid) LIMIT 1"
+            ),
+            {"id": document_id},
+        ).fetchone()
+    finally:
+        session.close()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    material_id = row[3]
+    filename = row[2] or row[1] or "document.pdf"
+
+    if not material_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Document has no material_id; cannot fetch PDF for reanalysis",
+        )
+
+    object_candidates = [f"uploads/{material_id}.pdf", filename, material_id]
+    storage = get_storage_client()
+    pdf_bytes: bytes | None = None
+    for object_name in object_candidates:
+        if not object_name:
+            continue
+        try:
+            pdf_bytes = storage.get_object("raw-papers", object_name)
+            break
+        except Exception:
+            continue
+    if pdf_bytes is None:
+        raise HTTPException(status_code=404, detail="PDF object not found in MinIO")
+
+    task_id = str(uuid.uuid4())[:12]
+    create_background_task(task_id, "document_reanalysis", current_user["id"])
+
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text(
+                "UPDATE documents SET status = 'processing', updated_at = now() "
+                "WHERE id = CAST(:id AS uuid)"
+            ),
+            {"id": document_id},
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+    finally:
+        session.close()
+
+    thread = threading.Thread(
+        target=process_material_background,
+        args=(material_id, document_id, filename, pdf_bytes, task_id),
+        daemon=True,
+    )
+    thread.start()
+
+    logger.info(
+        "Document reanalysis accepted: doc=%s material=%s task=%s by user=%s",
+        document_id, material_id, task_id, current_user["id"],
+    )
+    return {
+        "task_id": task_id,
+        "document_id": document_id,
+        "material_id": material_id,
+        "status": "pending",
+    }
+
+
 @router.get("/materials", response_model=list[MaterialOut])
 def list_materials(
     current_user: dict = Depends(_require_teacher),

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -2186,19 +2186,21 @@ def process_material_background(
     filename: str,
     pdf_bytes: bytes,
     task_id: str | None = None,
+    cartridge_id: str | None = None,
 ) -> None:
-    """バックグラウンドでPDF処理パイプラインを実行する。
+    """バックグラウンドで新Agent Pipelineを実行する (issue #226)。
 
-    各ステージで background_tasks.result_data["stage"] を更新するため、
-    失敗時にどのフェーズで止まったか GET /api/admin/tasks/{task_id} で確認できる。
+    Stages:
+        save_pdf → document_structure → source_chunking → source_embedding
+        → paper_skeleton → rhetorical_role → claim_qualification
+        → equation_semantics → thesis_reconstruction → dsl_linking
+        → dsl_embedding → component_assembly
+        → persist_claims_components_graph → completed
 
-    Stages: extracting → chunking → embedding → building_graph → finalizing
+    各ステージ完了時に background_tasks.result_data["stage"] を更新する。
+    旧 build_knowledge_graph / chunk_pdf_pages ベースの導線は廃止。
     """
-
-    def _update_stage(stage: str) -> None:
-        """現在の処理ステージを background_tasks に記録する。"""
-        if task_id:
-            update_background_task(task_id, "processing", result_data={"stage": stage})
+    from core.document_pipeline import PipelineStageError, run_document_pipeline
 
     with _material_lock:
         _material_status[material_id] = {
@@ -2209,89 +2211,43 @@ def process_material_background(
     if task_id:
         update_background_task(task_id, "processing", result_data={"stage": "started"})
 
-    # PDF を MinIO に保存（upload_material が古いバージョンで未保存だった場合の補完）
+    # PDF を MinIO に保存（pipeline は一時ファイルに書き出すが正本は MinIO）
     try:
         _get_storage().upload_pdf("raw-papers", f"uploads/{material_id}.pdf", pdf_bytes)
         logger.info("PDF saved to MinIO for material=%s", material_id)
     except Exception as _storage_exc:
-        logger.warning("Failed to save PDF to MinIO for material=%s: %s", material_id, _storage_exc)
+        logger.warning(
+            "Failed to save PDF to MinIO for material=%s: %s", material_id, _storage_exc,
+        )
 
-    embedded_count = 0
+    def _on_stage(stage: str, info: dict) -> None:
+        if task_id:
+            payload = {"stage": stage}
+            payload.update(info or {})
+            update_background_task(task_id, "processing", result_data=payload)
 
     try:
-        # ── Stage 1: テキスト抽出 ──────────────────────────────────────────
-        _update_stage("extracting")
-        pages = extract_pdf_pages(pdf_bytes)
-        extracted_text = "\n".join(str(p.get("text") or "") for p in pages).replace("\x00", "")
-        logger.info(
-            "Stage[extracting] completed: material=%s doc=%s chars=%d",
-            material_id, doc_id, len(extracted_text),
+        result = run_document_pipeline(
+            pdf_bytes=pdf_bytes,
+            document_id=doc_id,
+            material_id=material_id,
+            filename=filename,
+            cartridge_id=cartridge_id,
+            progress_callback=_on_stage,
         )
 
-        # ── Stage 2: チャンク分割 ──────────────────────────────────────────
-        _update_stage("chunking")
-        chunks = chunk_pdf_pages(pages, chunk_size=1000, overlap=100)
-        logger.info(
-            "Stage[chunking] completed: material=%s doc=%s chunks=%d",
-            material_id, doc_id, len(chunks),
-        )
-
-        if not chunks:
-            logger.warning(
-                "Stage[chunking] produced 0 chunks for material=%s doc=%s filename=%s. "
-                "PDFが空か、テキスト抽出に失敗している可能性があります。",
-                material_id, doc_id, filename,
-            )
-            raise RuntimeError("PDFからテキストチャンクを作成できませんでした")
-
-        # ── Stage 3: ナレッジグラフ構築 ───────────────────────────────────
-        _update_stage("building_graph")
-        title = os.path.splitext(filename)[0]
-        knowledge_graph = build_knowledge_graph(extracted_text, title)
-        logger.info(
-            "Stage[building_graph] completed: material=%s concepts=%d",
-            material_id, len(knowledge_graph.get("concepts", [])),
-        )
-
-        # ── Stage 4: Embedding & DB保存 ───────────────────────────────────
-        _update_stage("embedding")
-        try:
-            embedded_count = embed_chunks(material_id, doc_id, chunks, knowledge_graph)
-        except Exception as embed_exc:
-            # embed_chunks が失敗するとチャンクが1件も登録されない致命的エラー
-            raise RuntimeError(
-                f"チャンクのEmbedding/DB保存に失敗しました "
-                f"(material={material_id}, doc={doc_id}, "
-                f"text_chunks={len(chunks)}): {embed_exc}"
-            ) from embed_exc
-        logger.info(
-            "Stage[embedding] completed: material=%s doc=%s embedded=%d",
-            material_id, doc_id, embedded_count,
-        )
-
-        if embedded_count == 0:
-            raise RuntimeError("テキストチャンクが1件もDBに保存されませんでした")
-
-        # ── Stage 5: documents テーブル更新 ───────────────────────────────
-        _update_stage("finalizing")
+        # documents テーブルの最終ステータスを更新
         session = _pg_session()
         try:
             session.execute(
                 sa_text("""
                     UPDATE documents
                     SET status = 'completed',
-                        knowledge_graph = CAST(:kg AS jsonb),
-                        text_length = :text_length,
                         chunk_count = :chunk_count,
                         updated_at = now()
                     WHERE id = CAST(:doc_id AS uuid)
                 """),
-                {
-                    "doc_id": doc_id,
-                    "kg": json.dumps(knowledge_graph, ensure_ascii=False),
-                    "text_length": len(extracted_text),
-                    "chunk_count": embedded_count,  # 実際にDBに保存されたチャンク数
-                },
+                {"doc_id": doc_id, "chunk_count": result.chunk_count},
             )
             session.commit()
         except Exception:
@@ -2307,27 +2263,38 @@ def process_material_background(
             update_background_task(task_id, "completed", result_data={
                 "material_id": material_id,
                 "doc_id": doc_id,
-                "text_length": len(extracted_text),
-                "chunk_count": embedded_count,
+                "chunk_count": result.chunk_count,
+                "claim_count": result.claim_count,
+                "component_count": result.component_count,
+                "dsl_node_count": result.dsl_node_count,
+                "dsl_edge_count": result.dsl_edge_count,
                 "stage": "completed",
             })
 
         logger.info(
-            "Material processing completed: material=%s doc=%s filename=%s embedded_chunks=%d",
-            material_id, doc_id, filename, embedded_count,
+            "Material processing completed: material=%s doc=%s filename=%s "
+            "chunks=%d claims=%d components=%d",
+            material_id, doc_id, filename,
+            result.chunk_count, result.claim_count, result.component_count,
         )
 
     except Exception as exc:
+        stage = getattr(exc, "stage", "unknown") if isinstance(exc, PipelineStageError) else "unknown"
         logger.exception(
-            "Material processing FAILED: material=%s doc=%s filename=%s: %s",
-            material_id, doc_id, filename, exc,
+            "Material processing FAILED at stage=%s: material=%s doc=%s filename=%s: %s",
+            stage, material_id, doc_id, filename, exc,
         )
         with _material_lock:
             _material_status[material_id]["status"] = "failed"
 
-        error_msg = str(exc)
+        error_msg = f"[{stage}] {exc}" if stage != "unknown" else str(exc)
         if task_id:
-            update_background_task(task_id, "failed", error_message=error_msg)
+            update_background_task(
+                task_id,
+                "failed",
+                error_message=error_msg,
+                result_data={"stage": stage},
+            )
 
         # documents.status を 'failed' に更新する（ここでの失敗も明示的にログする）
         try:

--- a/backend/core/document_pipeline/__init__.py
+++ b/backend/core/document_pipeline/__init__.py
@@ -1,0 +1,27 @@
+"""Document-first analysis pipeline (issue #226).
+
+PDFアップロード後の解析を `src/episteme_graph/agents/` の8 agent群で実行する
+オーケストレータと、結果を既存の Postgres スキーマに保存する adapter 群を提供する。
+
+公開 API:
+    run_document_pipeline(pdf_bytes, document_id, material_id, ...)
+        → DocumentPipelineResult
+
+stage 一覧:
+    save_pdf → document_structure → source_chunking → source_embedding
+    → paper_skeleton → rhetorical_role → claim_qualification → equation_semantics
+    → thesis_reconstruction → dsl_linking → dsl_embedding → component_assembly
+    → persist_claims_components_graph → completed
+"""
+
+from .orchestrator import (
+    DocumentPipelineResult,
+    PipelineStageError,
+    run_document_pipeline,
+)
+
+__all__ = [
+    "DocumentPipelineResult",
+    "PipelineStageError",
+    "run_document_pipeline",
+]

--- a/backend/core/document_pipeline/chunker.py
+++ b/backend/core/document_pipeline/chunker.py
@@ -1,0 +1,216 @@
+"""Section-aware source chunker (issue #226).
+
+DocumentStructureAgent の出力 `DocumentStructureResult` を入力に取り、section /
+block 境界を尊重した source chunk を作る。固定長中心の旧 `chunk_pdf_pages` を
+置き換える。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable
+
+# DocumentStructureAgent 由来の dataclass はランタイム必須ではないため、
+# 型注釈は文字列で参照する。テストでは monkeypatch で代替可能。
+
+# 1 chunk あたりの最大文字数。embedding API のトークン制約と RAG 表示の見やすさ
+# を踏まえた経験値。section が長い場合は block 単位で分割する。
+DEFAULT_MAX_CHARS = 1800
+# section/block 単位の chunk 結合下限。これを下回る短い chunk は隣の chunk に
+# マージする（あまりに細切れになると検索ヒットの精度が下がるため）。
+MIN_CHARS = 200
+
+
+@dataclass
+class SourceChunk:
+    chunk_index: int
+    text: str
+    section_id: str | None
+    block_ids: list[str] = field(default_factory=list)
+    page_start: int | None = None
+    page_end: int | None = None
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "chunk_index": self.chunk_index,
+            "text": self.text,
+            "section_id": self.section_id,
+            "block_ids": list(self.block_ids),
+            "page_start": self.page_start,
+            "page_end": self.page_end,
+            "metadata": dict(self.metadata),
+        }
+
+
+def build_source_chunks(
+    structure,
+    max_chars: int = DEFAULT_MAX_CHARS,
+) -> list[SourceChunk]:
+    """`DocumentStructureResult` から source chunk を生成する。
+
+    Strategy:
+        1. blocks を section_id でグループ化。section 順は section.order、
+           無セクションの block は document 末尾扱い。
+        2. block を順に積み、累計 max_chars を超えたら chunk を確定する。
+        3. 1 つの block 単独で max_chars を超える場合は文字数で機械分割するが、
+           block_ids にはその block のみを記録する。
+        4. 末尾の極小 chunk は前の chunk へ吸収する。
+    """
+    blocks = list(structure.blocks)
+    sections_by_id = {s.section_id: s for s in structure.sections}
+    section_order = {
+        s.section_id: (s.order, s.page_start) for s in structure.sections
+    }
+
+    # section_id -> [TypedBlock] （section 内では block.order 昇順）
+    grouped: dict[str | None, list] = {}
+    for b in blocks:
+        key = b.section_id
+        grouped.setdefault(key, []).append(b)
+    for key in grouped:
+        grouped[key].sort(key=lambda b: (b.page, b.order))
+
+    # section_id 順を確定。None セクションは末尾に。
+    section_keys: list[str | None] = []
+    for sid in sorted(
+        (k for k in grouped if k is not None),
+        key=lambda k: section_order.get(k, (10**9, 10**9)),
+    ):
+        section_keys.append(sid)
+    if None in grouped:
+        section_keys.append(None)
+
+    chunks: list[SourceChunk] = []
+    chunk_index = 0
+    for sid in section_keys:
+        for chunk in _chunk_section_blocks(
+            section_id=sid,
+            section_obj=sections_by_id.get(sid) if sid else None,
+            blocks=grouped[sid],
+            max_chars=max_chars,
+            start_index=chunk_index,
+        ):
+            chunks.append(chunk)
+            chunk_index += 1
+
+    chunks = _absorb_short_tail_chunks(chunks)
+    # 安定した chunk_index を再採番する（吸収後）
+    for i, c in enumerate(chunks):
+        c.chunk_index = i
+    return chunks
+
+
+def _chunk_section_blocks(
+    section_id: str | None,
+    section_obj,
+    blocks: list,
+    max_chars: int,
+    start_index: int,
+) -> Iterable[SourceChunk]:
+    section_title = getattr(section_obj, "title", None) if section_obj else None
+
+    pending_text_parts: list[str] = []
+    pending_block_ids: list[str] = []
+    pending_pages: list[int] = []
+    pending_chars = 0
+
+    def emit() -> SourceChunk | None:
+        if not pending_text_parts:
+            return None
+        text = "\n\n".join(t for t in pending_text_parts if t).strip()
+        if not text:
+            return None
+        return SourceChunk(
+            chunk_index=0,  # 後で全体採番
+            text=text,
+            section_id=section_id,
+            block_ids=list(pending_block_ids),
+            page_start=min(pending_pages) if pending_pages else None,
+            page_end=max(pending_pages) if pending_pages else None,
+            metadata={
+                "section_title": section_title,
+            },
+        )
+
+    for block in blocks:
+        text = (block.text or "").strip()
+        if not text:
+            continue
+        block_chars = len(text)
+
+        # 単一 block で超過 → 文字数機械分割
+        if block_chars > max_chars:
+            if pending_text_parts:
+                yield_chunk = emit()
+                if yield_chunk:
+                    yield yield_chunk
+                pending_text_parts.clear()
+                pending_block_ids.clear()
+                pending_pages.clear()
+                pending_chars = 0
+            for sub in _split_long_text(text, max_chars):
+                yield SourceChunk(
+                    chunk_index=0,
+                    text=sub,
+                    section_id=section_id,
+                    block_ids=[block.block_id],
+                    page_start=block.page,
+                    page_end=block.page,
+                    metadata={
+                        "section_title": section_title,
+                        "block_type": block.block_type,
+                        "split_long_block": True,
+                    },
+                )
+            continue
+
+        # 通常: pending に追加。超過したら前を確定してから追加。
+        if pending_chars + block_chars + 2 > max_chars and pending_text_parts:
+            yield_chunk = emit()
+            if yield_chunk:
+                yield yield_chunk
+            pending_text_parts.clear()
+            pending_block_ids.clear()
+            pending_pages.clear()
+            pending_chars = 0
+
+        pending_text_parts.append(text)
+        pending_block_ids.append(block.block_id)
+        pending_pages.append(block.page)
+        pending_chars += block_chars + 2
+
+    last = emit()
+    if last:
+        yield last
+
+
+def _split_long_text(text: str, max_chars: int) -> list[str]:
+    if max_chars <= 0:
+        return [text]
+    parts: list[str] = []
+    i = 0
+    while i < len(text):
+        parts.append(text[i : i + max_chars])
+        i += max_chars
+    return parts
+
+
+def _absorb_short_tail_chunks(chunks: list[SourceChunk]) -> list[SourceChunk]:
+    """末尾が極端に短い chunk を直前の chunk に吸収する。"""
+    if not chunks:
+        return chunks
+    result: list[SourceChunk] = []
+    for c in chunks:
+        if (
+            result
+            and len(c.text) < MIN_CHARS
+            and result[-1].section_id == c.section_id
+        ):
+            prev = result[-1]
+            prev.text = prev.text + "\n\n" + c.text
+            prev.block_ids.extend(c.block_ids)
+            if c.page_end is not None:
+                prev.page_end = max(prev.page_end or c.page_end, c.page_end)
+            continue
+        result.append(c)
+    return result

--- a/backend/core/document_pipeline/dsl_text.py
+++ b/backend/core/document_pipeline/dsl_text.py
@@ -1,0 +1,47 @@
+"""DSLLinkingResult を embedding 用の検索可能テキストに変換する。"""
+from __future__ import annotations
+
+
+def dsl_result_to_search_text(dsl_result, document_id: str) -> str:
+    """DSLLinkingResult → embedding 用テキスト。
+
+    nodes / edges を「人間にもLLMにも読みやすい行ベース表現」で並べる。
+    polarity と reason を含めることで、検索時に意味的なマッチが取れるようにする。
+    """
+    lines: list[str] = [f"DSL graph for document {document_id}"]
+
+    nodes = list(getattr(dsl_result, "nodes", []) or [])
+    if nodes:
+        lines.append("Nodes:")
+        for n in nodes:
+            value = getattr(n, "node_value", "") or ""
+            ntype = getattr(n, "node_type", "") or ""
+            reason = getattr(n, "reason", "") or ""
+            node_id = getattr(n, "node_id", "") or ""
+            line = f"- {node_id} {ntype} {value}".rstrip()
+            if reason:
+                line = f"{line} :: {reason}"
+            lines.append(line)
+
+    edges = list(getattr(dsl_result, "edges", []) or [])
+    if edges:
+        lines.append("Edges:")
+        for e in edges:
+            src = getattr(e, "from_node_id", "") or ""
+            dst = getattr(e, "to_node_id", "") or ""
+            pred = getattr(e, "core_predicate", "") or ""
+            verb = getattr(e, "domain_verb", "") or ""
+            polarity = getattr(e, "polarity", "") or ""
+            reason = getattr(e, "reason", "") or ""
+            head = f"- {src} {pred}({verb}, {polarity}) {dst}".rstrip()
+            if reason:
+                head = f"{head} :: {reason}"
+            lines.append(head)
+
+    review_notes = list(getattr(dsl_result, "review_notes", []) or [])
+    if review_notes:
+        lines.append("Review notes:")
+        for note in review_notes:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -1,0 +1,383 @@
+"""8 agent pipeline orchestrator (issue #226).
+
+PDF → DocumentStructure → SourceChunking → SourceEmbedding → PaperSkeleton →
+RhetoricalRole → ClaimQualification → EquationSemantics → ThesisReconstruction →
+DSLLinking → DSLEmbedding → ComponentAssembly → Persist → Completed
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from .chunker import build_source_chunks
+from .dsl_text import dsl_result_to_search_text
+from .persistence import (
+    persist_component_graph,
+    persist_components,
+    persist_document_embedding,
+    persist_qualified_claims,
+    persist_source_chunks,
+    upsert_analysis_run,
+)
+
+logger = logging.getLogger(__name__)
+
+
+PIPELINE_STAGES = [
+    "save_pdf",
+    "document_structure",
+    "source_chunking",
+    "source_embedding",
+    "paper_skeleton",
+    "rhetorical_role",
+    "claim_qualification",
+    "equation_semantics",
+    "thesis_reconstruction",
+    "dsl_linking",
+    "dsl_embedding",
+    "component_assembly",
+    "persist_claims_components_graph",
+    "completed",
+]
+
+
+class PipelineStageError(RuntimeError):
+    """pipeline stage 失敗時に raise する。`stage` 属性で停止段階を伝える。"""
+
+    def __init__(self, stage: str, message: str, *, cause: BaseException | None = None):
+        super().__init__(f"[{stage}] {message}")
+        self.stage = stage
+        self.__cause__ = cause
+
+
+@dataclass
+class DocumentPipelineResult:
+    document_id: str
+    material_id: str
+    cartridge_id: str | None
+    run_id: str | None
+    chunk_count: int = 0
+    claim_count: int = 0
+    component_count: int = 0
+    dsl_node_count: int = 0
+    dsl_edge_count: int = 0
+    final_stage: str = "completed"
+    stage_outputs: dict[str, Any] = field(default_factory=dict)
+
+
+def _import_agents() -> dict:
+    """Lazy import. PYTHONPATH に src/ が入っていることを前提とする。"""
+    from episteme_graph.agents.claim_qualification.agent import ClaimQualificationAgent
+    from episteme_graph.agents.component_assembly.agent import ComponentAssemblyAgent
+    from episteme_graph.agents.document_structure.agent import DocumentStructureAgent
+    from episteme_graph.agents.dsl_linking.agent import DSLLinkingAgent
+    from episteme_graph.agents.equation_semantics.agent import EquationSemanticsAgent
+    from episteme_graph.agents.paper_skeleton.agent import PaperSkeletonAgent
+    from episteme_graph.agents.rhetorical_role.agent import RhetoricalRoleAgent
+    from episteme_graph.agents.thesis_reconstruction.agent import ThesisReconstructionAgent
+
+    return {
+        "DocumentStructureAgent": DocumentStructureAgent,
+        "PaperSkeletonAgent": PaperSkeletonAgent,
+        "RhetoricalRoleAgent": RhetoricalRoleAgent,
+        "ClaimQualificationAgent": ClaimQualificationAgent,
+        "EquationSemanticsAgent": EquationSemanticsAgent,
+        "ThesisReconstructionAgent": ThesisReconstructionAgent,
+        "DSLLinkingAgent": DSLLinkingAgent,
+        "ComponentAssemblyAgent": ComponentAssemblyAgent,
+    }
+
+
+def run_document_pipeline(
+    *,
+    pdf_bytes: bytes,
+    document_id: str,
+    material_id: str,
+    filename: str | None = None,
+    cartridge_id: str | None = None,
+    course_id: str | None = None,
+    progress_callback: Callable[[str, dict], None] | None = None,
+    agents: dict | None = None,
+) -> DocumentPipelineResult:
+    """新 pipeline 本体。同期実行。
+
+    Args:
+        pdf_bytes: PDF バイナリ。一時ファイルに書き出して DocumentStructureAgent
+            に渡す。
+        document_id: documents.id。後続で chunks/claims 等の document_id に使う。
+        material_id: 教材 ID（chunks.material_id）。
+        filename: 元ファイル名（任意・ログ用）。
+        cartridge_id: 使用カートリッジ。指定なしなら EPISTEME_DEFAULT_CARTRIDGE_ID
+            から決定。
+        course_id: 任意。指定された場合のみ component graph を course にも紐づける。
+        progress_callback: 各 stage 完了時に (stage_name, info_dict) で呼ばれる。
+            background_tasks への進捗反映に使う。
+        agents: テスト用に注入可能な agent インスタンス dict。
+
+    Raises:
+        PipelineStageError: 任意 stage で復旧不能な失敗が起きた場合。
+    """
+    if cartridge_id is None:
+        cartridge_id = os.getenv("EPISTEME_DEFAULT_CARTRIDGE_ID") or None
+
+    run_id = upsert_analysis_run(
+        document_id=document_id,
+        material_id=material_id,
+        cartridge_id=cartridge_id,
+        status="running",
+        current_stage="save_pdf",
+    )
+
+    def report(stage: str, payload: dict | None = None) -> None:
+        if progress_callback:
+            try:
+                progress_callback(stage, payload or {})
+            except Exception:
+                logger.warning("progress_callback raised", exc_info=True)
+        upsert_analysis_run(
+            run_id=run_id,
+            document_id=document_id,
+            material_id=material_id,
+            cartridge_id=cartridge_id,
+            status="running",
+            current_stage=stage,
+            stage_outputs={stage: payload or {}},
+        )
+
+    result = DocumentPipelineResult(
+        document_id=document_id,
+        material_id=material_id,
+        cartridge_id=cartridge_id,
+        run_id=run_id,
+    )
+
+    agent_classes = agents or _import_agents()
+
+    pdf_path: str | None = None
+    try:
+        # ── Stage 1: save_pdf (一時ファイル化。MinIO への保存は呼び出し側担当) ─
+        report("save_pdf", {"size_bytes": len(pdf_bytes)})
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".pdf", delete=False
+        ) as f:
+            f.write(pdf_bytes)
+            pdf_path = f.name
+
+        # ── Stage 2: document_structure ────────────────────────────────────
+        try:
+            ds_agent = agent_classes["DocumentStructureAgent"]() if isinstance(
+                agent_classes["DocumentStructureAgent"], type
+            ) else agent_classes["DocumentStructureAgent"]
+            structure = ds_agent.run(pdf_path=pdf_path, cartridge_id=cartridge_id)
+            structure.document_id = document_id  # 強制的に上書きして後段一貫
+        except Exception as exc:
+            raise PipelineStageError("document_structure", str(exc), cause=exc) from exc
+        report("document_structure", {
+            "block_count": len(structure.blocks),
+            "section_count": len(structure.sections),
+        })
+
+        # ── Stage 3: source_chunking ───────────────────────────────────────
+        try:
+            source_chunks = build_source_chunks(structure)
+        except Exception as exc:
+            raise PipelineStageError("source_chunking", str(exc), cause=exc) from exc
+        if not source_chunks:
+            raise PipelineStageError(
+                "source_chunking", "no source chunks produced from document structure"
+            )
+        report("source_chunking", {"chunk_count": len(source_chunks)})
+
+        # ── Stage 4: source_embedding ──────────────────────────────────────
+        try:
+            chunk_index = persist_source_chunks(
+                document_id=document_id,
+                material_id=material_id,
+                chunks=source_chunks,
+            )
+        except Exception as exc:
+            raise PipelineStageError("source_embedding", str(exc), cause=exc) from exc
+        result.chunk_count = len(chunk_index)
+        report("source_embedding", {"saved_chunks": len(chunk_index)})
+
+        # ── Stage 5: paper_skeleton ────────────────────────────────────────
+        try:
+            ps_agent = _instantiate(agent_classes["PaperSkeletonAgent"])
+            skeleton = ps_agent.run(structure=structure, cartridge_id=cartridge_id)
+        except Exception as exc:
+            raise PipelineStageError("paper_skeleton", str(exc), cause=exc) from exc
+        report("paper_skeleton", {"document_id": document_id})
+
+        # ── Stage 6: rhetorical_role ───────────────────────────────────────
+        try:
+            rr_agent = _instantiate(agent_classes["RhetoricalRoleAgent"])
+            roles = rr_agent.run(
+                structure=structure, skeleton=skeleton, cartridge_id=cartridge_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError("rhetorical_role", str(exc), cause=exc) from exc
+        report("rhetorical_role", {})
+
+        # ── Stage 7: claim_qualification ───────────────────────────────────
+        try:
+            cq_agent = _instantiate(agent_classes["ClaimQualificationAgent"])
+            qualified = cq_agent.run(
+                structure=structure, skeleton=skeleton, roles=roles,
+                cartridge_id=cartridge_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError("claim_qualification", str(exc), cause=exc) from exc
+        report("claim_qualification", {
+            "qualified_count": len(qualified.qualified_spans),
+        })
+
+        # ── Stage 8: equation_semantics ────────────────────────────────────
+        try:
+            eq_agent = _instantiate(agent_classes["EquationSemanticsAgent"])
+            equations = eq_agent.run(
+                structure=structure, skeleton=skeleton, roles=roles,
+                cartridge_id=cartridge_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError("equation_semantics", str(exc), cause=exc) from exc
+        report("equation_semantics", {})
+
+        # ── Stage 9: thesis_reconstruction ─────────────────────────────────
+        try:
+            th_agent = _instantiate(agent_classes["ThesisReconstructionAgent"])
+            thesis = th_agent.run(
+                skeleton=skeleton, qualified_claims=qualified, equations=equations,
+                cartridge_id=cartridge_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError("thesis_reconstruction", str(exc), cause=exc) from exc
+        report("thesis_reconstruction", {})
+
+        # ── Stage 10: dsl_linking ──────────────────────────────────────────
+        try:
+            dsl_agent = _instantiate(agent_classes["DSLLinkingAgent"])
+            dsl = dsl_agent.run(
+                qualified_claims=qualified, equations=equations, thesis=thesis,
+            )
+        except Exception as exc:
+            raise PipelineStageError("dsl_linking", str(exc), cause=exc) from exc
+        result.dsl_node_count = len(dsl.nodes)
+        result.dsl_edge_count = len(dsl.edges)
+        report("dsl_linking", {
+            "nodes": len(dsl.nodes), "edges": len(dsl.edges),
+        })
+
+        # ── Stage 11: dsl_embedding ────────────────────────────────────────
+        try:
+            dsl_text = dsl_result_to_search_text(dsl, document_id=document_id)
+            persist_document_embedding(
+                document_id=document_id,
+                material_id=material_id,
+                embedding_type="dsl_graph",
+                text=dsl_text,
+                metadata={
+                    "node_count": len(dsl.nodes),
+                    "edge_count": len(dsl.edges),
+                },
+            )
+        except Exception as exc:
+            # embedding は best-effort（agent pipeline 全体の致命傷にはしない）
+            logger.exception("dsl_embedding stage failed (non-fatal): %s", exc)
+        report("dsl_embedding", {})
+
+        # ── Stage 12: component_assembly ───────────────────────────────────
+        try:
+            ca_agent = _instantiate(agent_classes["ComponentAssemblyAgent"])
+            component_result = ca_agent.run(
+                qualified_claims=qualified, equations=equations,
+                thesis=thesis, dsl=dsl, cartridge_id=cartridge_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError("component_assembly", str(exc), cause=exc) from exc
+        result.component_count = len(component_result.components)
+        report("component_assembly", {
+            "components": len(component_result.components),
+        })
+
+        # ── Stage 13: persist_claims_components_graph ──────────────────────
+        try:
+            saved_claims = persist_qualified_claims(
+                document_id=document_id,
+                qualified_result=qualified,
+                chunk_index=chunk_index,
+            )
+            result.claim_count = len(saved_claims)
+
+            id_map = persist_components(
+                document_id=document_id,
+                component_result=component_result,
+                course_id=course_id,
+            )
+            persist_component_graph(
+                document_id=document_id,
+                component_id_map=id_map,
+                component_result=component_result,
+                dsl_result=dsl,
+                course_id=course_id,
+            )
+        except Exception as exc:
+            raise PipelineStageError(
+                "persist_claims_components_graph", str(exc), cause=exc
+            ) from exc
+        report("persist_claims_components_graph", {
+            "claims": result.claim_count,
+            "components": result.component_count,
+        })
+
+        # ── Stage 14: completed ────────────────────────────────────────────
+        upsert_analysis_run(
+            run_id=run_id,
+            document_id=document_id,
+            material_id=material_id,
+            cartridge_id=cartridge_id,
+            status="completed",
+            current_stage="completed",
+            stage_outputs={"completed": {
+                "chunks": result.chunk_count,
+                "claims": result.claim_count,
+                "components": result.component_count,
+                "dsl_nodes": result.dsl_node_count,
+                "dsl_edges": result.dsl_edge_count,
+            }},
+        )
+        result.final_stage = "completed"
+        report("completed", {
+            "chunks": result.chunk_count,
+            "claims": result.claim_count,
+            "components": result.component_count,
+        })
+        return result
+
+    except PipelineStageError as exc:
+        upsert_analysis_run(
+            run_id=run_id,
+            document_id=document_id,
+            material_id=material_id,
+            cartridge_id=cartridge_id,
+            status="failed",
+            current_stage=exc.stage,
+            error_message=str(exc),
+        )
+        result.final_stage = exc.stage
+        raise
+    finally:
+        if pdf_path:
+            try:
+                os.unlink(pdf_path)
+            except OSError:
+                pass
+
+
+def _instantiate(agent_class_or_instance):
+    """class 渡しなら ()、instance 渡しならそのまま返す。"""
+    if isinstance(agent_class_or_instance, type):
+        return agent_class_or_instance()
+    return agent_class_or_instance

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -1,0 +1,646 @@
+"""Adapters from agent results to existing Postgres tables (issue #226)."""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import text as sa_text
+
+from core.llm import generate_embeddings
+from core.postgres import get_session as _pg_session
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_nuls(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [_strip_nuls(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k).replace("\x00", ""): _strip_nuls(v) for k, v in value.items()}
+    return value
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(_strip_nuls(value), ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# chunks
+# ---------------------------------------------------------------------------
+
+
+def persist_source_chunks(
+    *,
+    document_id: str,
+    material_id: str,
+    chunks: list,
+) -> list[dict]:
+    """source chunk を embedding して `chunks` テーブルに保存する。
+
+    旧実装と同じカラム (text/embedding/material_id/document_id/page_start/page_end)
+    に加え、issue #226 で追加された section_id / block_ids / source_metadata を
+    埋める。
+
+    Returns:
+        各 chunk について {chunk_id, chunk_index, section_id, block_ids,
+        page_start, page_end, text} の dict を返す。後段 agent の evidence ref
+        を解決する際に使う。
+    """
+    if not chunks:
+        return []
+
+    texts = [str(c.text or "") for c in chunks]
+    # 空テキストを embedding に投げるとエラーになるため、空でもプレースホルダ化
+    safe_texts = [t if t.strip() else " " for t in texts]
+    embeddings = generate_embeddings(safe_texts)
+
+    saved: list[dict] = []
+    session = _pg_session()
+    try:
+        # 同じ document の既存 chunk を消してから入れ直す（再実行時の整合のため）
+        session.execute(
+            sa_text("DELETE FROM chunks WHERE document_id = CAST(:doc_id AS uuid)"),
+            {"doc_id": document_id},
+        )
+        for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            chunk_id = uuid.uuid4()
+            session.execute(
+                sa_text(
+                    """
+                    INSERT INTO chunks (
+                        id, document_id, chunk_index, text, embedding,
+                        material_id, page_start, page_end,
+                        section_id, block_ids, source_metadata
+                    )
+                    VALUES (
+                        :id, CAST(:doc_id AS uuid), :idx, :text, :embedding,
+                        :material_id, :page_start, :page_end,
+                        :section_id, CAST(:block_ids AS jsonb),
+                        CAST(:metadata AS jsonb)
+                    )
+                    """
+                ),
+                {
+                    "id": chunk_id,
+                    "doc_id": document_id,
+                    "idx": chunk.chunk_index,
+                    "text": _strip_nuls(chunk.text or ""),
+                    "embedding": str(list(embedding)),
+                    "material_id": material_id,
+                    "page_start": chunk.page_start,
+                    "page_end": chunk.page_end,
+                    "section_id": chunk.section_id,
+                    "block_ids": _json_dumps(chunk.block_ids),
+                    "metadata": _json_dumps(chunk.metadata),
+                },
+            )
+            saved.append({
+                "chunk_id": str(chunk_id),
+                "chunk_index": chunk.chunk_index,
+                "section_id": chunk.section_id,
+                "block_ids": list(chunk.block_ids),
+                "page_start": chunk.page_start,
+                "page_end": chunk.page_end,
+                "text": chunk.text,
+            })
+        session.commit()
+        logger.info(
+            "Persisted %d source chunks for document %s", len(saved), document_id
+        )
+        return saved
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# theory_claims
+# ---------------------------------------------------------------------------
+
+
+_VALID_CLAIM_TYPES = {
+    "definition", "assumption", "approximation", "equation", "relation",
+    "derivation_step", "observable_definition", "correction",
+    "uncertainty", "limitation", "result", "diagnostic_claim",
+    "equation_definition", "equation_relation", "equation_transformation",
+    "equation_approximation", "equation_constraint",
+}
+
+
+def _normalize_claim_type(qualification: dict | None) -> str:
+    if not isinstance(qualification, dict):
+        return "diagnostic_claim"
+    for key in ("claim_type", "tier", "type"):
+        v = qualification.get(key)
+        if isinstance(v, str) and v in _VALID_CLAIM_TYPES:
+            return v
+    return "diagnostic_claim"
+
+
+def persist_qualified_claims(
+    *,
+    document_id: str,
+    qualified_result,
+    chunk_index: list[dict],
+) -> list[dict]:
+    """ClaimQualificationResult.qualified_spans を `theory_claims` に保存する。
+
+    Args:
+        chunk_index: persist_source_chunks の戻り値。block_id → chunk_id の
+            解決に使う。
+
+    Returns:
+        [{claim_id, span_id, chunk_id, text}] のリスト。
+    """
+    block_to_chunk: dict[str, str] = {}
+    for ch in chunk_index:
+        for bid in ch.get("block_ids") or []:
+            block_to_chunk.setdefault(bid, ch["chunk_id"])
+
+    spans = list(getattr(qualified_result, "qualified_spans", []) or [])
+    if not spans:
+        return []
+
+    saved: list[dict] = []
+    session = _pg_session()
+    try:
+        # 同 document の既存 claim を削除（pipeline 再実行時の整合確保）
+        session.execute(
+            sa_text("DELETE FROM theory_claims WHERE document_id = :doc_id"),
+            {"doc_id": document_id},
+        )
+        for span in spans:
+            qualification = getattr(span, "qualification", {}) or {}
+            decision = qualification.get("decision") if isinstance(qualification, dict) else None
+            if decision == "rejected":
+                continue
+            chunk_id = block_to_chunk.get(getattr(span, "block_id", ""))
+            params = {
+                "document_id": _strip_nuls(document_id),
+                "chunk_id": chunk_id,
+                "source_scope": _json_dumps({
+                    "section_id": getattr(span, "section_id", None),
+                    "block_id": getattr(span, "block_id", None),
+                    "span_id": getattr(span, "span_id", None),
+                }),
+                "claim_type": _normalize_claim_type(qualification),
+                "text": _strip_nuls(getattr(span, "text", "") or ""),
+                "normalized_text": _strip_nuls(getattr(span, "text", "") or ""),
+                "concepts": _json_dumps([]),
+                "equation": _json_dumps({}),
+                "support_status": "source_backed",
+                "evidence_text": _strip_nuls(getattr(span, "reason", "") or ""),
+                "review_status": "teacher_review_required",
+            }
+            row = session.execute(
+                sa_text(
+                    """
+                    INSERT INTO theory_claims (
+                        document_id, chunk_id, source_scope, claim_type, text,
+                        normalized_text, concepts, equation, support_status,
+                        evidence_text, review_status
+                    )
+                    VALUES (
+                        :document_id, CAST(:chunk_id AS uuid), CAST(:source_scope AS jsonb),
+                        :claim_type, :text, :normalized_text, CAST(:concepts AS jsonb),
+                        CAST(:equation AS jsonb), :support_status, :evidence_text, :review_status
+                    )
+                    RETURNING id
+                    """
+                ),
+                params,
+            ).fetchone()
+            saved.append({
+                "claim_id": str(row[0]),
+                "span_id": getattr(span, "span_id", None),
+                "chunk_id": chunk_id,
+                "text": getattr(span, "text", ""),
+            })
+        session.commit()
+        logger.info(
+            "Persisted %d theory_claims for document %s", len(saved), document_id
+        )
+        return saved
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# theory_components & links
+# ---------------------------------------------------------------------------
+
+
+def persist_components(
+    *,
+    document_id: str,
+    component_result,
+    course_id: str | None = None,
+) -> dict[str, str]:
+    """ComponentAssemblyResult.components を `theory_components` に保存する。
+
+    Returns:
+        agent component_id → DB UUID のマッピング（dependency 解決用）。
+    """
+    components = list(getattr(component_result, "components", []) or [])
+    if not components:
+        return {}
+
+    id_map: dict[str, str] = {}
+    session = _pg_session()
+    try:
+        # 同 document の既存 component と link を削除
+        session.execute(
+            sa_text("DELETE FROM theory_component_links WHERE document_id = :doc_id"),
+            {"doc_id": document_id},
+        )
+        session.execute(
+            sa_text("DELETE FROM theory_components WHERE document_id = :doc_id"),
+            {"doc_id": document_id},
+        )
+        for comp in components:
+            params = {
+                "course_id": course_id,
+                "document_id": document_id,
+                "name": _strip_nuls(getattr(comp, "label", "") or "Untitled"),
+                "component_type": "theory",
+                "component_type_text": _strip_nuls(
+                    getattr(comp, "component_type", "") or ""
+                ),
+                "summary": _strip_nuls(getattr(comp, "summary", "") or ""),
+                "status": "candidate",
+                "source_chunks": _json_dumps(
+                    (getattr(comp, "evidence_refs", {}) or {}).get("source_chunks") or []
+                ),
+                "inputs": _json_dumps(getattr(comp, "inputs", []) or []),
+                "outputs": _json_dumps(getattr(comp, "outputs", []) or []),
+                "preconditions": _json_dumps(getattr(comp, "preconditions", []) or []),
+                "constraints": _json_dumps([]),
+                "invalid_conditions": _json_dumps([]),
+                "dependencies": _json_dumps(getattr(comp, "dependencies", []) or []),
+                "blackbox_policy": _json_dumps({
+                    "default_level": "summary",
+                    "expand_if_unlearned": True,
+                }),
+                "validation_warnings": _json_dumps([]),
+                "teacher_notes": "",
+                "source_scope": _json_dumps({"document_id": document_id}),
+                "evidence_claims": _json_dumps(
+                    (getattr(comp, "evidence_refs", {}) or {}).get("claim_ids") or []
+                ),
+                "maturity_level": "paper_claim",
+                "maturity_source": "llm_proposed",
+                "review_status": "teacher_review_required",
+                "cautions": _json_dumps(getattr(comp, "cautions", []) or []),
+                "connectors": _json_dumps({}),
+                "internal_flow": _json_dumps([]),
+                "duplicate_candidates": _json_dumps([]),
+            }
+            row = session.execute(
+                sa_text(
+                    """
+                    INSERT INTO theory_components (
+                        course_id, document_id, name, component_type,
+                        component_type_text, summary, status,
+                        source_chunks, inputs, outputs, preconditions, constraints,
+                        invalid_conditions, dependencies, blackbox_policy,
+                        validation_warnings, teacher_notes, source_scope,
+                        evidence_claims, maturity_level, maturity_source,
+                        review_status, cautions, connectors, internal_flow,
+                        duplicate_candidates
+                    )
+                    VALUES (
+                        :course_id, :document_id, :name, :component_type,
+                        :component_type_text, :summary, :status,
+                        CAST(:source_chunks AS jsonb), CAST(:inputs AS jsonb),
+                        CAST(:outputs AS jsonb), CAST(:preconditions AS jsonb),
+                        CAST(:constraints AS jsonb), CAST(:invalid_conditions AS jsonb),
+                        CAST(:dependencies AS jsonb), CAST(:blackbox_policy AS jsonb),
+                        CAST(:validation_warnings AS jsonb), :teacher_notes,
+                        CAST(:source_scope AS jsonb), CAST(:evidence_claims AS jsonb),
+                        :maturity_level, :maturity_source, :review_status,
+                        CAST(:cautions AS jsonb), CAST(:connectors AS jsonb),
+                        CAST(:internal_flow AS jsonb), CAST(:duplicate_candidates AS jsonb)
+                    )
+                    RETURNING id
+                    """
+                ),
+                params,
+            ).fetchone()
+            db_id = str(row[0])
+            id_map[getattr(comp, "component_id", db_id)] = db_id
+
+        # 依存リンクを生成
+        for comp in components:
+            src_db = id_map.get(getattr(comp, "component_id", ""))
+            if not src_db:
+                continue
+            for dep in getattr(comp, "dependencies", []) or []:
+                if not isinstance(dep, dict):
+                    continue
+                refs = dep.get("component_refs") or []
+                dep_type = dep.get("dependency_type") or "depends_on"
+                link_type = (
+                    "requires" if dep_type == "requires"
+                    else "depends_on" if dep_type in ("depends_on", "qualifies", "refines", "supports")
+                    else "depends_on"
+                )
+                for ref in refs:
+                    dst_db = id_map.get(ref)
+                    if not dst_db or dst_db == src_db:
+                        continue
+                    session.execute(
+                        sa_text(
+                            """
+                            INSERT INTO theory_component_links (
+                                course_id, document_id,
+                                source_component_id, target_component_id,
+                                link_type, status, validation_result
+                            )
+                            VALUES (
+                                :course_id, :document_id,
+                                CAST(:src AS uuid), CAST(:dst AS uuid),
+                                :link_type, 'candidate', CAST(:validation AS jsonb)
+                            )
+                            """
+                        ),
+                        {
+                            "course_id": course_id,
+                            "document_id": document_id,
+                            "src": src_db,
+                            "dst": dst_db,
+                            "link_type": link_type,
+                            "validation": _json_dumps({
+                                "agent_dependency_type": dep_type,
+                                "reason": dep.get("reason"),
+                            }),
+                        },
+                    )
+        session.commit()
+        logger.info(
+            "Persisted %d theory_components and dependency links for document %s",
+            len(id_map), document_id,
+        )
+        return id_map
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# theory_component_graphs
+# ---------------------------------------------------------------------------
+
+
+def persist_component_graph(
+    *,
+    document_id: str,
+    component_id_map: dict[str, str],
+    component_result,
+    dsl_result,
+    course_id: str | None = None,
+) -> str | None:
+    """document scope の component graph を `theory_component_graphs` に保存。"""
+    nodes = []
+    for agent_id, db_id in component_id_map.items():
+        nodes.append({
+            "id": db_id,
+            "agent_component_id": agent_id,
+            "type": "component",
+        })
+
+    edges = []
+    for comp in getattr(component_result, "components", []) or []:
+        src_db = component_id_map.get(getattr(comp, "component_id", ""))
+        if not src_db:
+            continue
+        for dep in getattr(comp, "dependencies", []) or []:
+            if not isinstance(dep, dict):
+                continue
+            for ref in dep.get("component_refs") or []:
+                dst_db = component_id_map.get(ref)
+                if not dst_db:
+                    continue
+                edges.append({
+                    "from": src_db,
+                    "to": dst_db,
+                    "type": dep.get("dependency_type") or "depends_on",
+                    "reason": dep.get("reason") or "",
+                })
+
+    dsl_nodes = [
+        {
+            "id": getattr(n, "node_id", ""),
+            "node_type": getattr(n, "node_type", ""),
+            "value": getattr(n, "node_value", ""),
+        }
+        for n in (getattr(dsl_result, "nodes", []) or [])
+    ]
+    dsl_edges = [
+        {
+            "from": getattr(e, "from_node_id", ""),
+            "to": getattr(e, "to_node_id", ""),
+            "predicate": getattr(e, "core_predicate", ""),
+            "verb": getattr(e, "domain_verb", ""),
+            "polarity": getattr(e, "polarity", ""),
+        }
+        for e in (getattr(dsl_result, "edges", []) or [])
+    ]
+
+    graph = {
+        "graph_id": f"graph_{document_id}",
+        "document_id": document_id,
+        "scope": {"level": "paper"},
+        "nodes": nodes,
+        "edges": edges,
+        "dsl": {"nodes": dsl_nodes, "edges": dsl_edges},
+        "validation_results": [],
+    }
+
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text(
+                """
+                INSERT INTO theory_component_graphs (
+                    course_id, document_id, scope, graph_json, validation_results
+                )
+                VALUES (
+                    :course_id, :document_id, CAST(:scope AS jsonb),
+                    CAST(:graph_json AS jsonb), CAST(:validation AS jsonb)
+                )
+                ON CONFLICT (document_id) DO UPDATE SET
+                    course_id = EXCLUDED.course_id,
+                    scope = EXCLUDED.scope,
+                    graph_json = EXCLUDED.graph_json,
+                    validation_results = EXCLUDED.validation_results,
+                    updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "course_id": course_id,
+                "document_id": document_id,
+                "scope": _json_dumps({"level": "paper"}),
+                "graph_json": _json_dumps(graph),
+                "validation": _json_dumps([]),
+            },
+        ).fetchone()
+        session.commit()
+        return str(row[0]) if row else None
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# document_embeddings
+# ---------------------------------------------------------------------------
+
+
+def persist_document_embedding(
+    *,
+    document_id: str,
+    material_id: str | None,
+    embedding_type: str,
+    text: str,
+    metadata: dict | None = None,
+    source_version: str = "v1",
+) -> str:
+    """document-level の derived embedding を保存する（DSL graph など）。"""
+    if not text or not text.strip():
+        text = " "
+    [embedding] = generate_embeddings([text])
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text(
+                """
+                INSERT INTO document_embeddings (
+                    document_id, material_id, embedding_type, source_version,
+                    text, embedding, metadata
+                )
+                VALUES (
+                    :document_id, :material_id, :embedding_type, :source_version,
+                    :text, :embedding, CAST(:metadata AS jsonb)
+                )
+                ON CONFLICT (document_id, embedding_type, source_version) DO UPDATE SET
+                    material_id = EXCLUDED.material_id,
+                    text = EXCLUDED.text,
+                    embedding = EXCLUDED.embedding,
+                    metadata = EXCLUDED.metadata,
+                    updated_at = now()
+                RETURNING id
+                """
+            ),
+            {
+                "document_id": document_id,
+                "material_id": material_id,
+                "embedding_type": embedding_type,
+                "source_version": source_version,
+                "text": _strip_nuls(text),
+                "embedding": str(list(embedding)),
+                "metadata": _json_dumps(metadata or {}),
+            },
+        ).fetchone()
+        session.commit()
+        return str(row[0]) if row else ""
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# document_analysis_runs
+# ---------------------------------------------------------------------------
+
+
+def upsert_analysis_run(
+    *,
+    document_id: str,
+    material_id: str | None,
+    cartridge_id: str | None,
+    status: str,
+    current_stage: str | None = None,
+    error_message: str = "",
+    stage_outputs: dict | None = None,
+    run_id: str | None = None,
+) -> str:
+    """`document_analysis_runs` に upsert する。
+
+    run_id を渡すとそのレコードを更新、None なら新規作成。
+    """
+    session = _pg_session()
+    try:
+        if run_id is None:
+            row = session.execute(
+                sa_text(
+                    """
+                    INSERT INTO document_analysis_runs (
+                        document_id, material_id, cartridge_id, status,
+                        current_stage, error_message, stage_outputs, started_at
+                    )
+                    VALUES (
+                        :document_id, :material_id, :cartridge_id, :status,
+                        :current_stage, :error_message, CAST(:stage_outputs AS jsonb),
+                        CASE WHEN :status = 'running' THEN now() ELSE NULL END
+                    )
+                    RETURNING id
+                    """
+                ),
+                {
+                    "document_id": document_id,
+                    "material_id": material_id,
+                    "cartridge_id": cartridge_id,
+                    "status": status,
+                    "current_stage": current_stage,
+                    "error_message": error_message or "",
+                    "stage_outputs": _json_dumps(stage_outputs or {}),
+                },
+            ).fetchone()
+            session.commit()
+            return str(row[0])
+        else:
+            session.execute(
+                sa_text(
+                    """
+                    UPDATE document_analysis_runs SET
+                        status = :status,
+                        current_stage = :current_stage,
+                        error_message = :error_message,
+                        stage_outputs = stage_outputs || CAST(:stage_outputs AS jsonb),
+                        completed_at = CASE WHEN :status IN ('completed', 'failed')
+                                            THEN now() ELSE completed_at END,
+                        updated_at = now()
+                    WHERE id = CAST(:id AS uuid)
+                    """
+                ),
+                {
+                    "id": run_id,
+                    "status": status,
+                    "current_stage": current_stage,
+                    "error_message": error_message or "",
+                    "stage_outputs": _json_dumps(stage_outputs or {}),
+                },
+            )
+            session.commit()
+            return run_id
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/db/015_document_pipeline.sql
+++ b/backend/db/015_document_pipeline.sql
@@ -1,0 +1,90 @@
+-- Migration 015: Document-first analysis pipeline (issue #226)
+--
+-- 変更概要:
+--   1. chunks に section_id / block_ids / source_metadata カラムを追加
+--      （DocumentStructureAgent ベースの section-aware chunking 用）
+--   2. theory_components / theory_component_links / theory_component_graphs の
+--      course_id を nullable 化し、document-first な永続化を許す
+--   3. theory_components / theory_component_graphs に document_id を追加し、
+--      course に依存しない document scope での集計を可能にする
+--   4. document_embeddings テーブル新設（DSL graph などの derived embedding 用）
+--   5. document_analysis_runs テーブル新設（agent pipeline の実行履歴と
+--      stage 単位の状況・raw output を保持）
+--
+-- すべて IF NOT EXISTS / DROP CONSTRAINT IF EXISTS で冪等。
+
+-- ----------------------------------------------------------------------------
+-- chunks: section-aware metadata
+-- ----------------------------------------------------------------------------
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS section_id      TEXT;
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS block_ids       JSONB NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS source_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_chunks_section ON chunks(section_id);
+
+-- ----------------------------------------------------------------------------
+-- theory_* : course_id を nullable に。document_id を追加。
+-- ----------------------------------------------------------------------------
+ALTER TABLE theory_components ALTER COLUMN course_id DROP NOT NULL;
+ALTER TABLE theory_components ADD COLUMN IF NOT EXISTS document_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_theory_components_document ON theory_components(document_id);
+
+ALTER TABLE theory_component_links ALTER COLUMN course_id DROP NOT NULL;
+ALTER TABLE theory_component_links ADD COLUMN IF NOT EXISTS document_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_theory_component_links_document ON theory_component_links(document_id);
+
+ALTER TABLE theory_component_graphs ALTER COLUMN course_id DROP NOT NULL;
+-- 既存の UNIQUE(course_id, document_id) は course_id が NULL になる行で
+-- 重複保存できなくなるため、document_id 単独の UNIQUE 制約を追加する。
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'theory_component_graphs_document_uq'
+    ) THEN
+        ALTER TABLE theory_component_graphs
+            ADD CONSTRAINT theory_component_graphs_document_uq UNIQUE (document_id);
+    END IF;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- document_embeddings: derived embedding 保存口
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS document_embeddings (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    document_id     TEXT NOT NULL,
+    material_id     TEXT,
+    embedding_type  TEXT NOT NULL,
+    source_version  TEXT NOT NULL DEFAULT 'v1',
+    text            TEXT NOT NULL,
+    embedding       vector(768),
+    metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(document_id, embedding_type, source_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_embeddings_document ON document_embeddings(document_id);
+CREATE INDEX IF NOT EXISTS idx_document_embeddings_type     ON document_embeddings(embedding_type);
+
+-- ----------------------------------------------------------------------------
+-- document_analysis_runs: agent pipeline の実行履歴
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS document_analysis_runs (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    document_id     TEXT NOT NULL,
+    material_id     TEXT,
+    cartridge_id    TEXT,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'running', 'completed', 'failed')),
+    current_stage   TEXT,
+    error_message   TEXT NOT NULL DEFAULT '',
+    stage_outputs   JSONB NOT NULL DEFAULT '{}'::jsonb,
+    started_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_analysis_runs_document ON document_analysis_runs(document_id);
+CREATE INDEX IF NOT EXISTS idx_document_analysis_runs_status   ON document_analysis_runs(status);

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1,0 +1,335 @@
+"""Tests for the document-first analysis pipeline (issue #226).
+
+Covers:
+    - section-aware chunker (pure logic, no DB)
+    - DSL graph → search text (pure logic, no DB)
+    - orchestrator stage flow with all agents and persistence mocked
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# --- Helpers ---------------------------------------------------------------
+
+@dataclass
+class _Block:
+    block_id: str
+    page: int
+    order: int
+    text: str
+    block_type: str = "body_paragraph"
+    section_id: str | None = None
+
+
+@dataclass
+class _Section:
+    section_id: str
+    title: str
+    level: int = 1
+    order: int = 0
+    page_start: int = 1
+    page_end: int | None = None
+
+
+@dataclass
+class _Structure:
+    document_id: str
+    blocks: list
+    sections: list
+
+
+# --- chunker ---------------------------------------------------------------
+
+def test_chunker_groups_blocks_by_section_and_respects_max_chars():
+    from core.document_pipeline.chunker import build_source_chunks
+
+    structure = _Structure(
+        document_id="doc-1",
+        sections=[
+            _Section(section_id="s1", title="Intro", order=1, page_start=1),
+            _Section(section_id="s2", title="Method", order=2, page_start=2),
+        ],
+        blocks=[
+            _Block("b1", 1, 0, "A" * 100, section_id="s1"),
+            _Block("b2", 1, 1, "B" * 100, section_id="s1"),
+            _Block("b3", 2, 0, "C" * 100, section_id="s2"),
+        ],
+    )
+
+    chunks = build_source_chunks(structure, max_chars=300)
+    assert len(chunks) >= 1
+    # 1個目の chunk が s1 section にあること
+    assert chunks[0].section_id == "s1"
+    # block_ids が記録されていること
+    assert "b1" in chunks[0].block_ids
+    # chunk_index が単調増加
+    assert [c.chunk_index for c in chunks] == list(range(len(chunks)))
+
+
+def test_chunker_splits_oversized_block():
+    from core.document_pipeline.chunker import build_source_chunks
+
+    long_text = "X" * 5000
+    structure = _Structure(
+        document_id="doc-2",
+        sections=[_Section("s1", "Long", order=1, page_start=1)],
+        blocks=[_Block("big", 1, 0, long_text, section_id="s1")],
+    )
+    chunks = build_source_chunks(structure, max_chars=1000)
+    # 5000 / 1000 = 5 個に分割される（吸収後でも複数）
+    assert len(chunks) >= 4
+    assert all(c.section_id == "s1" for c in chunks)
+    assert all(c.metadata.get("split_long_block") for c in chunks)
+
+
+def test_chunker_handles_blocks_without_section():
+    from core.document_pipeline.chunker import build_source_chunks
+
+    structure = _Structure(
+        document_id="doc-3",
+        sections=[],
+        blocks=[
+            _Block("b1", 1, 0, "Lone paragraph one.", section_id=None),
+            _Block("b2", 1, 1, "Lone paragraph two.", section_id=None),
+        ],
+    )
+    chunks = build_source_chunks(structure, max_chars=1000)
+    assert len(chunks) == 1
+    assert chunks[0].section_id is None
+    assert "Lone paragraph one." in chunks[0].text
+    assert "Lone paragraph two." in chunks[0].text
+
+
+# --- dsl_text -------------------------------------------------------------
+
+def test_dsl_result_to_search_text_includes_nodes_and_edges():
+    from core.document_pipeline.dsl_text import dsl_result_to_search_text
+
+    @dataclass
+    class N:
+        node_id: str
+        node_type: str
+        node_value: str
+        reason: str = ""
+        source_kind: str = "claim"
+        source_refs: dict = field(default_factory=dict)
+        confidence: float = 0.9
+
+    @dataclass
+    class E:
+        edge_id: str
+        from_node_id: str
+        to_node_id: str
+        core_predicate: str
+        domain_verb: str
+        polarity: str
+        evidence_refs: dict = field(default_factory=dict)
+        reason: str = ""
+        confidence: float = 0.9
+
+    @dataclass
+    class R:
+        nodes: list
+        edges: list
+        review_notes: list = field(default_factory=list)
+
+    result = R(
+        nodes=[
+            N("n1", "Relation", "total_rate_sum_rule", reason="from claim 12"),
+            N("n2", "Approximation", "isospin_limit"),
+        ],
+        edges=[
+            E("e1", "n1", "n2", "REQUIRES", "depends_on", "+", reason="motivated by"),
+        ],
+        review_notes=["uncertain edge n1→n2"],
+    )
+
+    text = dsl_result_to_search_text(result, document_id="doc-9")
+    assert "DSL graph for document doc-9" in text
+    assert "n1 Relation total_rate_sum_rule" in text
+    assert "n1 REQUIRES(depends_on, +) n2" in text
+    assert "uncertain edge" in text
+
+
+# --- orchestrator stage flow ---------------------------------------------
+
+class _MockAgent:
+    def __init__(self, returns):
+        self._returns = returns
+
+    def run(self, **kwargs):
+        return self._returns
+
+
+def test_orchestrator_runs_all_stages_in_order():
+    from core.document_pipeline import orchestrator
+
+    @dataclass
+    class _Result:
+        document_id: str = "doc"
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+        components: list = field(default_factory=list)
+        qualified_spans: list = field(default_factory=list)
+        sections: list = field(default_factory=lambda: [_Section("s1", "Intro", order=1, page_start=1)])
+        blocks: list = field(default_factory=lambda: [_Block("b1", 1, 0, "Hello world body.", section_id="s1")])
+        review_notes: list = field(default_factory=list)
+
+    structure_result = _Result()
+
+    agents = {
+        "DocumentStructureAgent": _MockAgent(structure_result),
+        "PaperSkeletonAgent": _MockAgent(_Result()),
+        "RhetoricalRoleAgent": _MockAgent(_Result()),
+        "ClaimQualificationAgent": _MockAgent(_Result()),
+        "EquationSemanticsAgent": _MockAgent(_Result()),
+        "ThesisReconstructionAgent": _MockAgent(_Result()),
+        "DSLLinkingAgent": _MockAgent(_Result()),
+        "ComponentAssemblyAgent": _MockAgent(_Result()),
+    }
+
+    visited: list[str] = []
+
+    def progress(stage, info):
+        visited.append(stage)
+
+    fake_persistence = {
+        "persist_source_chunks": MagicMock(return_value=[
+            {"chunk_id": "c1", "chunk_index": 0, "section_id": "s1",
+             "block_ids": ["b1"], "page_start": 1, "page_end": 1, "text": "Hello"}
+        ]),
+        "persist_qualified_claims": MagicMock(return_value=[]),
+        "persist_components": MagicMock(return_value={}),
+        "persist_component_graph": MagicMock(return_value="graph-1"),
+        "persist_document_embedding": MagicMock(return_value="emb-1"),
+        "upsert_analysis_run": MagicMock(return_value="run-1"),
+    }
+
+    with patch.multiple(orchestrator, **fake_persistence):
+        result = orchestrator.run_document_pipeline(
+            pdf_bytes=b"%PDF-1.4 fake bytes",
+            document_id="doc-42",
+            material_id="mat-1",
+            filename="paper.pdf",
+            cartridge_id="particle_physics",
+            progress_callback=progress,
+            agents=agents,
+        )
+
+    assert result.final_stage == "completed"
+    expected_stages = [
+        "save_pdf",
+        "document_structure",
+        "source_chunking",
+        "source_embedding",
+        "paper_skeleton",
+        "rhetorical_role",
+        "claim_qualification",
+        "equation_semantics",
+        "thesis_reconstruction",
+        "dsl_linking",
+        "dsl_embedding",
+        "component_assembly",
+        "persist_claims_components_graph",
+        "completed",
+    ]
+    for stage in expected_stages:
+        assert stage in visited, f"stage {stage} not invoked. got={visited}"
+    # 各 persist 関数が一度ずつ呼ばれる
+    fake_persistence["persist_source_chunks"].assert_called_once()
+    fake_persistence["persist_qualified_claims"].assert_called_once()
+    fake_persistence["persist_components"].assert_called_once()
+    fake_persistence["persist_component_graph"].assert_called_once()
+    fake_persistence["persist_document_embedding"].assert_called_once()
+
+
+# --- regression-style structural assertions (issue #226) ----------------
+
+def test_issue_226_pipeline_files_exist():
+    repo = Path(__file__).resolve().parents[2]
+    for rel in [
+        "backend/core/document_pipeline/__init__.py",
+        "backend/core/document_pipeline/orchestrator.py",
+        "backend/core/document_pipeline/chunker.py",
+        "backend/core/document_pipeline/persistence.py",
+        "backend/core/document_pipeline/dsl_text.py",
+        "backend/db/015_document_pipeline.sql",
+    ]:
+        assert (repo / rel).exists(), f"missing pipeline artifact {rel}"
+
+
+def test_issue_226_old_pipeline_no_longer_called_from_upload():
+    repo = Path(__file__).resolve().parents[2]
+    services_src = (repo / "backend/api/services.py").read_text(encoding="utf-8")
+    upload_section = services_src[
+        services_src.index("def process_material_background"):
+        services_src.index("def reanalyze_course_structure_background")
+    ]
+    # 旧 pipeline 関数は process_material_background から呼ばれてはいけない
+    assert "build_knowledge_graph(" not in upload_section
+    assert "chunk_pdf_pages(" not in upload_section
+    # 新 pipeline へ委譲している
+    assert "run_document_pipeline" in upload_section
+
+
+def test_issue_226_admin_has_document_reanalyze_endpoint():
+    repo = Path(__file__).resolve().parents[2]
+    admin_src = (repo / "backend/api/routes/admin.py").read_text(encoding="utf-8")
+    assert '"/documents/{document_id}/reanalyze"' in admin_src
+
+
+def test_issue_226_migration_adds_document_pipeline_artifacts():
+    repo = Path(__file__).resolve().parents[2]
+    sql = (repo / "backend/db/015_document_pipeline.sql").read_text(encoding="utf-8")
+    assert "ALTER TABLE chunks ADD COLUMN IF NOT EXISTS section_id" in sql
+    assert "CREATE TABLE IF NOT EXISTS document_embeddings" in sql
+    assert "CREATE TABLE IF NOT EXISTS document_analysis_runs" in sql
+    assert "ALTER TABLE theory_components ALTER COLUMN course_id DROP NOT NULL" in sql
+    assert "embedding_type" in sql
+
+
+def test_orchestrator_records_failed_stage():
+    from core.document_pipeline import orchestrator
+
+    @dataclass
+    class _Result:
+        document_id: str = "doc"
+        sections: list = field(default_factory=list)
+        blocks: list = field(default_factory=list)
+
+    class _Fail:
+        def run(self, **kwargs):
+            raise RuntimeError("boom")
+
+    agents = {
+        "DocumentStructureAgent": _Fail(),
+        "PaperSkeletonAgent": _MockAgent(_Result()),
+        "RhetoricalRoleAgent": _MockAgent(_Result()),
+        "ClaimQualificationAgent": _MockAgent(_Result()),
+        "EquationSemanticsAgent": _MockAgent(_Result()),
+        "ThesisReconstructionAgent": _MockAgent(_Result()),
+        "DSLLinkingAgent": _MockAgent(_Result()),
+        "ComponentAssemblyAgent": _MockAgent(_Result()),
+    }
+
+    with patch.object(orchestrator, "upsert_analysis_run", return_value="run-x"):
+        with pytest.raises(orchestrator.PipelineStageError) as exc_info:
+            orchestrator.run_document_pipeline(
+                pdf_bytes=b"x",
+                document_id="doc-1",
+                material_id="m-1",
+                agents=agents,
+            )
+    assert exc_info.value.stage == "document_structure"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
   # ── Application ───────────────────────────────────────────────────
   api-server:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
     environment:
       JWT_SECRET: ${JWT_SECRET:-episteme-dev-secret-change-in-prod}
       LLM_PROVIDER: ${LLM_PROVIDER:-openai}


### PR DESCRIPTION
## Summary

Implements a new document-first analysis pipeline (issue #226) that orchestrates 8 specialized agents to analyze PDFs and extract structured knowledge claims and components. This replaces the previous course/section-centric approach with a document-centric workflow that produces section-aware chunks, qualified claims, and theory components persisted to the database.

## Key Changes

### Core Pipeline Infrastructure
- **`orchestrator.py`**: Main pipeline orchestrator that sequences 14 stages from PDF ingestion through component assembly, with error handling and progress callbacks
- **`persistence.py`**: Adapters that persist agent outputs to existing Postgres tables (chunks, theory_claims, theory_components, theory_component_links, theory_component_graphs, document_embeddings, document_analysis_runs)
- **`chunker.py`**: Section-aware source chunker that respects document structure boundaries and produces chunks with section_id, block_ids, and metadata
- **`dsl_text.py`**: Converts DSL graph results to searchable text for embedding

### Database Schema
- **Migration 015** (`db/015_document_pipeline.sql` and inline migrations in `main.py`):
  - Added `section_id`, `block_ids`, `source_metadata` to chunks table
  - Made `course_id` nullable in theory_components, theory_component_links, theory_component_graphs
  - Added `document_id` to theory_components, theory_component_links, theory_component_graphs for document-scoped analysis
  - Created `document_embeddings` table for derived embeddings (DSL graphs, etc.)
  - Created `document_analysis_runs` table to track pipeline execution history and stage outputs

### API Integration
- **`services.py`**: Updated `process_material_background()` to use new pipeline instead of legacy chunking/embedding approach
- **`admin.py`**: Added `/documents/{document_id}/reanalyze` endpoint to re-run pipeline on existing documents

### Testing
- **`test_document_pipeline.py`**: Comprehensive test suite covering:
  - Section-aware chunking with max character limits and block splitting
  - DSL graph to search text conversion
  - Full orchestrator stage flow with mocked agents and persistence

### Build Configuration
- Updated `Dockerfile` and `docker-compose.yml` to reflect correct backend directory structure

## Implementation Details

- **Pipeline Stages**: 14 sequential stages from PDF save through completion, with each stage reporting progress via callback
- **Error Handling**: `PipelineStageError` exception captures which stage failed for debugging
- **Null Character Stripping**: `_strip_nuls()` utility prevents PostgreSQL JSON encoding issues
- **Chunk Merging**: Short tail chunks are absorbed into preceding chunks to avoid fragmentation
- **Dependency Resolution**: Component dependencies are resolved via agent component_id → DB UUID mapping
- **Lazy Agent Import**: Agents are imported only when pipeline runs, allowing flexible test injection
- **Idempotent Persistence**: Document-scoped deletes before inserts ensure re-run consistency

https://claude.ai/code/session_01PUac4vyj4XqAZWGGB7Rb4T