### PR TITLE
Replace course builder context with Agent-generated theory components

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -980,12 +980,19 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 - 提案するすべての章・トピック・概念は、提供された教材の記述内容に基づかなければならない
 - 教材に記載されていないトピックを「一般的だから」「基礎的だから」という理由で追加してはならない
 - 教材の内容を超えた一般知識に基づく補足は、明示的に「教材外の補足」として区別すること
-- 教材のチャンク（テキスト断片）やナレッジグラフが提供された場合、それらの情報を最大限活用してコースを設計すること
+- 提供された理論コンポーネント・依存関係グラフ・根拠Claimを最大限活用してコースを設計すること
 
 **【重要】段階的構造化の原則:**
-- チャンクの並び順（chunk_index）は教材内の論理的な流れを反映しているため、この順序を尊重してコースの章立てを構成する
+- コースの章・トピック候補は `theory_components` を主に使用する（各コンポーネントの name / summary / inputs / outputs / preconditions を参照）
+- 学習順序は `theory_component_graphs` の依存関係（edges）を優先する（PDFの出現順よりも依存関係を重視）
+- `theory_claims` は各コンポーネントの根拠確認・evidence検証に使う
+- `chunks`（原文抜粋）は説明補助として使い、コース設計の主判断材料にしない
 - 前提知識が必要な概念は、その前提となる概念より後の章・トピックに配置する（依存関係に基づいたシラバス）
 - 初学者がその分野に初めて触れることを想定し、専門用語は最初に出現する章で定義・説明するよう構成する
+
+**【注意】ナレッジグラフの扱い:**
+- `documents.knowledge_graph` はAgentパイプライン未実行の旧教材のみに利用するfallbackである
+- Agent解析済み教材では `theory_components` / `theory_component_graphs` を優先し、ナレッジグラフは参照しない
 
 **コース構成のJSONスキーマ (course_draft):**
 生成するコース構成案は以下の形式に従ってください:
@@ -1012,8 +1019,8 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 
 **対話の進め方:**
 1. まず教員の要望（テーマ、対象者、使用教材等）をヒアリングする
-2. 提供された教材の内容（ナレッジグラフ、テキストチャンク）を精査し、教材の範囲と構成を把握する
-3. 教材の内容に基づいた初期のコース構成案を提示する
+2. 提供された理論コンポーネントと依存関係グラフを精査し、教材の範囲と構成を把握する
+3. theory_components を章・トピック候補として使い、theory_component_graphs の依存関係で順序を決定する
 4. 教員のフィードバックに基づいて構成案を改善する
 5. 前提知識の不足や学習順序の問題があれば指摘する
 
@@ -1026,7 +1033,7 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 - topics[].prerequisites には、そのトピックを学ぶ前に習得しておくべき**同コース内の**トピックのタイトルを列挙する
   - 例: 第2章のトピックは第1章のトピックタイトルを prerequisites に入れる
   - 最初のトピックや前提知識不要なトピックは prerequisites を空配列 [] にする
-- domain フィールドは教材のナレッジグラフに記載されている「**分野:**」から引き継ぐこと
+- domain フィールドは教材の分野情報（コンポーネントや旧ナレッジグラフの「**分野:**」）から引き継ぐこと
   - 教材の分野情報がなければ、コースの内容を踏まえて適切な専門分野名を設定する
 - sources フィールドは常に空配列 [] のままにすること（教材はシステムが自動的に設定する）"""
 
@@ -1035,15 +1042,22 @@ _COURSE_BUILDER_SYSTEM_PROMPT = """あなたは大学教員が学習コース（
 # Course Builder: Material Context Builder
 # ---------------------------------------------------------------------------
 
-# チャンクテキストのサンプリング上限（1教材あたり）
+# サイズ制限（1教材あたり）
 _MAX_CHUNK_CHARS_PER_MATERIAL = 4000
+_MAX_COMPONENTS_PER_MATERIAL = 40
+_MAX_CLAIMS_PER_MATERIAL = 80
+_MAX_GRAPH_EDGES_PER_MATERIAL = 80
 
 
 def _build_material_context(
     material_ids: list[str],
     pg_session_factory=None,
 ) -> str | None:
-    """選択された教材のナレッジグラフとチャンクテキストからコンテキスト文字列を構築する。
+    """選択された教材のAgent解析済み理論コンポーネントを主入力としてコンテキスト文字列を構築する。
+
+    主入力: theory_components / theory_component_graphs / theory_claims
+    補助入力: chunks (原文抜粋) / document_analysis_runs._artifacts.document_structure
+    fallback: documents.knowledge_graph (Agent未実行の旧教材のみ)
 
     Returns None if no usable context could be built.
     """
@@ -1053,17 +1067,16 @@ def _build_material_context(
     _get_pg = pg_session_factory or _pg_session
     session = _get_pg()
     try:
-        # --- 1) ドキュメントメタデータ + knowledge_graph を取得 ---
         placeholders = ", ".join(f":mid_{i}" for i in range(len(material_ids)))
-        params: dict = {}
-        for i, mid in enumerate(material_ids):
-            params[f"mid_{i}"] = mid
+        params: dict = {f"mid_{i}": mid for i, mid in enumerate(material_ids)}
 
+        # --- 1) ドキュメントメタデータ取得（UUID と source_path の対応も取得）---
         doc_rows = session.execute(
             sa_text(f"""
-                SELECT source_path, title, filename, knowledge_graph
+                SELECT source_path, title, filename, id::text AS doc_uuid,
+                       status, knowledge_graph
                 FROM documents
-                WHERE source_path IN ({placeholders}) AND status = 'completed'
+                WHERE source_path IN ({placeholders})
             """),
             params,
         ).fetchall()
@@ -1071,77 +1084,264 @@ def _build_material_context(
         if not doc_rows:
             return None
 
-        # --- 2) チャンクテキストを取得 (chunk_index 順) ---
+        # doc_uuid → source_path マッピング
+        uuid_to_mid: dict[str, str] = {row[3]: row[0] for row in doc_rows}
+        doc_uuids = list(uuid_to_mid.keys())
+        uuid_placeholders = ", ".join(f":uuid_{i}" for i in range(len(doc_uuids)))
+        uuid_params: dict = {f"uuid_{i}": uid for i, uid in enumerate(doc_uuids)}
+
+        # --- 2) theory_components (主入力) ---
+        component_rows = session.execute(
+            sa_text(f"""
+                SELECT id::text, document_id, name, component_type, component_type_text,
+                       summary, inputs, outputs, preconditions, cautions,
+                       source_chunks, evidence_claims, review_status, maturity_level
+                FROM theory_components
+                WHERE document_id IN ({uuid_placeholders})
+                ORDER BY
+                    CASE review_status WHEN 'teacher_reviewed' THEN 0 ELSE 1 END,
+                    CASE maturity_level
+                        WHEN 'peer_reviewed' THEN 0
+                        WHEN 'textbook' THEN 1
+                        WHEN 'paper_claim' THEN 2
+                        ELSE 3
+                    END
+            """),
+            uuid_params,
+        ).fetchall() if doc_uuids else []
+
+        # --- 3) theory_component_graphs (主入力) ---
+        graph_rows = session.execute(
+            sa_text(f"""
+                SELECT document_id, graph_json
+                FROM theory_component_graphs
+                WHERE document_id IN ({uuid_placeholders})
+            """),
+            uuid_params,
+        ).fetchall() if doc_uuids else []
+
+        # --- 4) theory_claims (補助入力) ---
+        claim_rows = session.execute(
+            sa_text(f"""
+                SELECT id::text, document_id, claim_type, text, normalized_text,
+                       source_scope, evidence_text, support_status, review_status
+                FROM theory_claims
+                WHERE document_id IN ({uuid_placeholders})
+                ORDER BY
+                    CASE review_status WHEN 'teacher_reviewed' THEN 0 ELSE 1 END,
+                    CASE support_status WHEN 'source_backed' THEN 0 ELSE 1 END
+            """),
+            uuid_params,
+        ).fetchall() if doc_uuids else []
+
+        # --- 5) chunks (補助入力: 原文抜粋) ---
         chunk_rows = session.execute(
             sa_text(f"""
