### PR TITLE
Fix lecture studio source document retrieval from chunks table

### DIFF
--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -1578,19 +1578,19 @@ def get_lecture_studio_components(
     course_data = _course_data_for_studio(course_id, current_user)
     sources = course_data.get("sources", [])
     source_document_ids: list[str] = []
-    if sources:
-        mid_placeholders = ", ".join(f":mid_{i}" for i in range(len(sources)))
-        params_mid: dict = {f"mid_{i}": s.get("material_id", "") for i, s in enumerate(sources) if s.get("material_id")}
-        if params_mid:
-            session = _pg_session()
-            try:
-                doc_rows = session.execute(
-                    sa_text(f"SELECT id FROM documents WHERE material_id IN ({mid_placeholders})"),
-                    params_mid,
-                ).fetchall()
-                source_document_ids = [str(r[0]) for r in doc_rows]
-            finally:
-                session.close()
+    material_ids = [s.get("material_id", "") for s in sources if s.get("material_id")]
+    if material_ids:
+        mid_placeholders = ", ".join(f":mid_{i}" for i in range(len(material_ids)))
+        params_mid: dict = {f"mid_{i}": mid for i, mid in enumerate(material_ids)}
+        session = _pg_session()
+        try:
+            doc_rows = session.execute(
+                sa_text(f"SELECT DISTINCT document_id FROM chunks WHERE material_id IN ({mid_placeholders})"),
+                params_mid,
+            ).fetchall()
+            source_document_ids = [str(r[0]) for r in doc_rows if r[0]]
+        finally:
+            session.close()
 
     # --- theory_components ---
     session = _pg_session()


### PR DESCRIPTION
## Summary
Updated the source document ID retrieval logic in `get_lecture_studio_components` to query the `chunks` table instead of the `documents` table, and improved the filtering logic for material IDs.

## Key Changes
- Changed the database query to select from `chunks` table using `document_id` instead of querying `documents` table by `id`
- Added `DISTINCT` clause to avoid duplicate document IDs when multiple chunks reference the same document
- Refactored material ID extraction into a separate list comprehension for better clarity and to avoid nested conditionals
- Simplified the params dictionary construction by directly iterating over the extracted material IDs
- Added null check filter (`if r[0]`) when building the final source_document_ids list to handle potential null values
- Removed unnecessary nested `if params_mid` check since the outer `if material_ids` condition already ensures non-empty data

## Implementation Details
The change reflects a shift in how source documents are associated with materials - instead of a direct documents-to-materials relationship, documents are now linked through chunks, which is a more granular representation of document content.

https://claude.ai/code/session_01NgaVAGQZnAwfGz8PHovQgB