### PR TITLE
Add first-class equation, evidence, and derivation export artifacts (issue #242)

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -15,6 +15,15 @@ from sqlalchemy import text as sa_text
 
 from dependencies import _require_teacher
 from core.postgres import get_session as _pg_session
+from routes.export_artifacts import (
+    build_derivation_chains_export,
+    build_document_boundary,
+    build_equation_candidates_export,
+    build_equations_export,
+    build_evidence_export,
+    enrich_course_topics,
+    get_artifacts,
+)
 
 router = APIRouter(tags=["Export"])
 
@@ -172,6 +181,137 @@ def _get_document_ids_for_course(session: Any, course_id: str) -> list[str]:
         params,
     ).fetchall()
     return [str(r[0]) for r in doc_rows if r[0]]
+
+
+def _load_analysis_artifacts(session: Any, document_ids: list[str]) -> dict[str, dict]:
+    """Load `_artifacts` payload from document_analysis_runs for each document.
+
+    Returns: {document_id: {stage_name: artifact_dict, ...}, ...}.
+    Picks the most recent run per document so resumed runs surface the
+    latest artifacts. Defensive: never raises on malformed JSONB.
+    """
+    if not document_ids:
+        return {}
+    placeholders = ", ".join(f":doc_{i}" for i in range(len(document_ids)))
+    params = {f"doc_{i}": did for i, did in enumerate(document_ids)}
+    rows = session.execute(
+        sa_text(f"""
+            SELECT DISTINCT ON (document_id)
+                   document_id, stage_outputs, status, created_at
+            FROM document_analysis_runs
+            WHERE document_id IN ({placeholders})
+            ORDER BY document_id, created_at DESC
+        """),
+        params,
+    ).fetchall()
+    out: dict[str, dict] = {}
+    for r in rows:
+        doc_id = str(r[0]) if r[0] else ""
+        if not doc_id:
+            continue
+        artifacts = get_artifacts(r[1])
+        if artifacts:
+            out[doc_id] = artifacts
+    return out
+
+
+def _build_evidence_for_documents(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+    fallback_claims: list[dict],
+) -> list[dict]:
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        evidence_artifact = artifacts.get("evidence_registry")
+        doc_claims = [c for c in fallback_claims if c.get("document_id") == doc_id]
+        out.extend(build_evidence_export(
+            evidence_artifact,
+            document_id=doc_id,
+            fallback_claims=doc_claims,
+        ))
+    return out
+
+
+def _build_equations_for_documents(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> list[dict]:
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        out.extend(build_equations_export(
+            artifacts.get("equation_semantics"),
+            document_id=doc_id,
+            structure_artifact=artifacts.get("document_structure"),
+        ))
+    return out
+
+
+def _build_equation_candidates_for_documents(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> list[dict]:
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        out.extend(build_equation_candidates_export(
+            artifacts.get("equation_semantics"),
+            document_id=doc_id,
+            structure_artifact=artifacts.get("document_structure"),
+        ))
+    return out
+
+
+def _build_derivations_for_documents(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> list[dict]:
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        out.extend(build_derivation_chains_export(
+            artifacts.get("derivation_chain"),
+            document_id=doc_id,
+            equation_artifact=artifacts.get("equation_semantics"),
+        ))
+    return out
+
+
+def _build_document_boundaries(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> list[dict]:
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        structure = artifacts.get("document_structure")
+        if not structure:
+            continue
+        out.append(build_document_boundary(structure, document_id=doc_id))
+    return out
+
+
+def _enrich_course_for_export(
+    course: dict,
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> dict:
+    # Pick the first document's artifacts (single-paper scoped courses are the
+    # common case). Multi-document course mapping is a pipeline concern.
+    course_mapping = None
+    blueprint = None
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        if course_mapping is None:
+            course_mapping = artifacts.get("course_mapping")
+        if blueprint is None:
+            blueprint = artifacts.get("blueprint")
+    return enrich_course_topics(
+        course,
+        course_mapping_artifact=course_mapping,
+        blueprint_artifact=blueprint,
+    )
 
 
 def _load_course_documents(session: Any, course_id: str, document_ids: list[str]) -> list[dict]:
@@ -637,9 +777,17 @@ def _build_manifest(
     component_graph: dict,
     evidence_snippets: list[dict],
     options: dict,
+    equations: list[dict] | None = None,
+    equation_candidates: list[dict] | None = None,
+    derivation_chains: list[dict] | None = None,
+    document_boundaries: list[dict] | None = None,
 ) -> dict:
+    equations = equations or []
+    equation_candidates = equation_candidates or []
+    derivation_chains = derivation_chains or []
+    document_boundaries = document_boundaries or []
     return {
-        "export_schema_version": "0.1.0",
+        "export_schema_version": "0.2.0",
         "exported_at": _now_iso(),
         "export_id": export_id,
         "app": {"name": "episteme-graph", "version": "unknown", "git_commit": "unknown"},
@@ -656,6 +804,10 @@ def _build_manifest(
             "components": "components/components.json",
             "component_graph": "graph/component_graph.json",
             "evidence_snippets": "evidence/evidence_snippets.json",
+            "equations": "equations/equations.json",
+            "equation_candidates": "equations/equation_candidates.json",
+            "derivation_chains": "derivations/derivation_chains.json",
+            "document_boundary": "document_boundary.json",
         },
         "counts": {
             "claims": len(claims),
@@ -664,6 +816,10 @@ def _build_manifest(
             "components": len(components),
             "component_edges": len(component_graph.get("edges", [])),
             "evidence_snippets": len(evidence_snippets),
+            "equations": len(equations),
+            "equation_candidates": len(equation_candidates),
+            "derivation_chains": len(derivation_chains),
+            "document_boundaries": len(document_boundaries),
         },
         "options": options,
     }
@@ -677,12 +833,16 @@ This ZIP contains machine-readable outputs generated by episteme-graph.
 ## Contents
 
 - `manifest.json`: index of this export bundle
-- `course_info.json`: course metadata, topics, chapters, and source materials
+- `course_info.json`: course metadata, topics (with learning_objectives, prerequisite_concepts, blackbox_policy, expected_misconceptions, assessment_prompts, visualization_plan), chapters, and source materials
 - `claims/claims.json`: extracted claims from source documents
 - `dsl/dsl_graph.json`: lightweight logical graph representation (DSL)
 - `components/components.json`: reusable logical/theory components (Component)
 - `graph/component_graph.json`: graph connections between components (Component Graph)
-- `evidence/evidence_snippets.json`: source snippets supporting claims (Evidence)
+- `evidence/evidence_snippets.json`: source-backed Evidence (PDF spans). `evidence_text` is PDF-derived text; LLM commentary is kept in `analysis_note` / `review_note`. `extraction_source`, `extraction_status`, `needs_review`, `review_reason` audit the provenance.
+- `equations/equations.json`: first-class equation registry. Each entry has `latex`, `plain_text`, `source_location`, `equation_type`, `defined_symbols`, `used_symbols`, `input_equation_ids`, `output_equation_ids`, `extraction_source`, `extraction_status`, `needs_math_review`, `review_reason`, `candidate_trace_ids`.
+- `equations/equation_candidates.json`: audit trail for equation candidate detection. Each entry records `raw_text`, `source_location`, `detection_method`, `matched_label`, `acceptance_status`, `accepted_equation_id`, `rejection_reason`.
+- `derivations/derivation_chains.json`: derivation steps linking equations / claims with `operation`, `input_equation_ids`, `output_equation_ids`, `assumption_refs`.
+- `document_boundary.json`: per-document active article boundary (page_start, page_end, confidence, needs_review). Useful for multi-article PDFs (journal scans, conference proceedings).
 
 ## Data Model Summary
 
@@ -744,7 +904,15 @@ def _build_zip(
     include_ndjson: bool = False,
     include_debug: bool = False,
     debug_data: dict | None = None,
+    equations: list[dict] | None = None,
+    equation_candidates: list[dict] | None = None,
+    derivation_chains: list[dict] | None = None,
+    document_boundaries: list[dict] | None = None,
 ) -> bytes:
+    equations = equations or []
+    equation_candidates = equation_candidates or []
+    derivation_chains = derivation_chains or []
+    document_boundaries = document_boundaries or []
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("README.md", _README_TEMPLATE)
@@ -760,7 +928,26 @@ def _build_zip(
             "graph/component_graph.json",
             _json_bytes({**component_graph, "graph_schema_version": component_graph.get("graph_schema_version", "0.1.0")}),
         )
-        zf.writestr("evidence/evidence_snippets.json", _json_bytes({"snippets": evidence_snippets}))
+        zf.writestr("evidence/evidence_snippets.json", _json_bytes({
+            "evidence_schema_version": "0.2.0",
+            "snippets": evidence_snippets,
+        }))
+        zf.writestr("equations/equations.json", _json_bytes({
+            "equation_schema_version": "0.1.0",
+            "equations": equations,
+        }))
+        zf.writestr("equations/equation_candidates.json", _json_bytes({
+            "candidate_schema_version": "0.1.0",
+            "candidates": equation_candidates,
+        }))
+        zf.writestr("derivations/derivation_chains.json", _json_bytes({
+            "derivation_schema_version": "0.1.0",
+            "chains": derivation_chains,
+        }))
+        zf.writestr("document_boundary.json", _json_bytes({
+            "boundary_schema_version": "0.1.0",
+            "boundaries": document_boundaries,
+        }))
 
         if include_ndjson:
             zf.writestr("claims/claims.ndjson", _ndjson_bytes(claims))
@@ -802,7 +989,17 @@ def export_course_bundle(
         dsl_graph = _load_dsl_graph_for_course(session, course_id, document_ids)
         components = _load_components_for_course(session, course_id, document_ids)
         component_graph = _load_component_graph_for_course(session, course_id, document_ids)
-        evidence_snippets = _build_evidence_snippets(claims) if req.include_source_snippets else []
+
+        artifacts_by_doc = _load_analysis_artifacts(session, document_ids)
+        evidence_snippets = (
+            _build_evidence_for_documents(artifacts_by_doc, document_ids, claims)
+            if req.include_source_snippets else []
+        )
+        equations = _build_equations_for_documents(artifacts_by_doc, document_ids)
+        equation_candidates = _build_equation_candidates_for_documents(artifacts_by_doc, document_ids)
+        derivation_chains = _build_derivations_for_documents(artifacts_by_doc, document_ids)
+        document_boundaries = _build_document_boundaries(artifacts_by_doc, document_ids)
+        course = _enrich_course_for_export(course, artifacts_by_doc, document_ids)
 
         docs = _load_course_documents(session, course_id, document_ids)
 
@@ -825,6 +1022,10 @@ def export_course_bundle(
             components=components,
             component_graph=component_graph,
             evidence_snippets=evidence_snippets,
+            equations=equations,
+            equation_candidates=equation_candidates,
+            derivation_chains=derivation_chains,
+            document_boundaries=document_boundaries,
             options=options,
         )
 
@@ -836,6 +1037,10 @@ def export_course_bundle(
             components=components,
             component_graph=component_graph,
             evidence_snippets=evidence_snippets,
+            equations=equations,
+            equation_candidates=equation_candidates,
+            derivation_chains=derivation_chains,
+            document_boundaries=document_boundaries,
             include_ndjson=req.include_ndjson,
             include_debug=req.include_debug_data,
             debug_data={"validation_errors": [], "pipeline_logs": []} if req.include_debug_data else None,
@@ -868,7 +1073,18 @@ def export_document_bundle(
         dsl_graph = _load_dsl_graph_for_document(session, document_id)
         components = _load_components_for_document(session, document_id)
         component_graph = _load_component_graph_for_document(session, document_id)
-        evidence_snippets = _build_evidence_snippets(claims) if req.include_source_snippets else []
+
+        document_ids = [document_id]
+        artifacts_by_doc = _load_analysis_artifacts(session, document_ids)
+        evidence_snippets = (
+            _build_evidence_for_documents(artifacts_by_doc, document_ids, claims)
+            if req.include_source_snippets else []
+        )
+        equations = _build_equations_for_documents(artifacts_by_doc, document_ids)
+        equation_candidates = _build_equation_candidates_for_documents(artifacts_by_doc, document_ids)
+        derivation_chains = _build_derivations_for_documents(artifacts_by_doc, document_ids)
+        document_boundaries = _build_document_boundaries(artifacts_by_doc, document_ids)
+        document = _enrich_course_for_export(document, artifacts_by_doc, document_ids)
 
         eid = _export_id("document", document_id)
         options = {
@@ -883,12 +1099,16 @@ def export_document_bundle(
             scope_type="document",
             scope_id=document_id,
             material_ids=[],
-            document_ids=[document_id],
+            document_ids=document_ids,
             claims=claims,
             dsl_graph=dsl_graph,
             components=components,
             component_graph=component_graph,
             evidence_snippets=evidence_snippets,
+            equations=equations,
+            equation_candidates=equation_candidates,
+            derivation_chains=derivation_chains,
+            document_boundaries=document_boundaries,
             options=options,
         )
 
@@ -900,6 +1120,10 @@ def export_document_bundle(
             components=components,
             component_graph=component_graph,
             evidence_snippets=evidence_snippets,
+            equations=equations,
+            equation_candidates=equation_candidates,
+            derivation_chains=derivation_chains,
+            document_boundaries=document_boundaries,
             include_ndjson=req.include_ndjson,
             include_debug=req.include_debug_data,
             debug_data={"validation_errors": [], "pipeline_logs": []} if req.include_debug_data else None,

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -1,0 +1,549 @@
+"""Helpers for surfacing agent pipeline artifacts in the export bundle (issue #242).
+
+Source-of-truth: `document_analysis_runs.stage_outputs._artifacts` JSONB column,
+populated by `core.document_pipeline.orchestrator.save_artifact`.
+
+Each helper here is purely functional and operates on the artifact dicts so the
+export route can compose them without coupling to SQLAlchemy or the orchestrator.
+
+Issue #242 acceptance criteria:
+- equations.json contains first-class Equation objects.
+- equation_candidates.json keeps the audit trail (raw_text, source_location,
+  detection_method, acceptance_status, accepted_equation_id, ...).
+- derivation_chains.json exposes step-level operation / inputs / outputs.
+- evidence_snippets.json keeps PDF-derived evidence_text separate from LLM
+  analysis_note / review_note, with extraction_source / extraction_status /
+  needs_review.
+- document_boundary records the active article boundary inside multi-article
+  PDFs (e.g. journal scans).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+ARTIFACTS_KEY = "_artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Low-level artifact access
+# ---------------------------------------------------------------------------
+
+
+def _coerce_dict(value: Any) -> dict:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def get_artifacts(stage_outputs: Any) -> dict[str, Any]:
+    """Return the `_artifacts` sub-dict from a stage_outputs JSONB payload.
+
+    Tolerates missing / malformed payloads; returns {} so callers can chain
+    `get_artifacts(...).get("equation_semantics")` without guarding every call.
+    """
+    payload = _coerce_dict(stage_outputs)
+    artifacts = payload.get(ARTIFACTS_KEY)
+    return artifacts if isinstance(artifacts, dict) else {}
+
+
+# ---------------------------------------------------------------------------
+# Equation registry (first-class equations.json)
+# ---------------------------------------------------------------------------
+
+
+def _section_id_to_block_lookup(structure: dict) -> dict[str, dict]:
+    blocks = structure.get("blocks", []) if isinstance(structure, dict) else []
+    out: dict[str, dict] = {}
+    for b in blocks:
+        if isinstance(b, dict) and b.get("block_id"):
+            out[b["block_id"]] = b
+    return out
+
+
+def build_equations_export(
+    equation_artifact: Any,
+    *,
+    document_id: str,
+    structure_artifact: Any = None,
+    evidence_index: dict[str, list[str]] | None = None,
+    claim_index: dict[str, list[str]] | None = None,
+) -> list[dict]:
+    """Convert the equation_semantics artifact into equations/equations.json shape.
+
+    Each output entry follows the schema defined in issue #242 §3:
+    equation_id, label, latex, plain_text, source_location, equation_type,
+    defined_symbols, used_symbols, derivation_links, source_evidence_ids,
+    extraction_source, extraction_status, needs_math_review, review_reason,
+    candidate_trace_ids.
+    """
+    eq = _coerce_dict(equation_artifact)
+    records = eq.get("equations") if isinstance(eq.get("equations"), list) else []
+    structure = _coerce_dict(structure_artifact)
+    block_lookup = _section_id_to_block_lookup(structure)
+    evidence_index = evidence_index or {}
+    claim_index = claim_index or {}
+
+    out: list[dict] = []
+    for r in records:
+        if not isinstance(r, dict):
+            continue
+        equation_id = str(r.get("equation_id") or "").strip()
+        if not equation_id:
+            continue
+        block_id = str(r.get("block_id") or "")
+        section_id = r.get("section_id")
+        block = block_lookup.get(block_id, {})
+        page = block.get("page") if isinstance(block, dict) else None
+        bbox = block.get("bbox") if isinstance(block, dict) else None
+        text = block.get("text") if isinstance(block, dict) else ""
+        text = text or r.get("text") or ""
+
+        eq_role = r.get("equation_role") or {}
+        primary_role = (eq_role.get("primary") if isinstance(eq_role, dict) else None) or "unknown"
+
+        defined_symbols_raw = r.get("defined_symbols") or []
+        defined_symbols: list[str] = []
+        used_symbols: list[str] = []
+        symbol_definitions: dict[str, str] = {}
+        for s in defined_symbols_raw if isinstance(defined_symbols_raw, list) else []:
+            if not isinstance(s, dict):
+                continue
+            sym = str(s.get("symbol") or "").strip()
+            if not sym:
+                continue
+            status = s.get("definition_status") or "unknown"
+            if status in ("defined", "redefined"):
+                defined_symbols.append(sym)
+            elif status == "used":
+                used_symbols.append(sym)
+            ev_text = s.get("evidence_text") or ""
+            if ev_text:
+                symbol_definitions[sym] = ev_text
+
+        derivation_links = r.get("derivation_links") or {}
+        from_eqs = list(derivation_links.get("from_equations") or []) if isinstance(derivation_links, dict) else []
+        to_eqs = list(derivation_links.get("to_equations") or []) if isinstance(derivation_links, dict) else []
+
+        latex = r.get("latex")
+        plain_text = r.get("plain_text") or text
+        review_flags = list(r.get("review_flags") or [])
+        needs_math_review = bool(review_flags) or not bool(latex) or "low_confidence" in review_flags
+
+        # extraction_source: heuristic — prefer pdf_text_layer when block text is
+        # present, else flag llm_reconstruction (e.g. agent fallback).
+        if block.get("text"):
+            extraction_source = "pdf_text_layer"
+            extraction_status = "parsed" if latex else "partially_parsed"
+        else:
+            extraction_source = "llm_reconstruction"
+            extraction_status = "reconstructed" if latex or plain_text else "unparsed"
+
+        out.append({
+            "equation_id": equation_id,
+            "document_id": document_id,
+            "label": r.get("label"),
+            "latex": latex,
+            "plain_text": plain_text,
+            "source_location": {
+                "page": page,
+                "section_id": section_id,
+                "block_id": block_id,
+                "span_start": 0,
+                "span_end": len(text or ""),
+                "bbox": list(bbox) if isinstance(bbox, (list, tuple)) else [],
+            },
+            "equation_type": primary_role,
+            "defined_symbols": defined_symbols,
+            "used_symbols": used_symbols,
+            "symbol_definitions": symbol_definitions,
+            "assumptions": [
+                a.get("text", "") for a in (r.get("local_assumptions") or [])
+                if isinstance(a, dict) and a.get("text")
+            ],
+            "input_equation_ids": from_eqs,
+            "output_equation_ids": to_eqs,
+            "source_evidence_ids": list(evidence_index.get(block_id, [])),
+            "linked_claim_ids": list(claim_index.get(equation_id, [])),
+            "extraction_source": extraction_source,
+            "extraction_status": extraction_status,
+            "needs_math_review": needs_math_review,
+            "review_reason": review_flags,
+            "candidate_trace_ids": [f"eqcand_{equation_id}"],
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Equation candidate trace (audit log)
+# ---------------------------------------------------------------------------
+
+
+def build_equation_candidates_export(
+    equation_artifact: Any,
+    *,
+    document_id: str,
+    structure_artifact: Any = None,
+) -> list[dict]:
+    """Build equations/equation_candidates.json from available signals.
+
+    The current pipeline doesn't run a dedicated candidate detector, so we
+    reconstruct a minimal trace from the equation_semantics records and the
+    document_structure equation_blocks. Both produce auditable rows so the
+    downstream `eq_*` references can be traced back to a PDF span.
+    """
+    structure = _coerce_dict(structure_artifact)
+    block_lookup = _section_id_to_block_lookup(structure)
+
+    candidates: list[dict] = []
+    accepted_block_ids: set[str] = set()
+
+    eq = _coerce_dict(equation_artifact)
+    for r in eq.get("equations") or []:
+        if not isinstance(r, dict):
+            continue
+        equation_id = str(r.get("equation_id") or "")
+        if not equation_id:
+            continue
+        block_id = str(r.get("block_id") or "")
+        accepted_block_ids.add(block_id)
+        block = block_lookup.get(block_id, {})
+        text = block.get("text") if isinstance(block, dict) else ""
+        text = text or r.get("text") or ""
+        page = block.get("page") if isinstance(block, dict) else None
+        bbox = block.get("bbox") if isinstance(block, dict) else None
+        review_flags = list(r.get("review_flags") or [])
+        candidates.append({
+            "candidate_id": f"eqcand_{equation_id}",
+            "document_id": document_id,
+            "source_location": {
+                "page": page,
+                "section_id": r.get("section_id"),
+                "block_id": block_id,
+                "span_start": 0,
+                "span_end": len(text or ""),
+                "bbox": list(bbox) if isinstance(bbox, (list, tuple)) else [],
+            },
+            "raw_text": text or "",
+            "detection_method": ["document_structure_equation_block", "llm_semantic_classification"],
+            "matched_label": r.get("label"),
+            "candidate_score": None,
+            "acceptance_status": "accepted",
+            "accepted_equation_id": equation_id,
+            "rejection_reason": None,
+            "needs_math_review": bool(review_flags) or not bool(r.get("latex")),
+            "review_reason": review_flags,
+        })
+
+    # Also surface document_structure equation_blocks that did not become
+    # first-class equations — these are rejected candidates worth auditing.
+    for block in structure.get("blocks", []) or []:
+        if not isinstance(block, dict):
+            continue
+        if block.get("block_type") != "equation_block":
+            continue
+        block_id = block.get("block_id") or ""
+        if block_id in accepted_block_ids:
+            continue
+        candidates.append({
+            "candidate_id": f"eqcand_{block_id}",
+            "document_id": document_id,
+            "source_location": {
+                "page": block.get("page"),
+                "section_id": block.get("section_id"),
+                "block_id": block_id,
+                "span_start": 0,
+                "span_end": len(block.get("text") or ""),
+                "bbox": list(block.get("bbox") or []) if isinstance(block.get("bbox"), (list, tuple)) else [],
+            },
+            "raw_text": block.get("text") or "",
+            "detection_method": ["document_structure_equation_block"],
+            "matched_label": block.get("equation_label"),
+            "candidate_score": float(block.get("confidence") or 0.0),
+            "acceptance_status": "rejected",
+            "accepted_equation_id": None,
+            "rejection_reason": "not_promoted_by_equation_semantics_agent",
+            "needs_math_review": True,
+            "review_reason": ["not_promoted"],
+        })
+    return candidates
+
+
+# ---------------------------------------------------------------------------
+# Evidence registry (source-backed)
+# ---------------------------------------------------------------------------
+
+
+def build_evidence_export(
+    evidence_artifact: Any,
+    *,
+    document_id: str,
+    fallback_claims: list[dict] | None = None,
+) -> list[dict]:
+    """Build evidence/evidence_snippets.json with source-backed fields.
+
+    Prefers the EvidenceRegistry artifact (PDF-quoted text, separate review
+    notes). Falls back to claim.evidence_text when no registry artifact is
+    available, marking those entries with extraction_status=reconstructed and
+    needs_review=true so consumers know they may include LLM commentary.
+    """
+    out: list[dict] = []
+    ev = _coerce_dict(evidence_artifact)
+    records = ev.get("records") if isinstance(ev.get("records"), list) else []
+    if records:
+        for r in records:
+            if not isinstance(r, dict):
+                continue
+            src = r.get("source") or {}
+            evidence_text = r.get("evidence_text") or ""
+            review_note = r.get("review_note") or ""
+            out.append({
+                "evidence_id": r.get("evidence_id") or "",
+                "document_id": r.get("document_id") or document_id,
+                "page": src.get("page") if isinstance(src, dict) else None,
+                "section_id": src.get("section_id") if isinstance(src, dict) else None,
+                "block_id": src.get("block_id") if isinstance(src, dict) else "",
+                "span_start": src.get("span_start", 0) if isinstance(src, dict) else 0,
+                "span_end": src.get("span_end", 0) if isinstance(src, dict) else 0,
+                "evidence_text": evidence_text,
+                "evidence_role": r.get("evidence_role") or "source_quote",
+                "analysis_note": "",
+                "review_note": review_note,
+                "extraction_source": "pdf_text_layer",
+                "extraction_status": "extracted" if evidence_text else "unavailable",
+                "public_export_policy": r.get("public_export_policy") or "location_only",
+                "needs_review": bool(review_note),
+                "review_reason": [review_note] if review_note else [],
+            })
+        return out
+
+    # Fallback: synthesise evidence rows from claim.evidence_text. The text
+    # may be LLM commentary, so we mark needs_review=true and surface it as
+    # analysis_note to keep the source-backed contract honest.
+    for i, claim in enumerate(fallback_claims or []):
+        text = claim.get("evidence_text") or ""
+        if not text:
+            continue
+        scope = claim.get("source_scope") or {}
+        out.append({
+            "evidence_id": f"evidence_{i+1:04d}",
+            "document_id": claim.get("document_id") or document_id,
+            "page": scope.get("page"),
+            "section_id": scope.get("section_id", ""),
+            "block_id": scope.get("chunk_id", ""),
+            "span_start": 0,
+            "span_end": len(text),
+            "evidence_text": text,
+            "evidence_role": "section_summary",
+            "analysis_note": "",
+            "review_note": "",
+            "extraction_source": "reconstructed",
+            "extraction_status": "reconstructed",
+            "public_export_policy": "location_only",
+            "needs_review": True,
+            "review_reason": ["evidence_not_source_verified"],
+            "claim_id": claim.get("claim_id") or "",
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Derivation chains
+# ---------------------------------------------------------------------------
+
+
+def build_derivation_chains_export(
+    derivation_artifact: Any,
+    *,
+    document_id: str,
+    equation_artifact: Any = None,
+) -> list[dict]:
+    """Build derivations/derivation_chains.json.
+
+    Prefers the dedicated DerivationChainAgent artifact when present.
+    Otherwise reconstructs minimal chains from the equation_semantics
+    derivation_links so component.internal_flow can still be cross-checked.
+    """
+    out: list[dict] = []
+    dc = _coerce_dict(derivation_artifact)
+    chains = dc.get("chains") if isinstance(dc.get("chains"), list) else []
+    if chains:
+        for c in chains:
+            if not isinstance(c, dict):
+                continue
+            steps = []
+            for s in c.get("steps") or []:
+                if not isinstance(s, dict):
+                    continue
+                steps.append({
+                    "step_id": s.get("step_id") or "",
+                    "operation": s.get("operation") or "transform",
+                    "input_equation_ids": list(s.get("input_equation_ids") or []),
+                    "output_equation_ids": list(s.get("output_equation_ids") or []),
+                    "required_claim_ids": list(s.get("required_claim_ids") or []),
+                    "assumption_refs": list(s.get("assumption_refs") or []),
+                    "reason": s.get("reason") or "",
+                    "confidence": float(s.get("confidence") or 0.0),
+                })
+            out.append({
+                "derivation_id": c.get("derivation_id") or "",
+                "document_id": c.get("document_id") or document_id,
+                "source_section_ids": list(c.get("source_section_ids") or []),
+                "steps": steps,
+                "teaching_takeaway": c.get("teaching_takeaway") or "",
+                "blackbox_policy_suggestion": c.get("blackbox_policy_suggestion") or {},
+            })
+        return out
+
+    eq = _coerce_dict(equation_artifact)
+    eq_records = eq.get("equations") or []
+    chain_id = 1
+    for r in eq_records if isinstance(eq_records, list) else []:
+        if not isinstance(r, dict):
+            continue
+        derivation_links = r.get("derivation_links") or {}
+        from_eqs = list(derivation_links.get("from_equations") or []) if isinstance(derivation_links, dict) else []
+        if not from_eqs:
+            continue
+        eq_id = r.get("equation_id") or ""
+        out.append({
+            "derivation_id": f"deriv_{chain_id:04d}",
+            "document_id": document_id,
+            "source_section_ids": [r.get("section_id")] if r.get("section_id") else [],
+            "steps": [{
+                "step_id": f"deriv_{chain_id:04d}_step_1",
+                "operation": "derive_from",
+                "input_equation_ids": from_eqs,
+                "output_equation_ids": [eq_id] if eq_id else [],
+                "required_claim_ids": [],
+                "assumption_refs": [
+                    a.get("text", "") for a in (r.get("local_assumptions") or [])
+                    if isinstance(a, dict) and a.get("text")
+                ],
+                "reason": "Reconstructed from equation_semantics.derivation_links",
+                "confidence": 0.5,
+            }],
+            "teaching_takeaway": "",
+            "blackbox_policy_suggestion": {},
+        })
+        chain_id += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Course / topic metadata
+# ---------------------------------------------------------------------------
+
+
+def enrich_course_topics(
+    course: dict,
+    *,
+    course_mapping_artifact: Any = None,
+    blueprint_artifact: Any = None,
+) -> dict:
+    """Add learning_objectives, prerequisite_concepts, blackbox_policy,
+    expected_misconceptions, assessment_prompts, visualization_plan to topics.
+
+    Pulls from CourseMappingAgent (for objectives / prerequisites / blackbox)
+    and BlueprintAgent (for visualization_plan derived from narrative_arc).
+    """
+    if not isinstance(course, dict):
+        return course
+
+    cm = _coerce_dict(course_mapping_artifact)
+    mapping_topics = cm.get("topics") or []
+    mapping_by_title: dict[str, dict] = {}
+    for t in mapping_topics if isinstance(mapping_topics, list) else []:
+        if isinstance(t, dict) and t.get("title"):
+            mapping_by_title[str(t["title"]).strip()] = t
+
+    bp = _coerce_dict(blueprint_artifact)
+    narrative_arc = bp.get("narrative_arc") if isinstance(bp.get("narrative_arc"), list) else []
+    visualization_plan = []
+    for step in narrative_arc:
+        if not isinstance(step, dict):
+            continue
+        visualization_plan.append({
+            "step": step.get("step"),
+            "role": step.get("role"),
+            "visual_strategy": step.get("visual_strategy"),
+            "rationale": step.get("rationale"),
+            "linked_component_ids": list(step.get("linked_component_ids") or []),
+        })
+
+    enriched_topics: list[dict] = []
+    for t in course.get("topics") or []:
+        if not isinstance(t, dict):
+            continue
+        title = (t.get("title") or "").strip()
+        mapping = mapping_by_title.get(title, {})
+        topic = dict(t)
+        topic.setdefault("learning_objectives", list(mapping.get("learning_objectives") or []))
+        topic.setdefault("prerequisite_concepts", list(mapping.get("prerequisite_concepts") or t.get("prerequisites") or []))
+        topic.setdefault("blackbox_policy", mapping.get("blackbox_policy") or {})
+        topic.setdefault("assessment_prompts", list(mapping.get("assessment_prompts") or []))
+        topic.setdefault("expected_misconceptions", list(mapping.get("expected_misconceptions") or []))
+        topic.setdefault("visualization_plan", visualization_plan)
+        enriched_topics.append(topic)
+
+    enriched = dict(course)
+    enriched["topics"] = enriched_topics
+    return enriched
+
+
+# ---------------------------------------------------------------------------
+# Document boundary
+# ---------------------------------------------------------------------------
+
+
+def build_document_boundary(
+    structure_artifact: Any,
+    *,
+    document_id: str,
+) -> dict:
+    """Surface the active article boundary inside a (potentially multi-article) PDF.
+
+    The DocumentStructureAgent records page ranges per section; we expose the
+    first section's page_start as the article start and the last section's
+    page_end as the article end, plus the title block when present, so
+    consumers can flag spans that fall outside the boundary.
+    """
+    structure = _coerce_dict(structure_artifact)
+    sections = structure.get("sections") or []
+    metadata = structure.get("metadata") or {}
+    pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
+
+    boundary_page_start = None
+    boundary_page_end = None
+    section_ids: list[str] = []
+    for s in sections if isinstance(sections, list) else []:
+        if not isinstance(s, dict):
+            continue
+        if boundary_page_start is None and s.get("page_start") is not None:
+            boundary_page_start = s.get("page_start")
+        if s.get("page_end") is not None:
+            boundary_page_end = s.get("page_end")
+        if s.get("section_id"):
+            section_ids.append(s["section_id"])
+
+    confidence = 1.0 if (boundary_page_start is not None and boundary_page_end is not None) else 0.5
+    needs_review = confidence < 0.8
+
+    return {
+        "document_id": document_id,
+        "title": metadata.get("title") if isinstance(metadata, dict) else None,
+        "authors": list(metadata.get("authors") or []) if isinstance(metadata, dict) else [],
+        "boundary_page_start": boundary_page_start,
+        "boundary_page_end": boundary_page_end,
+        "pages_total": pages_total,
+        "active_section_ids": section_ids,
+        "confidence": confidence,
+        "needs_review": needs_review,
+        "review_reason": ([] if not needs_review else ["incomplete_section_page_range"]),
+    }

--- a/backend/tests/test_export_artifacts.py
+++ b/backend/tests/test_export_artifacts.py
@@ -1,0 +1,415 @@
+"""Tests for issue #242 export artifact helpers.
+
+Covers the source-backed evidence registry, first-class equation registry,
+equation candidate trace, derivation chain export, course/topic metadata
+enrichment, and document boundary detection produced by the export bundle.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+sys.path.insert(0, str(ROOT / "backend" / "api"))
+
+
+def _import_artifacts():
+    from routes import export_artifacts  # type: ignore
+    return export_artifacts
+
+
+def _import_export_module():
+    """Re-use the helper from test_export_bundle so we can call _build_zip."""
+    sys.path.insert(0, str(ROOT / "backend" / "tests"))
+    from test_export_bundle import _import_export_module as _impl  # type: ignore
+    return _impl()
+
+
+SAMPLE_STRUCTURE = {
+    "blocks": [
+        {
+            "block_id": "blk_5",
+            "page": 3,
+            "text": "F = ma",
+            "bbox": [0, 0, 10, 10],
+            "block_type": "equation_block",
+            "section_id": "sec_1",
+            "equation_label": "(1)",
+            "confidence": 0.9,
+        },
+        {
+            "block_id": "blk_6",
+            "page": 4,
+            "text": "leftover formula",
+            "bbox": [0, 0, 5, 5],
+            "block_type": "equation_block",
+            "section_id": "sec_1",
+            "equation_label": None,
+            "confidence": 0.4,
+        },
+    ],
+    "sections": [
+        {"section_id": "sec_1", "title": "Intro", "level": 1, "order": 0,
+         "page_start": 1, "page_end": 5},
+    ],
+    "metadata": {"title": "Test paper", "authors": ["Alice"], "pages": 10},
+}
+
+SAMPLE_EQUATIONS = {
+    "document_id": "doc_001",
+    "equations": [
+        {
+            "equation_id": "eq_001",
+            "block_id": "blk_5",
+            "section_id": "sec_1",
+            "label": "(1)",
+            "text": "F = ma",
+            "latex": "F = ma",
+            "plain_text": "F = ma",
+            "equation_role": {"primary": "equation_definition", "secondary": [],
+                              "confidence": 0.9, "reason": "Definition of force."},
+            "defined_symbols": [
+                {"symbol": "F", "definition_status": "defined", "evidence_text": "force"},
+                {"symbol": "m", "definition_status": "used"},
+            ],
+            "local_assumptions": [{"text": "small_x", "source_block_ids": []}],
+            "derivation_links": {"from_equations": [], "to_equations": ["eq_002"], "linked_text_spans": []},
+            "review_flags": [],
+        },
+        {
+            "equation_id": "eq_002",
+            "block_id": "blk_7",
+            "section_id": "sec_1",
+            "label": "(2)",
+            "text": "p = mv",
+            "latex": "p = mv",
+            "plain_text": "p = mv",
+            "equation_role": {"primary": "equation_relation", "secondary": [],
+                              "confidence": 0.7, "reason": "Momentum relation."},
+            "defined_symbols": [],
+            "local_assumptions": [],
+            "derivation_links": {"from_equations": ["eq_001"], "to_equations": [], "linked_text_spans": []},
+            "review_flags": ["low_confidence"],
+        },
+    ],
+}
+
+SAMPLE_EVIDENCE_REGISTRY = {
+    "document_id": "doc_001",
+    "records": [
+        {
+            "evidence_id": "ev_001",
+            "document_id": "doc_001",
+            "source": {"page": 2, "section_id": "sec_1", "block_id": "blk_5",
+                       "span_start": 100, "span_end": 200},
+            "evidence_text": "F = ma is the canonical statement of Newton's second law.",
+            "evidence_role": "source_quote",
+            "review_note": "",
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Equations export
+# ---------------------------------------------------------------------------
+
+class TestEquationsExport:
+    def test_first_class_equation_registry_exposes_required_fields(self):
+        ea = _import_artifacts()
+        eqs = ea.build_equations_export(
+            SAMPLE_EQUATIONS, document_id="doc_001",
+            structure_artifact=SAMPLE_STRUCTURE,
+        )
+        assert len(eqs) == 2
+        e1 = eqs[0]
+        # Issue #242 §3 acceptance criteria:
+        for field in (
+            "equation_id", "document_id", "label", "latex", "plain_text",
+            "source_location", "equation_type", "defined_symbols", "used_symbols",
+            "input_equation_ids", "output_equation_ids", "extraction_source",
+            "extraction_status", "needs_math_review", "review_reason",
+            "candidate_trace_ids",
+        ):
+            assert field in e1, f"missing {field}"
+        assert e1["source_location"]["page"] == 3
+        assert e1["source_location"]["block_id"] == "blk_5"
+        assert e1["extraction_source"] == "pdf_text_layer"
+        assert "F" in e1["defined_symbols"]
+        assert "m" in e1["used_symbols"]
+        assert e1["candidate_trace_ids"] == ["eqcand_eq_001"]
+
+    def test_equation_with_review_flag_marks_needs_math_review(self):
+        ea = _import_artifacts()
+        eqs = ea.build_equations_export(
+            SAMPLE_EQUATIONS, document_id="doc_001",
+            structure_artifact=SAMPLE_STRUCTURE,
+        )
+        eq2 = next(e for e in eqs if e["equation_id"] == "eq_002")
+        assert eq2["needs_math_review"] is True
+        assert "low_confidence" in eq2["review_reason"]
+
+    def test_equation_without_artifact_returns_empty(self):
+        ea = _import_artifacts()
+        assert ea.build_equations_export(None, document_id="doc_001") == []
+        assert ea.build_equations_export({}, document_id="doc_001") == []
+
+
+# ---------------------------------------------------------------------------
+# Equation candidate trace
+# ---------------------------------------------------------------------------
+
+class TestEquationCandidatesExport:
+    def test_accepted_candidates_link_back_to_equation_id(self):
+        ea = _import_artifacts()
+        cands = ea.build_equation_candidates_export(
+            SAMPLE_EQUATIONS, document_id="doc_001",
+            structure_artifact=SAMPLE_STRUCTURE,
+        )
+        # eq_001 → accepted; blk_6 (no equation_semantics record) → rejected
+        accepted = [c for c in cands if c["acceptance_status"] == "accepted"]
+        rejected = [c for c in cands if c["acceptance_status"] == "rejected"]
+        assert len(accepted) == 2
+        assert len(rejected) == 1
+        for field in (
+            "candidate_id", "document_id", "source_location", "raw_text",
+            "detection_method", "matched_label", "acceptance_status",
+            "accepted_equation_id", "rejection_reason", "needs_math_review",
+            "review_reason",
+        ):
+            assert field in accepted[0], f"missing {field}"
+        assert accepted[0]["accepted_equation_id"] in ("eq_001", "eq_002")
+        assert rejected[0]["accepted_equation_id"] is None
+        assert rejected[0]["rejection_reason"]
+
+
+# ---------------------------------------------------------------------------
+# Evidence registry export (source-backed)
+# ---------------------------------------------------------------------------
+
+class TestEvidenceExport:
+    def test_evidence_registry_artifact_yields_source_backed_rows(self):
+        ea = _import_artifacts()
+        evs = ea.build_evidence_export(SAMPLE_EVIDENCE_REGISTRY, document_id="doc_001")
+        assert len(evs) == 1
+        e = evs[0]
+        assert e["evidence_text"].startswith("F = ma")
+        assert e["extraction_source"] == "pdf_text_layer"
+        assert e["extraction_status"] == "extracted"
+        assert e["needs_review"] is False
+        assert e["block_id"] == "blk_5"
+        assert e["span_start"] == 100
+        assert e["span_end"] == 200
+
+    def test_fallback_evidence_marks_unverified(self):
+        ea = _import_artifacts()
+        evs = ea.build_evidence_export(None, document_id="doc_001", fallback_claims=[
+            {"claim_id": "c1", "evidence_text": "This span states the law.",
+             "document_id": "doc_001", "source_scope": {"page": 2}},
+        ])
+        assert len(evs) == 1
+        assert evs[0]["needs_review"] is True
+        assert evs[0]["extraction_status"] == "reconstructed"
+        # LLM-style commentary should not be silently treated as a source quote.
+        assert "evidence_not_source_verified" in evs[0]["review_reason"]
+
+
+# ---------------------------------------------------------------------------
+# Derivation chains
+# ---------------------------------------------------------------------------
+
+class TestDerivationChains:
+    def test_derivation_chain_artifact_passthrough(self):
+        ea = _import_artifacts()
+        artifact = {
+            "document_id": "doc_001",
+            "chains": [{
+                "derivation_id": "deriv_001",
+                "document_id": "doc_001",
+                "source_section_ids": ["sec_2"],
+                "steps": [{
+                    "step_id": "deriv_001_1",
+                    "input_equation_ids": ["eq_001"],
+                    "operation": "substitute",
+                    "output_equation_ids": ["eq_002"],
+                    "required_claim_ids": ["claim_007"],
+                    "assumption_refs": ["small_x"],
+                    "reason": "Substituting eq_001 into ...",
+                    "confidence": 0.8,
+                }],
+                "teaching_takeaway": "Take-home text.",
+                "blackbox_policy_suggestion": {"blackbox": ["eq_002"]},
+            }],
+        }
+        chains = ea.build_derivation_chains_export(artifact, document_id="doc_001")
+        assert len(chains) == 1
+        s = chains[0]["steps"][0]
+        assert s["operation"] == "substitute"
+        assert s["input_equation_ids"] == ["eq_001"]
+        assert s["output_equation_ids"] == ["eq_002"]
+        assert s["assumption_refs"] == ["small_x"]
+
+    def test_derivation_fallback_uses_equation_links(self):
+        ea = _import_artifacts()
+        chains = ea.build_derivation_chains_export(
+            None, document_id="doc_001", equation_artifact=SAMPLE_EQUATIONS,
+        )
+        # eq_002 has from_equations=[eq_001] → 1 chain
+        assert len(chains) == 1
+        step = chains[0]["steps"][0]
+        assert step["input_equation_ids"] == ["eq_001"]
+        assert step["output_equation_ids"] == ["eq_002"]
+
+
+# ---------------------------------------------------------------------------
+# Document boundary
+# ---------------------------------------------------------------------------
+
+class TestDocumentBoundary:
+    def test_boundary_pulls_from_document_structure(self):
+        ea = _import_artifacts()
+        b = ea.build_document_boundary(SAMPLE_STRUCTURE, document_id="doc_001")
+        assert b["title"] == "Test paper"
+        assert b["authors"] == ["Alice"]
+        assert b["boundary_page_start"] == 1
+        assert b["boundary_page_end"] == 5
+        assert b["needs_review"] is False
+        assert "sec_1" in b["active_section_ids"]
+
+    def test_boundary_flags_review_when_pages_missing(self):
+        ea = _import_artifacts()
+        structure = {
+            "blocks": [],
+            "sections": [{"section_id": "sec_x", "title": "x", "level": 1,
+                          "order": 0, "page_start": None, "page_end": None}],
+            "metadata": {},
+        }
+        b = ea.build_document_boundary(structure, document_id="doc_002")
+        assert b["needs_review"] is True
+        assert b["review_reason"]
+
+
+# ---------------------------------------------------------------------------
+# Course / topic enrichment
+# ---------------------------------------------------------------------------
+
+class TestCourseEnrichment:
+    def test_topic_metadata_gets_pulled_from_course_mapping_and_blueprint(self):
+        ea = _import_artifacts()
+        course = {
+            "topics": [
+                {"title": "Newton's law", "description": "...", "prerequisites": ["calc"]},
+            ],
+        }
+        mapping = {
+            "topics": [{
+                "title": "Newton's law",
+                "learning_objectives": ["state F=ma"],
+                "prerequisite_concepts": ["calc", "force_concept"],
+                "blackbox_policy": {"show_derivation": ["eq_001"], "blackbox": []},
+                "assessment_prompts": ["Derive F=ma."],
+                "expected_misconceptions": ["confuse mass with weight"],
+            }],
+        }
+        blueprint = {"narrative_arc": [
+            {"step": 1, "role": "problem_setup", "visual_strategy": "schematic",
+             "rationale": "intro", "linked_component_ids": ["comp_1"]},
+            {"step": 2, "role": "core_relation", "visual_strategy": "equation_map",
+             "rationale": "main eq", "linked_component_ids": ["comp_2"]},
+        ]}
+        enriched = ea.enrich_course_topics(course,
+            course_mapping_artifact=mapping, blueprint_artifact=blueprint)
+        topic = enriched["topics"][0]
+        assert topic["learning_objectives"] == ["state F=ma"]
+        assert topic["prerequisite_concepts"] == ["calc", "force_concept"]
+        assert topic["blackbox_policy"]["show_derivation"] == ["eq_001"]
+        assert topic["assessment_prompts"] == ["Derive F=ma."]
+        assert topic["expected_misconceptions"] == ["confuse mass with weight"]
+        assert len(topic["visualization_plan"]) == 2
+
+    def test_topics_without_artifacts_keep_existing_fields(self):
+        ea = _import_artifacts()
+        course = {"topics": [{"title": "T", "description": "d", "prerequisites": ["x"]}]}
+        enriched = ea.enrich_course_topics(course)
+        topic = enriched["topics"][0]
+        assert topic["title"] == "T"
+        assert topic["learning_objectives"] == []
+        assert topic["prerequisite_concepts"] == ["x"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ZIP bundle includes new artifacts
+# ---------------------------------------------------------------------------
+
+class TestExportZipNewArtifacts:
+    def _make_zip(self):
+        mod = _import_export_module()
+        manifest = mod._build_manifest(
+            export_id="x",
+            scope_type="course",
+            scope_id="c",
+            material_ids=[],
+            document_ids=["doc_001"],
+            claims=[],
+            dsl_graph={"nodes": [], "edges": []},
+            components=[],
+            component_graph={"nodes": [], "edges": []},
+            evidence_snippets=[],
+            equations=[{"equation_id": "eq_1"}],
+            equation_candidates=[{"candidate_id": "eqcand_eq_1"}],
+            derivation_chains=[{"derivation_id": "deriv_1"}],
+            document_boundaries=[{"document_id": "doc_001"}],
+            options={},
+        )
+        return mod._build_zip(
+            manifest=manifest,
+            claims=[],
+            dsl_graph={"nodes": [], "edges": []},
+            components=[],
+            component_graph={"nodes": [], "edges": []},
+            evidence_snippets=[],
+            equations=[{"equation_id": "eq_1"}],
+            equation_candidates=[{"candidate_id": "eqcand_eq_1"}],
+            derivation_chains=[{"derivation_id": "deriv_1"}],
+            document_boundaries=[{"document_id": "doc_001"}],
+        )
+
+    def test_zip_includes_new_files(self):
+        zip_bytes = self._make_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+        for name in (
+            "equations/equations.json",
+            "equations/equation_candidates.json",
+            "derivations/derivation_chains.json",
+            "document_boundary.json",
+        ):
+            assert name in names, f"missing {name}"
+
+    def test_manifest_counts_include_new_artifacts(self):
+        zip_bytes = self._make_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            manifest = json.loads(zf.read("manifest.json"))
+        for key in (
+            "equations", "equation_candidates", "derivation_chains",
+            "document_boundaries",
+        ):
+            assert key in manifest["counts"], f"missing count: {key}"
+        for key in (
+            "equations", "equation_candidates", "derivation_chains",
+            "document_boundary",
+        ):
+            assert key in manifest["files"], f"missing file index: {key}"
+
+    def test_readme_describes_new_artifacts(self):
+        zip_bytes = self._make_zip()
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            readme = zf.read("README.md").decode("utf-8")
+        assert "equations.json" in readme
+        assert "equation_candidates.json" in readme
+        assert "derivation_chains.json" in readme
+        assert "document_boundary.json" in readme

--- a/backend/tests/test_export_bundle.py
+++ b/backend/tests/test_export_bundle.py
@@ -145,7 +145,7 @@ class TestExportManifest:
         )
 
         assert "export_schema_version" in manifest
-        assert manifest["export_schema_version"] == "0.1.0"
+        assert manifest["export_schema_version"] == "0.2.0"
         assert "exported_at" in manifest
         assert "scope" in manifest
         assert manifest["scope"]["type"] == "course"


### PR DESCRIPTION
## Summary

Implements issue #242 acceptance criteria by surfacing agent pipeline artifacts in the export bundle as first-class JSON files. Adds helpers to extract and transform equations, equation candidates, evidence snippets, derivation chains, and document boundaries from the `document_analysis_runs.stage_outputs._artifacts` JSONB column into structured export formats.

## Key Changes

- **New module `backend/api/routes/export_artifacts.py`**: Purely functional helpers for composing export artifacts without coupling to SQLAlchemy or the orchestrator
  - `build_equations_export()`: Converts `equation_semantics` artifact into first-class equation registry with `latex`, `plain_text`, `source_location`, `equation_type`, `defined_symbols`, `used_symbols`, derivation links, extraction provenance, and review flags
  - `build_equation_candidates_export()`: Reconstructs audit trail from equation records and document structure, tracking accepted vs. rejected candidates with detection methods and rejection reasons
  - `build_evidence_export()`: Surfaces source-backed evidence from `evidence_registry` artifact, with fallback to claim-derived evidence marked as unverified; keeps PDF-derived `evidence_text` separate from LLM `analysis_note`/`review_note`
  - `build_derivation_chains_export()`: Exposes step-level operations, inputs, outputs, and assumptions; falls back to equation `derivation_links` when dedicated artifact unavailable
  - `build_document_boundary()`: Records active article boundary (page ranges, confidence) for multi-article PDFs
  - `enrich_course_topics()`: Adds learning objectives, prerequisites, blackbox policy, assessment prompts, and visualization plan from course mapping and blueprint artifacts

- **Updated `backend/api/routes/export.py`**:
  - Added imports for new artifact helpers
  - New helper functions to load analysis artifacts from database and build export collections per document
  - Updated `_build_manifest()` to include new artifact counts and file paths; bumped schema version to `0.2.0`
  - Updated `_build_zip()` to write new JSON files: `equations/equations.json`, `equations/equation_candidates.json`, `derivations/derivation_chains.json`, `document_boundary.json`
  - Updated README template to document new artifact files and their schemas

- **Comprehensive test suite `backend/tests/test_export_artifacts.py`**:
  - Tests for equations export with required fields, review flags, and symbol tracking
  - Tests for equation candidate trace (accepted vs. rejected)
  - Tests for evidence export with source-backed vs. reconstructed entries
  - Tests for derivation chain passthrough and fallback reconstruction
  - Tests for document boundary detection
  - Tests for course/topic metadata enrichment
  - End-to-end ZIP bundle tests verifying new files and manifest counts

## Notable Implementation Details

- **Defensive parsing**: All artifact access uses `_coerce_dict()` to tolerate missing/malformed JSONB payloads; callers can chain calls without guarding every access
- **Source-backed evidence contract**: Keeps PDF-derived text (`evidence_text`) separate from LLM analysis (`analysis_note`/`review_note`); marks reconstructed evidence with `needs_review=true` and `extraction_status=reconstructed`
- **Extraction provenance**: Equations track `extraction_source` (pdf_text_layer vs. llm_reconstruction) and `extraction_status` (parsed, partially_parsed, reconstructed, unparsed)
- **Audit trails**: Equation candidates include detection methods, acceptance status, and rejection reasons; derivation steps include confidence scores and reasoning
- **Fallback strategies**: When dedicated artifacts unavailable, reconstructs minimal traces from related artifacts (e.g., derivation chains from equation `derivation_links`)
- **Multi-document support**: Artifact loading queries most recent run per document; course enrichment picks first document's mapping/blueprint for single-paper scoped courses

https://claude.ai/code/session_01R9uDUvwqrmhErCcYXyfcb1