-                SELECT material_id, chunk_index, chapter, section, text
+                SELECT material_id, chunk_index, section_id, text, page_start, page_end
                 FROM chunks
                 WHERE material_id IN ({placeholders})
                 ORDER BY material_id, chunk_index
             """),
             params,
         ).fetchall()
+
+        # --- 6) document_analysis_runs: 完了状態確認 + document_structure ---
+        analysis_rows = session.execute(
+            sa_text(f"""
+                SELECT document_id, status, stage_outputs
+                FROM document_analysis_runs
+                WHERE document_id IN ({uuid_placeholders})
+                ORDER BY updated_at DESC
+            """),
+            uuid_params,
+        ).fetchall() if doc_uuids else []
+
     finally:
         session.close()
 
-    # --- 3) コンテキスト文字列を組み立て ---
+    # 完了済み analysis run のマップ (doc_uuid → row)
+    analysis_by_uuid: dict[str, object] = {}
+    for row in analysis_rows:
+        uid = row[0]
+        if uid not in analysis_by_uuid:
+            analysis_by_uuid[uid] = row
+
+    # --- 7) コンテキスト文字列を組み立て ---
     sections: list[str] = []
-    sections.append("## 教材の内容詳細\n以下は選択された教材から抽出された詳細情報です。"
-                     "コース設計はこの内容に基づいて行ってください。\n")
+    sections.append(
+        "## Agent解析済み教材コンテキスト\n"
+        "以下は選択された教材からAgentパイプラインが生成した理論コンポーネント情報です。"
+        "コース設計はこの内容に基づいて行ってください。\n"
+    )
 
     for doc in doc_rows:
         mid = doc[0] or ""
         title = doc[1] or doc[2] or ""
-        kg = doc[3] if doc[3] and isinstance(doc[3], dict) else {}
+        doc_uuid = doc[3] or ""
+        kg = doc[5] if doc[5] and isinstance(doc[5], dict) else {}
 
         sections.append(f"### 教材: {title}")
 
-        # ナレッジグラフの概要
-        if kg.get("summary"):
-            sections.append(f"**概要:** {kg['summary']}")
+        # Agent完了状態チェック
+        analysis_run = analysis_by_uuid.get(doc_uuid)
+        pipeline_complete = analysis_run is not None and analysis_run[1] == "completed"
 
-        if kg.get("domain"):
-            sections.append(f"**分野:** {kg['domain']}")
+        doc_components = [r for r in component_rows if r[1] == doc_uuid]
+        doc_graphs = [r for r in graph_rows if r[0] == doc_uuid]
+        has_agent_data = bool(doc_components or doc_graphs)
 
-        # 主要概念
-        concepts = kg.get("concepts", [])
-        if concepts:
-            concept_lines = []
-            for c in concepts:
-                name = c.get("name", "") if isinstance(c, dict) else str(c)
-                desc = c.get("description", "") if isinstance(c, dict) else ""
-                ctype = c.get("type", "") if isinstance(c, dict) else ""
-                line = f"- {name}"
+        if not has_agent_data and not pipeline_complete:
+            sections.append(
+                "> **警告:** この教材はAgentパイプラインが未完了のため、"
+                "コース構築に十分な解析情報がありません。"
+                "教材のアップロード後しばらく待ってから再試行してください。"
+            )
+
+        # ---- 主入力: 理論コンポーネント ----
+        if doc_components:
+            sections.append("#### 理論コンポーネント")
+            for comp in doc_components[:_MAX_COMPONENTS_PER_MATERIAL]:
+                comp_id = comp[0]
+                name = comp[2] or ""
+                ctype = comp[4] or comp[3] or ""
+                summary = comp[5] or ""
+                inputs = comp[6] if isinstance(comp[6], list) else []
+                outputs = comp[7] if isinstance(comp[7], list) else []
+                preconditions = comp[8] if isinstance(comp[8], list) else []
+                cautions = comp[9] if isinstance(comp[9], list) else []
+                review = comp[12] or ""
+                maturity = comp[13] or ""
+
+                lines = [f"- Component ID: {comp_id}"]
+                lines.append(f"  Name: {name}")
                 if ctype:
-                    line += f" ({ctype})"
-                if desc:
-                    line += f": {desc}"
-                concept_lines.append(line)
-            sections.append("**主要概念:**\n" + "\n".join(concept_lines))
+                    lines.append(f"  Type: {ctype}")
+                if summary:
+                    lines.append(f"  Summary: {summary}")
+                if inputs:
+                    lines.append(f"  Inputs: {', '.join(str(x) for x in inputs[:5])}")
+                if outputs:
+                    lines.append(f"  Outputs: {', '.join(str(x) for x in outputs[:5])}")
+                if preconditions:
+                    lines.append(f"  Preconditions: {', '.join(str(x) for x in preconditions[:5])}")
+                if cautions:
+                    lines.append(f"  Cautions: {', '.join(str(x) for x in cautions[:3])}")
+                if review:
+                    lines.append(f"  Review: {review}")
+                if maturity:
+                    lines.append(f"  Maturity: {maturity}")
+                sections.append("\n".join(lines))
 
-        # チャンクテキストのサンプリング
+        # ---- 主入力: コンポーネント依存関係グラフ ----
+        if doc_graphs:
+            graph_json = doc_graphs[0][1] if isinstance(doc_graphs[0][1], dict) else {}
+            edges = graph_json.get("edges", [])
+            if edges:
+                sections.append("#### コンポーネント依存関係")
+                for edge in edges[:_MAX_GRAPH_EDGES_PER_MATERIAL]:
+                    if not isinstance(edge, dict):
+                        continue
+                    src = edge.get("source", edge.get("from", ""))
+                    tgt = edge.get("target", edge.get("to", ""))
+                    etype = edge.get("type", edge.get("relation", ""))
+                    reason = edge.get("reason", edge.get("label", ""))
+                    line = f"- {src} -> {tgt}"
+                    if etype:
+                        line += f"  (Type: {etype})"
+                    if reason:
+                        line += f"  Reason: {reason}"
+                    sections.append(line)
+
+        # ---- 補助入力: 根拠Claim ----
+        doc_claims = [r for r in claim_rows if r[1] == doc_uuid]
+        if doc_claims:
+            sections.append("#### 根拠Claim")
+            for claim in doc_claims[:_MAX_CLAIMS_PER_MATERIAL]:
+                claim_id = claim[0]
+                ctype = claim[2] or ""
+                text = claim[3] or ""
+                evidence = claim[6] or ""
+                support = claim[7] or ""
+                lines = [f"- Claim ID: {claim_id}"]
+                if ctype:
+                    lines.append(f"  Type: {ctype}")
+                if text:
+                    lines.append(f"  Text: {text[:200]}")
+                if evidence:
+                    lines.append(f"  Evidence: {evidence[:150]}")
+                if support:
+                    lines.append(f"  Support: {support}")
+                sections.append("\n".join(lines))
+
+        # ---- 補助入力: 原文抜粋 ----
         material_chunks = [r for r in chunk_rows if r[0] == mid]
         if material_chunks:
-            sections.append("**教材テキスト（抜粋）:**")
+            sections.append("#### 原文抜粋")
             char_budget = _MAX_CHUNK_CHARS_PER_MATERIAL
             for chunk in material_chunks:
                 if char_budget <= 0:
                     sections.append("... (以降省略)")
                     break
                 idx = chunk[1]
-                chapter = chunk[2] or ""
-                section_ = chunk[3] or ""
-                text = chunk[4] or ""
-                header = f"[チャンク {idx}]"
-                if chapter:
-                    header += f" {chapter}"
-                if section_:
-                    header += f" / {section_}"
+                section_id = chunk[2] or ""
+                text = chunk[3] or ""
+                page_start = chunk[4]
+                page_end = chunk[5]
+                header = f"[Chunk {idx}"
+                if section_id:
+                    header += f" / section {section_id}"
+                if page_start is not None:
+                    page_info = f"page {page_start}"
+                    if page_end is not None and page_end != page_start:
+                        page_info += f"-{page_end}"
+                    header += f" / {page_info}"
+                header += "]"
                 snippet = text[:char_budget]
                 if len(text) > char_budget:
                     snippet += "..."
                 sections.append(f"{header}\n{snippet}")
                 char_budget -= len(snippet)
+
+        # ---- 補助入力: 文書構造 (document_structure) ----
+        if analysis_run:
+            stage_outputs = analysis_run[2] if isinstance(analysis_run[2], dict) else {}
+            doc_structure = (stage_outputs.get("_artifacts") or {}).get("document_structure")
+            if doc_structure and isinstance(doc_structure, dict):
+                struct_sections = doc_structure.get("sections") or doc_structure.get("blocks") or []
+                if struct_sections:
+                    sections.append("#### 文書構造（セクション一覧）")
+                    for sec in struct_sections[:20]:
+                        if not isinstance(sec, dict):
+                            continue
+                        sec_title = sec.get("title") or sec.get("heading") or sec.get("label") or ""
+                        if sec_title:
+                            sections.append(f"- {sec_title}")
+
+        # ---- fallback: 旧 knowledge_graph (Agent未実行の場合のみ) ----
+        if not has_agent_data:
+            logger.warning(
+                "Course builder falling back to legacy documents.knowledge_graph "
+                "because no agent components were found for material %s",
+                mid,
+            )
+            if kg.get("summary"):
+                sections.append(f"**概要 (legacy):** {kg['summary']}")
+            if kg.get("domain"):
+                sections.append(f"**分野:** {kg['domain']}")
+            concepts = kg.get("concepts", [])
+            if concepts:
+                concept_lines = []
+                for c in concepts:
+                    name = c.get("name", "") if isinstance(c, dict) else str(c)
+                    desc = c.get("description", "") if isinstance(c, dict) else ""
+                    ctype = c.get("type", "") if isinstance(c, dict) else ""
+                    line = f"- {name}"
+                    if ctype:
+                        line += f" ({ctype})"
+                    if desc:
+                        line += f": {desc}"
+                    concept_lines.append(line)
+                sections.append("**主要概念 (legacy):**\n" + "\n".join(concept_lines))
 
         sections.append("")  # blank line separator
 

--- a/backend/tests/fixtures/neutralino_seed.json
+++ b/backend/tests/fixtures/neutralino_seed.json
@@ -2,6 +2,7 @@
   "documents": [
     {
       "material_id": "mat-neutralino-001",
+      "doc_uuid": "a1b2c3d4-0000-0000-0000-000000000001",
       "title": "Unitarity and Higher-Order Corrections in Neutralino Dark Matter Annihilation into Two Photons",
       "filename": "0212022v2.pdf",
       "status": "completed",
@@ -22,6 +23,210 @@
           {"name": "Radiative Correction", "type": "TECHNIQUE", "description": "Higher-order perturbative corrections arising from virtual particle loops in quantum field theory."},
           {"name": "Gamma-Ray Line", "type": "OBSERVABLE", "description": "A monochromatic photon signal at E_gamma = m_chi, a distinctive spectral feature for indirect dark matter detection."}
         ]
+      }
+    }
+  ],
+  "theory_components": [
+    {
+      "id": "comp-uuid-0001",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "name": "Neutralino Dark Matter Candidate",
+      "component_type": "concept",
+      "component_type_text": "fundamental particle concept",
+      "summary": "The lightest neutralino chi^0_1 as a stable, electrically neutral Majorana fermion forming the leading dark matter candidate in the MSSM under R-parity conservation.",
+      "inputs": ["MSSM parameter space", "R-parity conservation"],
+      "outputs": ["stable dark matter particle"],
+      "preconditions": ["MSSM framework", "R-parity conservation"],
+      "cautions": ["Mass bounds from LEP/LHC constraints"],
+      "source_chunks": [],
+      "evidence_claims": ["claim-uuid-0001"],
+      "review_status": "teacher_reviewed",
+      "maturity_level": "paper_claim"
+    },
+    {
+      "id": "comp-uuid-0002",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "name": "Loop-Induced Annihilation Amplitude",
+      "component_type": "mechanism",
+      "component_type_text": "loop process mechanism",
+      "summary": "The process chi chi -> gamma gamma is loop-induced at leading order because neutralinos have no tree-level photon coupling. Contributions arise from chargino loops, sfermion loops, and mixed diagrams.",
+      "inputs": ["neutralino pair", "MSSM loop particles"],
+      "outputs": ["two-photon amplitude M"],
+      "preconditions": ["Neutralino Dark Matter Candidate", "One-loop perturbation theory"],
+      "cautions": ["Triangle and box topologies must all be included"],
+      "source_chunks": [],
+      "evidence_claims": ["claim-uuid-0002"],
+      "review_status": "teacher_review_required",
+      "maturity_level": "paper_claim"
+    },
+    {
+      "id": "comp-uuid-0003",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "name": "Partial-Wave Unitarity Constraint",
+      "component_type": "law",
+      "component_type_text": "unitarity principle",
+      "summary": "The partial-wave unitarity condition |a_J| <= 1 must be satisfied for every partial wave. Naive one-loop calculations violate this for m_chi > 500 GeV in certain MSSM parameter regions.",
+      "inputs": ["partial-wave amplitude a_J", "neutralino mass"],
+      "outputs": ["unitarity bound check"],
+      "preconditions": ["Loop-Induced Annihilation Amplitude"],
+      "cautions": ["Violation signals missing higher-order contributions"],
+      "source_chunks": [],
+      "evidence_claims": ["claim-uuid-0003"],
+      "review_status": "teacher_review_required",
+      "maturity_level": "paper_claim"
+    },
+    {
+      "id": "comp-uuid-0004",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "name": "Box Diagram Unitarity Restoration",
+      "component_type": "mechanism",
+      "component_type_text": "higher-order correction mechanism",
+      "summary": "Including the complete set of box diagrams (gamma-gamma, Z-gamma, W-W topologies) restores partial-wave unitarity and reduces the cross section by 15-30% for m_chi ~ 200-800 GeV.",
+      "inputs": ["box diagram topologies", "chargino-sfermion exchange"],
+      "outputs": ["unitarity-restored cross section"],
+      "preconditions": ["Partial-Wave Unitarity Constraint"],
+      "cautions": ["All three box topologies must be included simultaneously"],
+      "source_chunks": [],
+      "evidence_claims": ["claim-uuid-0004"],
+      "review_status": "teacher_review_required",
+      "maturity_level": "paper_claim"
+    },
+    {
+      "id": "comp-uuid-0005",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "name": "Corrected Annihilation Cross Section",
+      "component_type": "observation",
+      "component_type_text": "phenomenological result",
+      "summary": "The unitarity-restored sigma(chi chi -> gamma gamma) is ~25% smaller than uncorrected one-loop value for a 200 GeV wino-like neutralino, directly impacting Fermi-LAT, MAGIC, and CTA predictions.",
+      "inputs": ["Box Diagram Unitarity Restoration", "MSSM parameters"],
+      "outputs": ["corrected sigma v ~ 2.3e-28 cm^3/s", "gamma-ray line prediction"],
+      "preconditions": ["Box Diagram Unitarity Restoration"],
+      "cautions": ["Correction comparable to astrophysical density profile uncertainties"],
+      "source_chunks": [],
+      "evidence_claims": ["claim-uuid-0005"],
+      "review_status": "teacher_review_required",
+      "maturity_level": "paper_claim"
+    }
+  ],
+  "theory_component_graphs": [
+    {
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "graph_json": {
+        "nodes": [
+          {"id": "comp-uuid-0001", "label": "Neutralino Dark Matter Candidate"},
+          {"id": "comp-uuid-0002", "label": "Loop-Induced Annihilation Amplitude"},
+          {"id": "comp-uuid-0003", "label": "Partial-Wave Unitarity Constraint"},
+          {"id": "comp-uuid-0004", "label": "Box Diagram Unitarity Restoration"},
+          {"id": "comp-uuid-0005", "label": "Corrected Annihilation Cross Section"}
+        ],
+        "edges": [
+          {
+            "source": "comp-uuid-0001",
+            "target": "comp-uuid-0002",
+            "type": "requires",
+            "reason": "Loop amplitude requires neutralino as initial state particle"
+          },
+          {
+            "source": "comp-uuid-0002",
+            "target": "comp-uuid-0003",
+            "type": "output_to_input",
+            "reason": "Amplitude feeds into partial-wave unitarity analysis"
+          },
+          {
+            "source": "comp-uuid-0003",
+            "target": "comp-uuid-0004",
+            "type": "output_to_input",
+            "reason": "Unitarity violation motivates box diagram inclusion"
+          },
+          {
+            "source": "comp-uuid-0004",
+            "target": "comp-uuid-0005",
+            "type": "output_to_input",
+            "reason": "Box diagrams produce the corrected cross section"
+          }
+        ],
+        "dsl": "(comp-uuid-0001:concept) ==[requires]==> (comp-uuid-0002:mechanism) ==[output_to_input]==> (comp-uuid-0003:law)"
+      }
+    }
+  ],
+  "theory_claims": [
+    {
+      "id": "claim-uuid-0001",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "claim_type": "definition",
+      "text": "The lightest neutralino chi^0_1 is a Majorana fermion and the leading MSSM dark matter candidate, stable under R-parity conservation.",
+      "normalized_text": "neutralino chi^0_1 is Majorana fermion, stable dark matter candidate under R-parity",
+      "source_scope": {"section": "1.1 Motivation"},
+      "evidence_text": "In the MSSM, the lightest neutralino chi^0_1 is a leading dark matter candidate, being stable (under R-parity conservation), electrically neutral, and weakly interacting.",
+      "support_status": "source_backed",
+      "review_status": "teacher_reviewed"
+    },
+    {
+      "id": "claim-uuid-0002",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "claim_type": "relation",
+      "text": "chi chi -> gamma gamma is loop-induced because neutralinos have no tree-level photon coupling.",
+      "normalized_text": "neutralino annihilation to photons is loop-induced at leading order",
+      "source_scope": {"section": "2.1 One-Loop Amplitudes"},
+      "evidence_text": "Since neutralinos are Majorana fermions with no tree-level coupling to photons, the process chi chi -> gamma gamma is loop-induced at leading order.",
+      "support_status": "source_backed",
+      "review_status": "teacher_review_required"
+    },
+    {
+      "id": "claim-uuid-0003",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "claim_type": "result",
+      "text": "Naive one-loop calculation violates partial-wave unitarity for m_chi > 500 GeV in certain MSSM parameter regions.",
+      "normalized_text": "one-loop unitarity violation above 500 GeV neutralino mass",
+      "source_scope": {"section": "2.2 Partial-Wave Decomposition"},
+      "evidence_text": "We find that the naive one-loop calculation violates this bound for neutralino masses m_chi > 500 GeV in certain MSSM parameter regions, particularly when mu is small and tan(beta) is large.",
+      "support_status": "source_backed",
+      "review_status": "teacher_review_required"
+    },
+    {
+      "id": "claim-uuid-0004",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "claim_type": "result",
+      "text": "Box diagrams reduce the cross section by 15-30% relative to naive one-loop for m_chi ~ 200-800 GeV.",
+      "normalized_text": "box diagram contribution reduces cross section 15-30 percent",
+      "source_scope": {"section": "3.1 Box Diagram Contributions"},
+      "evidence_text": "Numerically, the box diagrams reduce the total cross section by 15-30% relative to the naive one-loop result for m_chi ~ 200-800 GeV, depending on the MSSM parameters.",
+      "support_status": "source_backed",
+      "review_status": "teacher_review_required"
+    },
+    {
+      "id": "claim-uuid-0005",
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "claim_type": "result",
+      "text": "Corrected sigma v ~ 2.3e-28 cm^3/s for 200 GeV wino-like neutralino, ~25% smaller than uncorrected one-loop value.",
+      "normalized_text": "corrected annihilation cross section 25 percent smaller than one-loop prediction",
+      "source_scope": {"section": "4.1 Phenomenological Implications"},
+      "evidence_text": "For a 200 GeV neutralino with wino-like composition, the corrected cross section is sigma v ~ 2.3 x 10^{-28} cm^3/s, approximately 25% smaller than the uncorrected one-loop value.",
+      "support_status": "source_backed",
+      "review_status": "teacher_review_required"
+    }
+  ],
+  "analysis_runs": [
+    {
+      "document_id": "a1b2c3d4-0000-0000-0000-000000000001",
+      "material_id": "mat-neutralino-001",
+      "status": "completed",
+      "stage_outputs": {
+        "_artifacts": {
+          "document_structure": {
+            "sections": [
+              {"title": "1. Introduction"},
+              {"title": "1.1 Motivation"},
+              {"title": "2. Framework"},
+              {"title": "2.1 One-Loop Amplitudes"},
+              {"title": "2.2 Partial-Wave Decomposition"},
+              {"title": "3. Higher-Order Corrections"},
+              {"title": "3.1 Box Diagram Contributions"},
+              {"title": "4. Results and Discussion"},
+              {"title": "4.1 Phenomenological Implications"}
+            ]
+          }
+        }
       }
     }
   ],

--- a/backend/tests/test_course_builder_context.py
+++ b/backend/tests/test_course_builder_context.py
@@ -1,8 +1,8 @@
-"""Issue #113: ソース文献準拠のコース生成 — コンテキスト注入・プロンプトのテスト。
+"""Issue #230: コース構築コンテキストをAgent生成済み理論コンポーネント中心に置き換える。
 
-コースビルダーにおいて、選択された教材のナレッジグラフとチャンクテキストが
-LLMプロンプトに正しく注入されること、およびシステムプロンプトがソース準拠と
-段階的構造化を要求していることを検証する。
+_build_material_context() が theory_components / theory_component_graphs / theory_claims を
+主入力として使用し、documents.knowledge_graph はAgent未実行の場合のfallbackに限定されること、
+および _COURSE_BUILDER_SYSTEM_PROMPT が理論コンポーネント中心の方針に更新されていることを検証する。
 """
 
 from __future__ import annotations
