### PR TITLE
Fix document retrieval query to use chunks table

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -168,7 +168,7 @@ def _get_document_ids_for_course(session: Any, course_id: str) -> list[str]:
     placeholders = ", ".join(f":mid_{i}" for i in range(len(material_ids)))
     params = {f"mid_{i}": mid for i, mid in enumerate(material_ids)}
     doc_rows = session.execute(
-        sa_text(f"SELECT DISTINCT id::text FROM documents WHERE material_id IN ({placeholders})"),
+        sa_text(f"SELECT DISTINCT document_id::text FROM chunks WHERE material_id IN ({placeholders})"),
         params,
     ).fetchall()
     return [str(r[0]) for r in doc_rows if r[0]]


### PR DESCRIPTION
## Summary
Updated the document ID retrieval query in the export functionality to query the correct table and column for fetching documents associated with a course.

## Key Changes
- Changed the query source from `documents` table to `chunks` table
- Updated the column reference from `id` to `document_id` to match the chunks table schema
- This ensures document IDs are correctly retrieved from the chunks table where the material_id relationship exists

## Implementation Details
The `_get_document_ids_for_course` function now queries the `chunks` table instead of the `documents` table, using the `document_id` column to retrieve the associated documents for a given course's materials. This aligns the query with the actual data model where documents are referenced through chunks.

https://claude.ai/code/session_01K3mR3zF2Xxn2BscJFsqDnf