### PR TITLE
Update embedding vector dimensions from 768 to 3072

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -595,7 +595,7 @@ def _run_migrations() -> None:
                 embedding_type  TEXT NOT NULL,
                 source_version  TEXT NOT NULL DEFAULT 'v1',
                 text            TEXT NOT NULL,
-                embedding       vector(768),
+                embedding       vector(3072),
                 metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
                 created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
                 updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -641,8 +641,48 @@ def _run_migrations() -> None:
             END $$
         """))
 
+        # Migration 016: chunks.embedding / document_embeddings.embedding を 768 → 3072 次元に変更
+        # text-embedding-3-large は 3072 次元を返すが init.sql が vector(768) で作成されていたため
+        # INSERT 時に "expected 768 dimensions, not 3072" が発生していた。
+        # 既存の 768 次元 embedding は 3072 次元モデルと互換性がないため NULL にリセットする。
+        session.execute(sa_text("""
+            DO $$
+            DECLARE
+                col_type TEXT;
+            BEGIN
+                SELECT format_type(atttypid, atttypmod) INTO col_type
+                FROM pg_attribute
+                WHERE attrelid = 'chunks'::regclass
+                  AND attname = 'embedding'
+                  AND attnum > 0;
+
+                IF col_type IS NOT NULL AND col_type != 'vector(3072)' THEN
+                    DROP INDEX IF EXISTS idx_chunks_embedding;
+                    ALTER TABLE chunks ALTER COLUMN embedding TYPE vector(3072) USING NULL;
+                    CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON chunks
+                        USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+                END IF;
+            END $$
+        """))
+        session.execute(sa_text("""
+            DO $$
+            DECLARE
+                col_type TEXT;
+            BEGIN
+                SELECT format_type(atttypid, atttypmod) INTO col_type
+                FROM pg_attribute
+                WHERE attrelid = 'document_embeddings'::regclass
+                  AND attname = 'embedding'
+                  AND attnum > 0;
+
+                IF col_type IS NOT NULL AND col_type != 'vector(3072)' THEN
+                    ALTER TABLE document_embeddings ALTER COLUMN embedding TYPE vector(3072) USING NULL;
+                END IF;
+            END $$
+        """))
+
         session.commit()
-        logger.info("Migrations (002-013) applied successfully.")
+        logger.info("Migrations (002-016) applied successfully.")
 
         # Seed builtin schema types/predicates
         from core.schema_registry import seed_builtin_schema

--- a/backend/db/015_document_pipeline.sql
+++ b/backend/db/015_document_pipeline.sql
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS document_embeddings (
     embedding_type  TEXT NOT NULL,
     source_version  TEXT NOT NULL DEFAULT 'v1',
     text            TEXT NOT NULL,
-    embedding       vector(768),
+    embedding       vector(3072),
     metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),

--- a/backend/db/016_embedding_dim_3072.sql
+++ b/backend/db/016_embedding_dim_3072.sql
@@ -1,0 +1,41 @@
+-- Migration 016: chunks.embedding の次元数を 768 → 3072 に変更
+--
+-- 変更理由:
+--   LLM_EMBEDDING_MODEL=text-embedding-3-large は 3072 次元のベクトルを返すが、
+--   init.sql で定義された chunks.embedding は vector(768) のままだったため、
+--   INSERTが "expected 768 dimensions, not 3072" エラーで失敗していた。
+--
+-- 変更概要:
+--   1. chunks テーブルの embedding カラムを vector(768) → vector(3072) に ALTER
+--   2. 既存の HNSW インデックスを halfvec(3072) で再作成
+--   3. document_embeddings テーブルの embedding カラムも同様に変更
+--
+-- 冪等: 既に 3072 次元であれば ALTER は no-op（PostgreSQL が型キャストエラーを
+--       出さないが、同一型へのキャストは警告なしに成功する）
+
+-- ----------------------------------------------------------------------------
+-- chunks: embedding 次元数を 3072 に変更
+-- ----------------------------------------------------------------------------
+
+-- 既存の HNSW インデックスを先に削除（型変更には DROP が必要）
+DROP INDEX IF EXISTS idx_chunks_embedding;
+
+-- カラムを vector(3072) に変更
+-- 既存データが 768 次元の場合は次元不一致エラーになるので NULL にリセットする
+ALTER TABLE chunks ALTER COLUMN embedding TYPE vector(3072)
+    USING NULL;
+
+-- HNSW インデックスを halfvec(3072) で再作成
+-- halfvec を使うことで 3072 次元でも HNSW インデックスが作成可能
+-- (pgvector の vector 型は HNSW 上限 2000 次元だが、halfvec は 16000 次元まで対応)
+CREATE INDEX IF NOT EXISTS idx_chunks_embedding ON chunks
+    USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
+
+-- ----------------------------------------------------------------------------
+-- document_embeddings: embedding 次元数を 3072 に変更
+-- ----------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS idx_document_embeddings_embedding;
+
+ALTER TABLE document_embeddings ALTER COLUMN embedding TYPE vector(3072)
+    USING NULL;

--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -85,7 +85,7 @@ CREATE TABLE chunks (
                         CHECK (chunk_type IN ('prose', 'equation', 'figure_caption',
                                               'table', 'definition', 'theorem', 'example')),
     latex_formulas  TEXT[] DEFAULT '{}',
-    embedding       vector(768),
+    embedding       vector(3072),
     material_id     TEXT,
     smiles_dsl      TEXT,
     variables       JSONB,
@@ -100,10 +100,10 @@ CREATE TABLE chunks (
 CREATE INDEX idx_chunks_document ON chunks(document_id);
 CREATE INDEX idx_chunks_material ON chunks(material_id);
 
--- HNSW index on halfvec cast (pgvector limits HNSW/IVFFlat to 2000 dims;
--- casting to halfvec allows indexing 768-dim vectors)
+-- HNSW index on halfvec cast (pgvector の vector 型は HNSW 上限 2000 次元だが、
+-- halfvec 型は 16000 次元まで対応するため 3072 次元でもインデックス作成可能)
 CREATE INDEX idx_chunks_embedding ON chunks
-    USING hnsw ((embedding::halfvec(768)) halfvec_cosine_ops);
+    USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);
 
 -- ============================================================
 -- 学習者状態


### PR DESCRIPTION
## Summary
Updates the embedding vector dimensions across the database schema from 768 to 3072 dimensions to support the `text-embedding-3-large` model, which returns 3072-dimensional vectors. Previously, INSERT operations were failing with "expected 768 dimensions, not 3072" errors.

## Key Changes
- **Schema updates**: Modified `chunks` and `document_embeddings` tables to use `vector(3072)` instead of `vector(768)`
- **Index migration**: Updated HNSW index to use `halfvec(3072)` casting, which supports up to 16,000 dimensions (vs. the 2,000-dimension limit of the standard `vector` type)
- **Data handling**: Existing 768-dimensional embeddings are reset to NULL during migration since they are incompatible with the new 3072-dimensional model
- **Migration scripts**: Added Migration 016 with idempotent PostgreSQL procedures that check current column types before applying changes
- **Documentation**: Updated comments in `init.sql` to clarify the halfvec casting rationale

## Implementation Details
- The migration uses PostgreSQL's `pg_attribute` system catalog to detect the current column type and only applies changes if needed
- Both `init.sql` (for new installations) and migration scripts (for existing databases) are updated to maintain consistency
- The `USING NULL` clause in ALTER TABLE statements ensures the migration completes even when existing data cannot be cast to the new type

https://claude.ai/code/session_018wTos1q1M9ENMyUuHJqniJ