@@ -22,11 +22,21 @@ if _backend_dir not in sys.path:
 if _api_dir not in sys.path:
     sys.path.insert(0, _api_dir)
 
+# Python 3.11+ では pkgutil.resolve_name が routes パッケージ属性の
+# 遅延解決をサポートしないため、patch() 前に明示的にロードしておく
+import importlib as _importlib
+try:
+    import routes.admin as _routes_admin_mod  # noqa: F401
+except Exception:
+    pass
+
 # Load test fixture data
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
 NEUTRALINO_SEED = json.loads(
     (FIXTURE_DIR / "neutralino_seed.json").read_text(encoding="utf-8")
 )
+
+DOC_UUID = NEUTRALINO_SEED["documents"][0]["doc_uuid"]
 
 
 # ---------------------------------------------------------------------------
@@ -34,30 +44,109 @@ NEUTRALINO_SEED = json.loads(
 # ---------------------------------------------------------------------------
 
 def _make_doc_rows(seed=NEUTRALINO_SEED):
-    """fixtures の documents を DB 行形式 (source_path, title, filename, knowledge_graph) に変換。"""
+    """documents を DB 行形式 (source_path, title, filename, doc_uuid, status, knowledge_graph) に変換。"""
     rows = []
     for doc in seed["documents"]:
         rows.append((
             doc["material_id"],
             doc["title"],
             doc["filename"],
+            doc["doc_uuid"],
+            doc["status"],
             doc["knowledge_graph"],
         ))
     return rows
 
 
+def _make_component_rows(seed=NEUTRALINO_SEED):
+    """theory_components を DB 行形式に変換。
+    (id, document_id, name, component_type, component_type_text,
+     summary, inputs, outputs, preconditions, cautions,
+     source_chunks, evidence_claims, review_status, maturity_level)
+    """
+    rows = []
+    for c in seed["theory_components"]:
+        rows.append((
+            c["id"],
+            c["document_id"],
+            c["name"],
+            c["component_type"],
+            c["component_type_text"],
+            c["summary"],
+            c["inputs"],
+            c["outputs"],
+            c["preconditions"],
+            c["cautions"],
+            c["source_chunks"],
+            c["evidence_claims"],
+            c["review_status"],
+            c["maturity_level"],
+        ))
+    return rows
+
+
+def _make_graph_rows(seed=NEUTRALINO_SEED):
+    """theory_component_graphs を DB 行形式 (document_id, graph_json) に変換。"""
+    return [
+        (g["document_id"], g["graph_json"])
+        for g in seed["theory_component_graphs"]
+    ]
+
+
+def _make_claim_rows(seed=NEUTRALINO_SEED):
+    """theory_claims を DB 行形式に変換。
+    (id, document_id, claim_type, text, normalized_text,
+     source_scope, evidence_text, support_status, review_status)
+    """
+    rows = []
+    for cl in seed["theory_claims"]:
+        rows.append((
+            cl["id"],
+            cl["document_id"],
+            cl["claim_type"],
+            cl["text"],
+            cl["normalized_text"],
+            cl["source_scope"],
+            cl["evidence_text"],
+            cl["support_status"],
+            cl["review_status"],
+        ))
+    return rows
+
+
 def _make_chunk_rows(seed=NEUTRALINO_SEED):
-    """fixtures の chunks を DB 行形式 (material_id, chunk_index, chapter, section, text) に変換。"""
+    """chunks を DB 行形式 (material_id, chunk_index, section_id, text, page_start, page_end) に変換。"""
     rows = []
     for ch in seed["chunks"]:
         rows.append((
             ch["material_id"],
             ch["chunk_index"],
-            ch.get("chapter", ""),
-            ch.get("section", ""),
+            ch.get("section", ch.get("section_id", "")),
             ch["text"],
+            None,  # page_start
+            None,  # page_end
         ))
     return rows
+
+
+def _make_analysis_rows(seed=NEUTRALINO_SEED):
+    """analysis_runs を DB 行形式 (document_id, status, stage_outputs) に変換。"""
+    return [
+        (r["document_id"], r["status"], r["stage_outputs"])
+        for r in seed["analysis_runs"]
+    ]
+
+
+def _full_side_effect(seed=NEUTRALINO_SEED):
+    """_build_material_context の全6クエリに対応する side_effect リストを返す。"""
+    return [
+        _make_doc_rows(seed),
+        _make_component_rows(seed),
+        _make_graph_rows(seed),
+        _make_claim_rows(seed),
+        _make_chunk_rows(seed),
+        _make_analysis_rows(seed),
+    ]
 
 
 # ===========================================================================
@@ -81,7 +170,6 @@ class TestBuildMaterialContext:
         """DB にマッチするドキュメントがない場合 None を返すこと。"""
         func = self._import_func()
         mock_session = MagicMock()
-        # First call: doc query returns empty
         mock_session.execute.return_value.fetchall.return_value = []
         mock_pg.return_value = mock_session
 
@@ -89,129 +177,280 @@ class TestBuildMaterialContext:
         assert result is None
 
     @patch("routes.admin._pg_session")
-    def test_includes_knowledge_graph_summary(self, mock_pg):
-        """ナレッジグラフの概要がコンテキストに含まれること。"""
+    def test_includes_theory_components(self, mock_pg):
+        """theory_components の名前・summaryがコンテキストに含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
         mock_pg.return_value = mock_session
 
         ctx = func(["mat-neutralino-001"])
         assert ctx is not None
-        assert "unitarity" in ctx.lower() or "Unitarity" in ctx
-        assert "neutralino" in ctx.lower() or "Neutralino" in ctx
+        assert "Neutralino Dark Matter Candidate" in ctx
+        assert "Loop-Induced Annihilation Amplitude" in ctx
+        assert "Partial-Wave Unitarity Constraint" in ctx
 
     @patch("routes.admin._pg_session")
-    def test_includes_knowledge_graph_concepts(self, mock_pg):
-        """ナレッジグラフの主要概念がコンテキストに含まれること。"""
+    def test_includes_component_dependencies(self, mock_pg):
+        """theory_component_graphs の依存エッジがコンテキストに含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
         mock_pg.return_value = mock_session
 
         ctx = func(["mat-neutralino-001"])
         assert ctx is not None
-        # Check that key domain concepts appear
-        assert "Neutralino" in ctx
-        assert "Dark Matter" in ctx
-        assert "Annihilation Cross Section" in ctx
-        assert "MSSM" in ctx
+        assert "comp-uuid-0001" in ctx
+        assert "comp-uuid-0002" in ctx
+        assert "->" in ctx or "→" in ctx
 
     @patch("routes.admin._pg_session")
-    def test_includes_chunk_text(self, mock_pg):
-        """チャンクテキストがコンテキストに含まれること。"""
+    def test_includes_theory_claims(self, mock_pg):
+        """theory_claims のテキストがコンテキストに含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
         mock_pg.return_value = mock_session
 
         ctx = func(["mat-neutralino-001"])
         assert ctx is not None
-        # Introduction text should be present
+        assert "claim-uuid-0001" in ctx
+        assert "Majorana fermion" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_includes_chunk_excerpts(self, mock_pg):
+        """chunks の原文抜粋がコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
         assert "dark matter" in ctx.lower()
-        assert "monochromatic gamma-ray" in ctx.lower() or "gamma-ray" in ctx.lower()
 
     @patch("routes.admin._pg_session")
-    def test_includes_chunk_headers(self, mock_pg):
-        """チャンクのチャプター・セクション情報がヘッダとして含まれること。"""
-        func = self._import_func()
-        mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
-        mock_pg.return_value = mock_session
-
-        ctx = func(["mat-neutralino-001"])
-        assert ctx is not None
-        assert "Introduction" in ctx
-        assert "Framework" in ctx or "One-Loop Amplitudes" in ctx
-
-    @patch("routes.admin._pg_session")
-    def test_includes_domain_field(self, mock_pg):
-        """ナレッジグラフの分野 (domain) がコンテキストに含まれること。"""
-        func = self._import_func()
-        mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
-        mock_pg.return_value = mock_session
-
-        ctx = func(["mat-neutralino-001"])
-        assert ctx is not None
-        assert "Particle Physics" in ctx
-
-    @patch("routes.admin._pg_session")
-    def test_chunk_text_is_truncated_within_budget(self, mock_pg):
+    def test_chunk_text_truncated_within_budget(self, mock_pg):
         """チャンクテキストが _MAX_CHUNK_CHARS_PER_MATERIAL 以内に収まること。"""
         func = self._import_func()
         from routes.admin import _MAX_CHUNK_CHARS_PER_MATERIAL
 
         mock_session = MagicMock()
-        # Create a document with very long chunks
-        doc_rows = [("mat-long", "Long Doc", "long.pdf", {"summary": "test"})]
+        doc_rows = [("mat-long", "Long Doc", "long.pdf", "uuid-long-001", "completed", {})]
         long_text = "A" * 10000
         chunk_rows = [
-            ("mat-long", 0, "Ch1", "S1", long_text),
-            ("mat-long", 1, "Ch2", "S2", long_text),
+            ("mat-long", 0, "", long_text, None, None),
+            ("mat-long", 1, "", long_text, None, None),
         ]
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows,   # doc query
+            [],         # components (empty → fallback)
+            [],         # graphs
+            [],         # claims
+            chunk_rows, # chunks
+            [],         # analysis runs
+        ]
         mock_pg.return_value = mock_session
 
         ctx = func(["mat-long"])
         assert ctx is not None
-        # The total chunk text should not exceed budget significantly
-        # (headers add some overhead but the bulk text is within budget)
         chunk_text_portions = [line for line in ctx.split("\n") if line.startswith("AAA")]
         total_a_chars = sum(line.count("A") for line in chunk_text_portions)
-        assert total_a_chars <= _MAX_CHUNK_CHARS_PER_MATERIAL + 100  # small header overhead
+        assert total_a_chars <= _MAX_CHUNK_CHARS_PER_MATERIAL + 100
 
     @patch("routes.admin._pg_session")
-    def test_context_section_header(self, mock_pg):
-        """コンテキストに「教材の内容詳細」セクションヘッダが含まれること。"""
+    def test_fallback_to_knowledge_graph_when_no_agent_data(self, mock_pg):
+        """theory_components が存在しない場合、旧 knowledge_graph にfallbackすること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        doc_rows = [("mat-legacy", "Legacy Doc", "legacy.pdf", "uuid-legacy-001", "completed", {
+            "domain": "Particle Physics / Dark Matter",
+            "summary": "Legacy knowledge graph summary about neutralino annihilation",
+            "concepts": [
+                {"name": "Neutralino", "type": "PARTICLE", "description": "DM candidate"},
+                {"name": "Dark Matter", "type": "PHENOMENON", "description": "Non-luminous matter"},
+            ],
+        })]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows,  # doc query
+            [],        # no components → fallback
+            [],        # no graphs
+            [],        # no claims
+            [],        # no chunks
+            [],        # no analysis runs
+        ]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-legacy"])
+        assert ctx is not None
+        assert "legacy" in ctx.lower() or "Neutralino" in ctx
+        assert "Particle Physics" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_no_fallback_when_agent_data_exists(self, mock_pg):
+        """theory_components が存在する場合、旧 knowledge_graph の概念一覧が主コンテキストに出ないこと。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
         mock_pg.return_value = mock_session
 
         ctx = func(["mat-neutralino-001"])
         assert ctx is not None
-        assert "教材の内容詳細" in ctx
+        # Agent component data should dominate
+        assert "理論コンポーネント" in ctx
+        # Legacy knowledge_graph concepts section should NOT appear as primary content
+        assert "**主要概念 (legacy):**" not in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_context_section_header(self, mock_pg):
+        """コンテキストに「Agent解析済み教材コンテキスト」ヘッダが含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "Agent解析済み教材コンテキスト" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_warning_when_pipeline_incomplete(self, mock_pg):
+        """Agentパイプライン未完了の場合、警告メッセージがコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        doc_rows = [("mat-pending", "Pending Doc", "pending.pdf", "uuid-pending-001", "processing", {})]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows,
+            [],  # no components
+            [],  # no graphs
+            [],  # no claims
+            [],  # no chunks
+            [("uuid-pending-001", "running", {})],  # analysis running
+        ]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-pending"])
+        assert ctx is not None
+        assert "警告" in ctx or "未完了" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_document_structure_included(self, mock_pg):
+        """document_structure のセクション一覧がコンテキストに含まれること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "文書構造" in ctx
+        assert "Introduction" in ctx or "Framework" in ctx
+
+    @patch("routes.admin._pg_session")
+    def test_material_title_header(self, mock_pg):
+        """各教材のタイトルが ### ヘッダとして出力されること。"""
+        func = self._import_func()
+        mock_session = MagicMock()
+        mock_session.execute.return_value.fetchall.side_effect = _full_side_effect()
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-neutralino-001"])
+        assert ctx is not None
+        assert "### 教材:" in ctx
 
 
 # ===========================================================================
-# 2. システムプロンプトのテスト
+# 2. サイズ制限テスト
+# ===========================================================================
+
+class TestMaterialContextSizeLimits:
+    """_build_material_context のサイズ制限を検証。"""
+
+    def _import_func(self):
+        from routes.admin import _build_material_context
+        return _build_material_context
+
+    @patch("routes.admin._pg_session")
+    def test_components_capped_at_max(self, mock_pg):
+        """コンポーネント数が _MAX_COMPONENTS_PER_MATERIAL を超えないこと。"""
+        from routes.admin import _MAX_COMPONENTS_PER_MATERIAL
+        func = self._import_func()
+        mock_session = MagicMock()
+
+        doc_uuid = "uuid-many-001"
+        doc_rows = [("mat-many", "Many Doc", "many.pdf", doc_uuid, "completed", {})]
+        many_components = [
+            (f"comp-{i:04d}", doc_uuid, f"Component {i}", "theory", "", f"Summary {i}",
+             [], [], [], [], [], [], "teacher_review_required", "paper_claim")
+            for i in range(60)
+        ]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, many_components, [], [], [], [],
+        ]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-many"])
+        assert ctx is not None
+        # Only up to _MAX_COMPONENTS_PER_MATERIAL components should appear
+        component_count = ctx.count("Component ID:")
+        assert component_count <= _MAX_COMPONENTS_PER_MATERIAL
+
+    @patch("routes.admin._pg_session")
+    def test_claims_capped_at_max(self, mock_pg):
+        """Claim数が _MAX_CLAIMS_PER_MATERIAL を超えないこと。"""
+        from routes.admin import _MAX_CLAIMS_PER_MATERIAL
+        func = self._import_func()
+        mock_session = MagicMock()
+
+        doc_uuid = "uuid-claims-001"
+        doc_rows = [("mat-claims", "Claims Doc", "claims.pdf", doc_uuid, "completed", {})]
+        many_claims = [
+            (f"claim-{i:04d}", doc_uuid, "result", f"Claim text {i}", f"Normalized {i}",
+             {}, f"Evidence {i}", "source_backed", "teacher_review_required")
+            for i in range(100)
+        ]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, [], [], many_claims, [], [],
+        ]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-claims"])
+        assert ctx is not None
+        claim_count = ctx.count("Claim ID:")
+        assert claim_count <= _MAX_CLAIMS_PER_MATERIAL
+
+    @patch("routes.admin._pg_session")
+    def test_graph_edges_capped_at_max(self, mock_pg):
+        """グラフエッジ数が _MAX_GRAPH_EDGES_PER_MATERIAL を超えないこと。"""
+        from routes.admin import _MAX_GRAPH_EDGES_PER_MATERIAL
+        func = self._import_func()
+        mock_session = MagicMock()
+
+        doc_uuid = "uuid-graph-001"
+        doc_rows = [("mat-graph", "Graph Doc", "graph.pdf", doc_uuid, "completed", {})]
+        many_edges = [
+            {"source": f"comp-{i}", "target": f"comp-{i+1}", "type": "requires"}
+            for i in range(100)
+        ]
+        graph_rows = [(doc_uuid, {"nodes": [], "edges": many_edges})]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, [], graph_rows, [], [], [],
+        ]
+        mock_pg.return_value = mock_session
+
+        ctx = func(["mat-graph"])
+        assert ctx is not None
+        edge_count = ctx.count("comp-")
+        # Each edge line contains 2 comp- references (source + target)
+        assert edge_count <= _MAX_GRAPH_EDGES_PER_MATERIAL * 2 + 10  # allow small overhead
+
+
+# ===========================================================================
+# 3. システムプロンプトのテスト
 # ===========================================================================
 
 class TestCourseBuilderSystemPrompt:
-    """_COURSE_BUILDER_SYSTEM_PROMPT がソース準拠・段階的構造化を要求していることを検証。"""
+    """_COURSE_BUILDER_SYSTEM_PROMPT が理論コンポーネント中心の方針を要求していることを検証。"""
 
     def _get_prompt(self):
         from routes.admin import _COURSE_BUILDER_SYSTEM_PROMPT
@@ -226,24 +465,33 @@ class TestCourseBuilderSystemPrompt:
     def test_prompt_prohibits_hallucination(self):
         """教材にないトピックの追加を明示的に禁止していること。"""
         prompt = self._get_prompt()
-        # Check for anti-hallucination instruction
         assert "一般的だから" in prompt
+
+    def test_prompt_mentions_theory_components_as_primary(self):
+        """プロンプトが theory_components をコース章・トピック候補の主入力として言及していること。"""
+        prompt = self._get_prompt()
+        assert "theory_components" in prompt
+
+    def test_prompt_mentions_dependency_graph(self):
+        """プロンプトが theory_component_graphs の依存関係を学習順序の主判断として言及していること。"""
+        prompt = self._get_prompt()
+        assert "theory_component_graphs" in prompt
+        assert "依存関係" in prompt
+
+    def test_prompt_mentions_claims_for_evidence(self):
+        """プロンプトが theory_claims を根拠確認用として言及していること。"""
+        prompt = self._get_prompt()
+        assert "theory_claims" in prompt
+
+    def test_prompt_treats_knowledge_graph_as_fallback(self):
+        """プロンプトが documents.knowledge_graph をfallbackとして位置づけていること。"""
+        prompt = self._get_prompt()
+        assert "fallback" in prompt or "旧教材" in prompt or "Agentパイプライン未実行" in prompt
 
     def test_prompt_requires_stepwise_structure(self):
         """段階的構造化（依存関係に基づくシラバス）を要求していること。"""
         prompt = self._get_prompt()
         assert "段階的" in prompt or "依存関係" in prompt
-        assert "chunk_index" in prompt or "チャンクの並び" in prompt
-
-    def test_prompt_mentions_knowledge_graph(self):
-        """プロンプトがナレッジグラフの活用に言及していること。"""
-        prompt = self._get_prompt()
-        assert "ナレッジグラフ" in prompt
-
-    def test_prompt_mentions_chunks(self):
-        """プロンプトがチャンクの活用に言及していること。"""
-        prompt = self._get_prompt()
-        assert "チャンク" in prompt
 
     def test_prompt_requires_prerequisites_ordering(self):
         """前提知識の順序付けルールが含まれていること。"""
@@ -263,15 +511,20 @@ class TestCourseBuilderSystemPrompt:
         assert '"chapters"' in prompt
         assert '"topics"' in prompt
 
+    def test_prompt_chunks_as_supplementary(self):
+        """プロンプトが chunks を補助情報として位置づけていること。"""
+        prompt = self._get_prompt()
+        assert "チャンク" in prompt or "chunks" in prompt
+
 
 # ===========================================================================
-# 3. course_builder_chat エンドポイントの結合テスト
+# 4. course_builder_chat エンドポイントの結合テスト
 # ===========================================================================
 
 _HAS_FASTAPI = True
 try:
     from fastapi.testclient import TestClient
-except ImportError:
+except (ImportError, RuntimeError):
     _HAS_FASTAPI = False
 
 _skip_no_fastapi = pytest.mark.skipif(
@@ -317,9 +570,9 @@ class TestCourseBuilderChatContextInjection:
     ):
         """_build_material_context の結果がメッセージに注入されること。"""
         mock_build_ctx.return_value = (
-            "## 教材の内容詳細\n### 教材: Neutralino Paper\n"
-            "**概要:** Unitarity constraints on neutralino annihilation\n"
-            "**主要概念:**\n- Neutralino\n- Dark Matter\n"
+            "## Agent解析済み教材コンテキスト\n### 教材: Neutralino Paper\n"
+            "#### 理論コンポーネント\n- Component ID: comp-uuid-0001\n"
+            "  Name: Neutralino Dark Matter Candidate\n"
         )
         mock_gen.return_value = "テスト応答"
 
@@ -333,12 +586,11 @@ class TestCourseBuilderChatContextInjection:
         )
         assert resp.status_code == 200
 
-        # generate_text に渡されたメッセージを検証
         call_args = mock_gen.call_args
         messages = call_args[1].get("messages") or call_args[0][0]
         all_content = " ".join(m["content"] for m in messages)
-        assert "教材の内容詳細" in all_content
-        assert "Neutralino" in all_content
+        assert "Agent解析済み教材コンテキスト" in all_content
+        assert "Neutralino Dark Matter Candidate" in all_content
 
     @patch("routes.admin.save_cb_session")
     @patch("routes.admin.generate_text")
@@ -358,7 +610,6 @@ class TestCourseBuilderChatContextInjection:
             headers=auth_headers,
         )
         assert resp.status_code == 200
-        # _build_material_context は呼ばれない
         mock_build_ctx.assert_not_called()
 
     @patch("routes.admin.save_cb_session")
@@ -368,7 +619,7 @@ class TestCourseBuilderChatContextInjection:
         self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
     ):
         """最初のメッセージがシステムプロンプトであること。"""
-        mock_build_ctx.return_value = "## 教材の内容詳細\nテスト"
+        mock_build_ctx.return_value = "## Agent解析済み教材コンテキスト\nテスト"
         mock_gen.return_value = "テスト応答"
 
         resp = client.post(
@@ -393,7 +644,7 @@ class TestCourseBuilderChatContextInjection:
         self, mock_build_ctx, mock_gen, mock_save, client, auth_headers,
     ):
         """教材コンテキストがユーザーの質問メッセージより前に配置されること。"""
-        mock_build_ctx.return_value = "## 教材の内容詳細\nNeutralino論文"
+        mock_build_ctx.return_value = "## Agent解析済み教材コンテキスト\nNeutralino論文"
         mock_gen.return_value = "テスト応答"
 
         resp = client.post(
@@ -409,11 +660,10 @@ class TestCourseBuilderChatContextInjection:
         call_args = mock_gen.call_args
         messages = call_args[1].get("messages") or call_args[0][0]
 
-        # Find context message and user message positions
         ctx_idx = None
         user_msg_idx = None
         for i, m in enumerate(messages):
-            if "教材の内容詳細" in m.get("content", ""):
+            if "Agent解析済み教材コンテキスト" in m.get("content", ""):
                 ctx_idx = i
             if m.get("content", "") == "コースを設計して":
                 user_msg_idx = i
@@ -439,10 +689,13 @@ class TestCourseBuilderChatContextInjection:
             "---COURSE_DRAFT_JSON---\n"
             + json.dumps(draft, ensure_ascii=False)
         )
-        # Mock for sources injection query
         mock_session = MagicMock()
-        mock_session.execute.return_value.fetchall.return_value = [
-            ("mat-neutralino-001", "Neutralino Paper", "0212022v2.pdf"),
+        mock_session.execute.return_value.fetchall.side_effect = [
+            # _build_material_context: 6 queries
+            _make_doc_rows(), _make_component_rows(), _make_graph_rows(),
+            _make_claim_rows(), _make_chunk_rows(), _make_analysis_rows(),
+            # sources injection query
+            [("mat-neutralino-001", "Neutralino Paper", "0212022v2.pdf")],
         ]
         mock_pg.return_value = mock_session
 
@@ -461,161 +714,159 @@ class TestCourseBuilderChatContextInjection:
 
 
 # ===========================================================================
-# 4. テストデータ（フィクスチャ）の検証
+# 5. フィクスチャデータの検証
 # ===========================================================================
 
 class TestNeutralinoSeedData:
-    """ニュートラリーノテストデータの構造とドメイン特化性を検証。"""
+    """ニュートラリーノテストデータの構造とAgent成果物の整合性を検証。"""
 
     def test_seed_has_documents(self):
-        """documents セクションが存在すること。"""
         assert "documents" in NEUTRALINO_SEED
         assert len(NEUTRALINO_SEED["documents"]) >= 1
 
+    def test_seed_has_theory_components(self):
+        """theory_components が存在すること。"""
+        assert "theory_components" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["theory_components"]) >= 3
+
+    def test_seed_has_theory_component_graphs(self):
+        """theory_component_graphs が存在すること。"""
+        assert "theory_component_graphs" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["theory_component_graphs"]) >= 1
+
+    def test_seed_has_theory_claims(self):
+        """theory_claims が存在すること。"""
+        assert "theory_claims" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["theory_claims"]) >= 3
+
+    def test_seed_has_analysis_runs(self):
+        """analysis_runs が存在すること。"""
+        assert "analysis_runs" in NEUTRALINO_SEED
+        assert len(NEUTRALINO_SEED["analysis_runs"]) >= 1
+
     def test_seed_has_chunks(self):
-        """chunks セクションが存在すること。"""
         assert "chunks" in NEUTRALINO_SEED
         assert len(NEUTRALINO_SEED["chunks"]) >= 3
 
+    def test_document_has_doc_uuid(self):
+        """documents に doc_uuid が存在すること。"""
+        doc = NEUTRALINO_SEED["documents"][0]
+        assert "doc_uuid" in doc
+        assert len(doc["doc_uuid"]) > 10
+
+    def test_theory_components_linked_to_doc_uuid(self):
+        """theory_components の document_id が documents の doc_uuid と一致すること。"""
+        doc_uuid = NEUTRALINO_SEED["documents"][0]["doc_uuid"]
+        for comp in NEUTRALINO_SEED["theory_components"]:
+            assert comp["document_id"] == doc_uuid
+
+    def test_theory_claims_linked_to_doc_uuid(self):
+        """theory_claims の document_id が documents の doc_uuid と一致すること。"""
+        doc_uuid = NEUTRALINO_SEED["documents"][0]["doc_uuid"]
+        for claim in NEUTRALINO_SEED["theory_claims"]:
+            assert claim["document_id"] == doc_uuid
+
+    def test_graph_edges_reference_component_ids(self):
+        """グラフのエッジが theory_components の id を参照していること。"""
+        comp_ids = {c["id"] for c in NEUTRALINO_SEED["theory_components"]}
+        graph = NEUTRALINO_SEED["theory_component_graphs"][0]["graph_json"]
+        for edge in graph["edges"]:
+            assert edge["source"] in comp_ids, f"Edge source {edge['source']} not in components"
+            assert edge["target"] in comp_ids, f"Edge target {edge['target']} not in components"
+
+    def test_analysis_run_is_completed(self):
+        """analysis_run の status が completed であること。"""
+        run = NEUTRALINO_SEED["analysis_runs"][0]
+        assert run["status"] == "completed"
+
     def test_document_has_knowledge_graph(self):
-        """ドキュメントにナレッジグラフが含まれること。"""
+        """旧 knowledge_graph も fallback テスト用に保持されていること。"""
         doc = NEUTRALINO_SEED["documents"][0]
         kg = doc["knowledge_graph"]
         assert "summary" in kg
         assert "concepts" in kg
         assert len(kg["concepts"]) >= 5
 
-    def test_document_domain_is_particle_physics(self):
-        """ドメインが素粒子物理学であること。"""
-        doc = NEUTRALINO_SEED["documents"][0]
-        assert "Particle Physics" in doc["knowledge_graph"]["domain"]
-
     def test_chunks_are_ordered_by_index(self):
-        """チャンクが chunk_index 順に並んでいること。"""
         indices = [c["chunk_index"] for c in NEUTRALINO_SEED["chunks"]]
         assert indices == sorted(indices)
 
-    def test_chunks_cover_multiple_sections(self):
-        """チャンクが複数のセクションをカバーしていること。"""
-        chapters = {c.get("chapter", "") for c in NEUTRALINO_SEED["chunks"]}
-        assert len(chapters) >= 3
-
-    def test_concepts_include_neutralino(self):
-        """主要概念にニュートラリーノが含まれること。"""
-        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
-        names = [c["name"] for c in concepts]
-        assert "Neutralino" in names
-
-    def test_concepts_include_dark_matter(self):
-        """主要概念にダークマターが含まれること。"""
-        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
-        names = [c["name"] for c in concepts]
-        assert "Dark Matter" in names
-
-    def test_concepts_include_unitarity(self):
-        """主要概念にユニタリティが含まれること。"""
-        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
-        names = [c["name"] for c in concepts]
-        assert "Unitarity" in names
-
-    def test_concepts_have_types(self):
-        """各概念に type フィールドがあること。"""
-        concepts = NEUTRALINO_SEED["documents"][0]["knowledge_graph"]["concepts"]
-        for c in concepts:
-            assert "type" in c, f"Concept '{c['name']}' is missing 'type'"
-
-    def test_chunks_contain_domain_specific_terms(self):
-        """チャンクテキストがドメイン固有の用語を含むこと（一般的な物理学ではなく）。"""
-        all_text = " ".join(c["text"] for c in NEUTRALINO_SEED["chunks"])
-        # These terms should appear in the fixture (domain-specific, not general physics)
-        assert "neutralino" in all_text.lower()
-        assert "MSSM" in all_text or "mssm" in all_text.lower()
-        assert "chargino" in all_text.lower()
-        assert "sfermion" in all_text.lower()
-        assert "partial-wave" in all_text.lower() or "partial wave" in all_text.lower()
-
-    def test_seed_material_id_consistency(self):
-        """documents と chunks の material_id が一致すること。"""
-        doc_ids = {d["material_id"] for d in NEUTRALINO_SEED["documents"]}
-        chunk_mids = {c["material_id"] for c in NEUTRALINO_SEED["chunks"]}
-        assert chunk_mids.issubset(doc_ids)
+    def test_theory_components_have_required_fields(self):
+        """各理論コンポーネントが必要フィールドを持つこと。"""
+        required = {"id", "document_id", "name", "summary", "review_status", "maturity_level"}
+        for comp in NEUTRALINO_SEED["theory_components"]:
+            for field in required:
+                assert field in comp, f"Component '{comp.get('name')}' missing field '{field}'"
 
 
 # ===========================================================================
-# 5. _build_material_context の出力形式検証
+# 6. fallback 動作の検証
 # ===========================================================================
 
-class TestMaterialContextFormat:
-    """_build_material_context が生成するコンテキスト文字列のフォーマット検証。"""
+class TestFallbackBehavior:
+    """旧 knowledge_graph fallback の動作を検証。"""
 
     def _import_func(self):
         from routes.admin import _build_material_context
         return _build_material_context
 
     @patch("routes.admin._pg_session")
-    def test_context_has_material_title_header(self, mock_pg):
-        """各教材のタイトルがMarkdownヘッダとして出力されること。"""
+    def test_fallback_includes_kg_summary(self, mock_pg):
+        """fallback 時に knowledge_graph の summary が含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        doc_rows = [("mat-legacy", "Legacy Doc", "legacy.pdf", "uuid-legacy-001", "completed", {
+            "domain": "Particle Physics / Dark Matter",
+            "summary": "Legacy summary about neutralino annihilation cross section",
+            "concepts": [{"name": "Neutralino", "type": "PARTICLE", "description": "DM candidate"}],
+        })]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, [], [], [], [], [],
+        ]
         mock_pg.return_value = mock_session
 
-        ctx = func(["mat-neutralino-001"])
-        assert "### 教材:" in ctx
+        ctx = func(["mat-legacy"])
+        assert ctx is not None
+        assert "Legacy summary" in ctx or "neutralino annihilation" in ctx.lower()
 
     @patch("routes.admin._pg_session")
-    def test_context_has_summary_section(self, mock_pg):
-        """概要セクションが含まれること。"""
+    def test_fallback_includes_kg_concepts(self, mock_pg):
+        """fallback 時に knowledge_graph の概念一覧が含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        doc_rows = [("mat-legacy2", "Legacy Doc2", "legacy2.pdf", "uuid-legacy-002", "completed", {
+            "domain": "Particle Physics",
+            "summary": "some summary",
+            "concepts": [
+                {"name": "Neutralino", "type": "PARTICLE", "description": "DM candidate"},
+                {"name": "MSSM", "type": "THEORY", "description": "Supersymmetric model"},
+            ],
+        })]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, [], [], [], [], [],
+        ]
         mock_pg.return_value = mock_session
 
-        ctx = func(["mat-neutralino-001"])
-        assert "**概要:**" in ctx
+        ctx = func(["mat-legacy2"])
+        assert ctx is not None
+        assert "Neutralino" in ctx
+        assert "MSSM" in ctx
 
     @patch("routes.admin._pg_session")
-    def test_context_has_concepts_section(self, mock_pg):
-        """主要概念セクションが含まれること。"""
+    def test_fallback_includes_kg_domain(self, mock_pg):
+        """fallback 時に knowledge_graph の domain が含まれること。"""
         func = self._import_func()
         mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
+        doc_rows = [("mat-legacy3", "Legacy Doc3", "legacy3.pdf", "uuid-legacy-003", "completed", {
+            "domain": "Particle Physics / Dark Matter",
+            "summary": "some summary",
+            "concepts": [],
+        })]
+        mock_session.execute.return_value.fetchall.side_effect = [
+            doc_rows, [], [], [], [], [],
+        ]
         mock_pg.return_value = mock_session
 
-        ctx = func(["mat-neutralino-001"])
-        assert "**主要概念:**" in ctx
-
-    @patch("routes.admin._pg_session")
-    def test_context_has_text_excerpt_section(self, mock_pg):
-        """教材テキスト抜粋セクションが含まれること。"""
-        func = self._import_func()
-        mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
-        mock_pg.return_value = mock_session
-
-        ctx = func(["mat-neutralino-001"])
-        assert "**教材テキスト（抜粋）:**" in ctx
-
-    @patch("routes.admin._pg_session")
-    def test_context_does_not_contain_general_physics_only(self, mock_pg):
-        """コンテキストが一般的な物理学ではなくドメイン固有の内容を含むこと。"""
-        func = self._import_func()
-        mock_session = MagicMock()
-        doc_rows = _make_doc_rows()
-        chunk_rows = _make_chunk_rows()
-        mock_session.execute.return_value.fetchall.side_effect = [doc_rows, chunk_rows]
-        mock_pg.return_value = mock_session
-
-        ctx = func(["mat-neutralino-001"])
-        # The context should contain specific particle physics terms from the fixture
-        ctx_lower = ctx.lower()
-        assert "neutralino" in ctx_lower
-        assert "annihilation" in ctx_lower or "cross section" in ctx_lower
+        ctx = func(["mat-legacy3"])
+        assert ctx is not None
+        assert "Particle Physics" in ctx


### PR DESCRIPTION
## Summary
This PR refactors the course builder material context to prioritize Agent-generated theory components, dependency graphs, and claims over the legacy knowledge graph and chunk-based approach. The system now treats `theory_components`, `theory_component_graphs`, and `theory_claims` as primary inputs, with chunks and knowledge graphs relegated to fallback/supplementary roles.

## Key Changes

### Core Functionality (`routes/admin.py`)
- **Refactored `_build_material_context()`**: Now executes 6 sequential database queries instead of 2:
  1. Documents (with doc_uuid and status)
  2. Theory components (ordered by review status and maturity level)
  3. Theory component graphs (dependency relationships)
  4. Theory claims (evidence and support information)
  5. Chunks (supplementary text excerpts)
  6. Document analysis runs (pipeline completion status)

- **Added size limits** to prevent context bloat:
  - `_MAX_COMPONENTS_PER_MATERIAL = 40`
  - `_MAX_CLAIMS_PER_MATERIAL = 80`
  - `_MAX_GRAPH_EDGES_PER_MATERIAL = 80`

- **Updated system prompt** (`_COURSE_BUILDER_SYSTEM_PROMPT`):
  - Explicitly directs course design to use `theory_components` as primary chapter/topic candidates
  - Prioritizes `theory_component_graphs` edges for learning order over PDF chunk sequence
  - Treats `chunks` as supplementary explanation material only
  - Positions `documents.knowledge_graph` as fallback for Agent-unprocessed materials
  - Adds explicit warning when Agent pipeline is incomplete

- **Context output structure**: Changed from "教材の内容詳細" to "Agent解析済み教材コンテキスト" with sections for:
  - Theory components (with name, type, summary, inputs/outputs, preconditions)
  - Component dependency relationships (edges with reasons)
  - Theory claims (with evidence and support status)
  - Chunk excerpts (as supplementary material)
  - Pipeline completion warnings when applicable

### Test Suite (`tests/test_course_builder_context.py`)
- **Expanded test fixture helpers**:
  - Added `_make_component_rows()`, `_make_graph_rows()`, `_make_claim_rows()`, `_make_analysis_rows()`
  - Created `_full_side_effect()` to provide all 6 query results for comprehensive testing

- **Refactored test cases** to verify:
  - Theory components are included in context (names, summaries)
  - Component dependency edges appear in output
  - Theory claims are present with evidence
  - Fallback to knowledge graph only when no Agent data exists
  - Pipeline completion status triggers appropriate warnings
  - Size limits are enforced for components, claims, and graph edges
  - Document structure and material titles are properly formatted

- **Updated system prompt tests** to verify:
  - `theory_components` mentioned as primary input
  - `theory_component_graphs` referenced for dependency ordering
  - `theory_claims` positioned for evidence verification
  - Knowledge graph treated as fallback
  - Chunks positioned as supplementary

### Test Fixtures (`tests/fixtures/neutralino_seed.json`)
- Added `doc_uuid` field to documents
- Added complete `theory_components` array (5 components with full metadata)
- Added `theory_component_graphs` with dependency edges and DSL representation
- Added `theory_claims` array (5 claims with evidence and support status)
- Added `analysis_runs` array for pipeline completion tracking
- Updated chunk structure to match new schema (section_id, page_start, page_end)

## Implementation Details

- **Fallback logic**: When `theory_components` exist, the legacy knowledge graph concepts section is suppressed. Knowledge graph is only used when Agent pipeline hasn't run.
- **Ordering**: Components are sorted by review status (teacher_reviewed first) then maturity level (peer_reviewed > textbook > paper_claim).
- **Claims filtering**: Claims are ordered by review status and support status to prioritize teacher-reviewed, source-backed claims.
- **Pipeline awareness**: System detects incomplete Agent pipelines via `

https://claude.ai/code/session_012Tv1GTfKf8Qtnf7Mcshh3w