### PR TITLE
Add ExportValidationGate for deterministic cross-artifact validation

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -1,0 +1,407 @@
+"""ExportValidationGate — deterministic cross-artifact validation before persist.
+
+Aggregates validation_issues from all stage artifacts, runs cross-artifact ID
+checks, and decides whether the pipeline result is exportable.
+
+Status values:
+  passed              — no errors, no warnings
+  passed_with_warnings — no errors, has warnings
+  needs_review        — review items present but no hard errors
+  failed_validation   — has hard errors → persist / completed are blocked
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+EXPORT_STATUSES = [
+    "passed",
+    "passed_with_warnings",
+    "needs_review",
+    "failed_validation",
+]
+
+
+@dataclass
+class ValidationEntry:
+    code: str
+    message: str
+    artifact: str
+    path: str | None = None
+    source_stage: str | None = None
+
+
+@dataclass
+class ValidationSummary:
+    error_count: int = 0
+    warning_count: int = 0
+    review_required_count: int = 0
+
+
+@dataclass
+class ExportValidationResult:
+    status: str                          # one of EXPORT_STATUSES
+    exportable: bool
+    publish_ready: bool
+    errors: list[ValidationEntry] = field(default_factory=list)
+    warnings: list[ValidationEntry] = field(default_factory=list)
+    review_items: list[ValidationEntry] = field(default_factory=list)
+    summary: ValidationSummary = field(default_factory=ValidationSummary)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+# Severity → bucket mapping
+_SEVERITY_ERROR = "error"
+_SEVERITY_WARNING = "warning"
+
+# Rule IDs that represent hard errors from ComponentAssembly
+_HARD_ERROR_RULE_IDS = {
+    "unresolved_claim_id",
+    "unresolved_evidence_id",
+    "unresolved_equation_id",
+    "unresolved_dsl_node_id",
+    "unresolved_dsl_edge_id",
+    "no_components",
+    "component_assembly_failed",
+    "invalid_component_type",
+    "internal_flow_invalid_entry",
+    "internal_flow_incomplete_step",
+}
+
+# Rule IDs that always need_review (but not necessarily hard error)
+_NEEDS_REVIEW_RULE_IDS = {
+    "summary_only_component",
+    "boundary_needs_review",
+    "review_required_claim_in_component",
+}
+
+# Stage names where validation_issues with severity=error are hard errors
+_HARD_ERROR_STAGES = {
+    "component_assembly",
+    "course_mapping",
+    "dsl_linking",
+    "claim_object_builder",
+    "evidence_registry",
+}
+
+# Stage names where validation_issues are always warnings/review
+_SOFT_STAGES = {
+    "equation_semantics",
+    "rhetorical_role",
+    "figure_table_semantics",
+    "derivation_chain",
+    "blueprint",
+}
+
+
+class ExportValidationGate:
+    """Deterministic gate run after Blueprint and before Persist."""
+
+    def run(
+        self,
+        *,
+        artifacts: dict,
+        component_result=None,
+        course_mapping=None,
+        claim_objects=None,
+        evidence=None,
+        dsl=None,
+    ) -> ExportValidationResult:
+        errors: list[ValidationEntry] = []
+        warnings: list[ValidationEntry] = []
+        review_items: list[ValidationEntry] = []
+
+        # 1. Aggregate validation_issues from all stage artifacts
+        self._aggregate_artifact_issues(
+            artifacts, errors, warnings, review_items
+        )
+
+        # 2. Cross-artifact ID validation
+        if component_result and claim_objects and evidence:
+            self._cross_validate_component_ids(
+                component_result, claim_objects, evidence, dsl,
+                errors, warnings,
+            )
+
+        # 3. Course mapping → component ID resolution
+        if course_mapping and component_result:
+            self._cross_validate_course_mapping(
+                course_mapping, component_result, errors, warnings,
+            )
+
+        # 4. DSL graph edge completeness
+        if dsl:
+            self._check_dsl_edges(dsl, errors, warnings)
+
+        # 5. Required artifact presence
+        self._check_required_artifacts(artifacts, errors)
+
+        # 6. Determine status
+        summary = ValidationSummary(
+            error_count=len(errors),
+            warning_count=len(warnings),
+            review_required_count=len(review_items),
+        )
+
+        if errors:
+            status = "failed_validation"
+            exportable = False
+            publish_ready = False
+        elif review_items:
+            status = "needs_review"
+            exportable = True
+            publish_ready = False
+        elif warnings:
+            status = "passed_with_warnings"
+            exportable = True
+            publish_ready = False
+        else:
+            status = "passed"
+            exportable = True
+            publish_ready = True
+
+        return ExportValidationResult(
+            status=status,
+            exportable=exportable,
+            publish_ready=publish_ready,
+            errors=errors,
+            warnings=warnings,
+            review_items=review_items,
+            summary=summary,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _aggregate_artifact_issues(
+        self,
+        artifacts: dict,
+        errors: list,
+        warnings: list,
+        review_items: list,
+    ) -> None:
+        """Walk stage artifacts and collect their validation_issues."""
+        for stage, artifact in artifacts.items():
+            if stage.startswith("_") or not isinstance(artifact, dict):
+                continue
+            issues = artifact.get("validation_issues") or []
+            for issue in issues:
+                code = issue.get("rule_id") or issue.get("code") or "unknown"
+                severity = issue.get("severity", "warning")
+                message = issue.get("message", "")
+                path = issue.get("field") or issue.get("path")
+
+                entry = ValidationEntry(
+                    code=code,
+                    message=message,
+                    artifact=stage,
+                    path=path,
+                    source_stage=stage,
+                )
+
+                if code in _NEEDS_REVIEW_RULE_IDS:
+                    review_items.append(entry)
+                elif severity == _SEVERITY_ERROR and (
+                    stage in _HARD_ERROR_STAGES or code in _HARD_ERROR_RULE_IDS
+                ):
+                    errors.append(entry)
+                elif severity == _SEVERITY_ERROR:
+                    # errors from soft stages downgraded to warnings
+                    warnings.append(entry)
+                else:
+                    warnings.append(entry)
+
+    def _cross_validate_component_ids(
+        self,
+        component_result,
+        claim_objects,
+        evidence,
+        dsl,
+        errors: list,
+        warnings: list,
+    ) -> None:
+        """Verify Component evidence_refs reference only real artifact IDs."""
+        known_claim_ids: set[str] = {
+            c.claim_id
+            for c in (getattr(claim_objects, "claims", []) or [])
+        }
+        known_evidence_ids: set[str] = {
+            r.evidence_id
+            for r in (getattr(evidence, "records", []) or [])
+        }
+        known_eq_ids: set[str] = set()
+        known_dsl_node_ids: set[str] = set()
+        known_dsl_edge_ids: set[str] = set()
+        if dsl:
+            known_dsl_node_ids = {n.node_id for n in (dsl.nodes or [])}
+            known_dsl_edge_ids = {e.edge_id for e in (dsl.edges or [])}
+
+        for component in getattr(component_result, "components", []) or []:
+            comp_id = component.component_id
+            refs = component.evidence_refs or {}
+
+            for cid in refs.get("claim_ids") or []:
+                if known_claim_ids and cid not in known_claim_ids:
+                    errors.append(ValidationEntry(
+                        code="UNRESOLVED_COMPONENT_CLAIM_ID",
+                        message=f"component {comp_id!r} references missing claim {cid!r}",
+                        artifact="component_assembly",
+                        path=f"$.components[{comp_id}].evidence_refs.claim_ids",
+                        source_stage="export_validation",
+                    ))
+
+            for eid in refs.get("evidence_ids") or []:
+                if known_evidence_ids and eid not in known_evidence_ids:
+                    errors.append(ValidationEntry(
+                        code="UNRESOLVED_COMPONENT_EVIDENCE_ID",
+                        message=f"component {comp_id!r} references missing evidence {eid!r}",
+                        artifact="component_assembly",
+                        path=f"$.components[{comp_id}].evidence_refs.evidence_ids",
+                        source_stage="export_validation",
+                    ))
+
+            dsl_refs = refs.get("dsl_refs") or {}
+            for nid in dsl_refs.get("node_ids") or []:
+                if known_dsl_node_ids and nid not in known_dsl_node_ids:
+                    errors.append(ValidationEntry(
+                        code="UNRESOLVED_DSL_NODE_ID",
+                        message=f"component {comp_id!r} references missing DSL node {nid!r}",
+                        artifact="component_assembly",
+                        path=f"$.components[{comp_id}].evidence_refs.dsl_refs.node_ids",
+                        source_stage="export_validation",
+                    ))
+            for eid in dsl_refs.get("edge_ids") or []:
+                if known_dsl_edge_ids and eid not in known_dsl_edge_ids:
+                    errors.append(ValidationEntry(
+                        code="UNRESOLVED_DSL_EDGE_ID",
+                        message=f"component {comp_id!r} references missing DSL edge {eid!r}",
+                        artifact="component_assembly",
+                        path=f"$.components[{comp_id}].evidence_refs.dsl_refs.edge_ids",
+                        source_stage="export_validation",
+                    ))
+
+            # Warn on summary-only (no claim or evidence)
+            if (
+                not refs.get("claim_ids")
+                and not refs.get("evidence_ids")
+            ):
+                warnings.append(ValidationEntry(
+                    code="SUMMARY_ONLY_COMPONENT",
+                    message=f"component {comp_id!r} has no claim_ids or evidence_ids",
+                    artifact="component_assembly",
+                    path=f"$.components[{comp_id}].evidence_refs",
+                    source_stage="export_validation",
+                ))
+
+    def _cross_validate_course_mapping(
+        self,
+        course_mapping,
+        component_result,
+        errors: list,
+        warnings: list,
+    ) -> None:
+        """Verify CourseMapping topics reference real component IDs."""
+        known_component_ids: set[str] = {
+            c.component_id
+            for c in (getattr(component_result, "components", []) or [])
+        }
+        topics = getattr(course_mapping, "topics", []) or []
+        if isinstance(topics, list):
+            for idx, topic in enumerate(topics):
+                linked = []
+                if isinstance(topic, dict):
+                    linked = topic.get("linked_component_ids") or []
+                else:
+                    linked = getattr(topic, "linked_component_ids", []) or []
+                for comp_id in linked:
+                    if known_component_ids and comp_id not in known_component_ids:
+                        errors.append(ValidationEntry(
+                            code="UNRESOLVED_COMPONENT_ID",
+                            message=f"course topic [{idx}] references missing component {comp_id!r}",
+                            artifact="course_mapping",
+                            path=f"$.topics[{idx}].linked_component_ids",
+                            source_stage="export_validation",
+                        ))
+
+    def _check_dsl_edges(
+        self,
+        dsl,
+        errors: list,
+        warnings: list,
+    ) -> None:
+        """Verify DSL graph edges have non-empty source and target."""
+        node_ids: set[str] = {n.node_id for n in (dsl.nodes or [])}
+        for edge in dsl.edges or []:
+            if not getattr(edge, "from_node_id", None):
+                errors.append(ValidationEntry(
+                    code="EMPTY_GRAPH_EDGE_SOURCE",
+                    message=f"DSL edge {getattr(edge, 'edge_id', '?')} has empty from_node_id",
+                    artifact="dsl_linking",
+                    path="$.edges",
+                    source_stage="export_validation",
+                ))
+            elif node_ids and edge.from_node_id not in node_ids:
+                errors.append(ValidationEntry(
+                    code="UNRESOLVED_GRAPH_EDGE_SOURCE",
+                    message=f"DSL edge {edge.edge_id!r} from_node_id {edge.from_node_id!r} not in nodes",
+                    artifact="dsl_linking",
+                    path=f"$.edges[{edge.edge_id}].from_node_id",
+                    source_stage="export_validation",
+                ))
+            if not getattr(edge, "to_node_id", None):
+                errors.append(ValidationEntry(
+                    code="EMPTY_GRAPH_EDGE_TARGET",
+                    message=f"DSL edge {getattr(edge, 'edge_id', '?')} has empty to_node_id",
+                    artifact="dsl_linking",
+                    path="$.edges",
+                    source_stage="export_validation",
+                ))
+            elif node_ids and edge.to_node_id not in node_ids:
+                errors.append(ValidationEntry(
+                    code="UNRESOLVED_GRAPH_EDGE_TARGET",
+                    message=f"DSL edge {edge.edge_id!r} to_node_id {edge.to_node_id!r} not in nodes",
+                    artifact="dsl_linking",
+                    path=f"$.edges[{edge.edge_id}].to_node_id",
+                    source_stage="export_validation",
+                ))
+
+    def _check_required_artifacts(
+        self,
+        artifacts: dict,
+        errors: list,
+    ) -> None:
+        """Ensure required pipeline stages produced non-empty artifacts."""
+        required_stages = [
+            "document_structure",
+            "source_chunking",
+            "claim_qualification",
+            "component_assembly",
+        ]
+        for stage in required_stages:
+            artifact = artifacts.get(stage)
+            if artifact is None:
+                errors.append(ValidationEntry(
+                    code="MISSING_REQUIRED_ARTIFACT",
+                    message=f"Required artifact for stage {stage!r} is missing",
+                    artifact=stage,
+                    path=f"$.stage_outputs._artifacts.{stage}",
+                    source_stage="export_validation",
+                ))

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -49,6 +49,7 @@ PIPELINE_STAGES = [
     "component_assembly",
     "course_mapping",
     "blueprint",
+    "export_validation",
     "persist_claims_components_graph",
     "completed",
 ]
@@ -584,6 +585,9 @@ def run_document_pipeline(
                 component_result = ca_agent.run(
                     qualified_claims=qualified, equations=equations,
                     thesis=thesis, dsl=dsl, cartridge_id=cartridge_id,
+                    claim_objects=claim_objects,
+                    evidence_registry=evidence,
+                    derivations=derivations,
                 )
             except Exception as exc:
                 logger.exception("component_assembly stage failed for document=%s material=%s", document_id, material_id)
@@ -648,6 +652,71 @@ def run_document_pipeline(
             "total": 1,
             "processed": 1,
         })
+
+        # ── Stage 12d: export_validation ───────────────────────────────────
+        export_validation_artifact = artifact("export_validation")
+        if export_validation_artifact:
+            validation_result_dict = export_validation_artifact
+            logger.info("Resuming document pipeline: loaded export_validation artifact for document %s", document_id)
+        else:
+            report_start("export_validation", total=1, unit="gate")
+            try:
+                from .export_validation_gate import ExportValidationGate
+
+                gate = ExportValidationGate()
+                validation_result = gate.run(
+                    artifacts=dict(previous_artifacts),
+                    component_result=component_result,
+                    course_mapping=course_mapping,
+                    claim_objects=claim_objects,
+                    evidence=evidence,
+                    dsl=dsl,
+                )
+                validation_result_dict = validation_result.to_dict()
+            except Exception as exc:
+                logger.exception(
+                    "export_validation stage failed (non-fatal): document=%s material=%s error=%s",
+                    document_id, material_id, exc,
+                )
+                validation_result_dict = {
+                    "status": "passed_with_warnings",
+                    "exportable": True,
+                    "publish_ready": False,
+                    "errors": [],
+                    "warnings": [{"code": "GATE_ERROR", "message": str(exc), "artifact": "export_validation"}],
+                    "review_items": [],
+                    "summary": {"error_count": 0, "warning_count": 1, "review_required_count": 0},
+                }
+            save_artifact("export_validation", validation_result_dict)
+        report_done("export_validation", {
+            "status": validation_result_dict.get("status"),
+            "error_count": (validation_result_dict.get("summary") or {}).get("error_count", 0),
+            "warning_count": (validation_result_dict.get("summary") or {}).get("warning_count", 0),
+            "total": 1,
+            "processed": 1,
+        })
+
+        # Block persist / completed if validation failed
+        if validation_result_dict.get("status") == "failed_validation":
+            error_count = (validation_result_dict.get("summary") or {}).get("error_count", 0)
+            upsert_analysis_run(
+                run_id=run_id,
+                document_id=document_id,
+                material_id=material_id,
+                cartridge_id=cartridge_id,
+                status="failed",
+                current_stage="export_validation",
+                error_message=f"ExportValidationGate: {error_count} hard error(s) found; persist blocked",
+            )
+            result.final_stage = "export_validation"
+            logger.warning(
+                "ExportValidationGate blocked persist for document=%s: %d error(s)",
+                document_id, error_count,
+            )
+            raise PipelineStageError(
+                "export_validation",
+                f"Validation failed with {error_count} hard error(s); see export_validation artifact",
+            )
 
         # ── Stage 13: persist_claims_components_graph ──────────────────────
         report_start("persist_claims_components_graph", total=3, unit="tables")

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -42,6 +42,9 @@ class ComponentAssemblyAgent:
         dsl: DSLLinkingResult | None = None,
         cartridge_id: str | None = None,
         config: dict | None = None,
+        claim_objects=None,
+        evidence_registry=None,
+        derivations=None,
     ) -> ComponentAssemblyResult:
         cartridge = self._load_cartridge(cartridge_id)
         llm_input = self._input_builder.build(
@@ -51,6 +54,9 @@ class ComponentAssemblyAgent:
             dsl=dsl,
             cartridge=cartridge,
             config=config,
+            claim_objects=claim_objects,
+            evidence_registry=evidence_registry,
+            derivations=derivations,
         )
         messages = self._prompt_factory.build_messages(llm_input)
         try:
@@ -63,7 +69,7 @@ class ComponentAssemblyAgent:
         result = self._cleanup.cleanup(
             _parse_raw(raw_output, qualified_claims.document_id, llm_input.cartridge_id)
         )
-        issues = self._validator.validate(result, cartridge)
+        issues = self._validator.validate(result, cartridge, llm_input=llm_input)
         if [i for i in issues if i.severity == "error"]:
             result = self._repairer.repair(
                 llm_input=llm_input,

--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -29,6 +29,9 @@ class ComponentAssemblyInputBuilder:
         dsl: DSLLinkingResult | None = None,
         cartridge: CartridgeContext | None = None,
         config: dict | None = None,
+        claim_objects=None,
+        evidence_registry=None,
+        derivations=None,
     ) -> ComponentAssemblyLLMInput:
         cfg = config or {}
         return ComponentAssemblyLLMInput(
@@ -46,6 +49,12 @@ class ComponentAssemblyInputBuilder:
             allowed_component_types=self.allowed_component_types(cartridge),
             allowed_dependency_types=self.allowed_dependency_types(cartridge),
             normalized_terms=self._normalized_terms(cartridge) if cartridge else None,
+            available_claims=self._available_claims(claim_objects),
+            available_evidence=self._available_evidence(evidence_registry),
+            available_equations=self._available_equations_index(equations),
+            available_dsl_nodes=self._available_dsl_nodes(dsl),
+            available_dsl_edges=self._available_dsl_edges(dsl),
+            available_derivation_ids=self._available_derivation_ids(derivations),
         )
 
     @staticmethod
@@ -179,3 +188,78 @@ class ComponentAssemblyInputBuilder:
             for canonical, aliases in cartridge.aliases.items():
                 terms.append({"canonical": canonical, "aliases": aliases})
         return terms
+
+    @staticmethod
+    def _available_claims(claim_objects) -> list[dict]:
+        """Build available claim ID list from ClaimObjectBuildResult."""
+        if not claim_objects:
+            return []
+        result = []
+        for claim in getattr(claim_objects, "claims", []) or []:
+            result.append({
+                "claim_id": claim.claim_id,
+                "claim_type": claim.claim_type,
+                "text": claim.text[:200],
+                "source_evidence_ids": list(claim.source_evidence_ids or []),
+                "equation_ids": list(claim.equation_ids or []),
+                "support_status": claim.support_status,
+                "review_status": claim.review_status,
+            })
+        return result
+
+    @staticmethod
+    def _available_evidence(evidence_registry) -> list[dict]:
+        """Build available evidence ID list from EvidenceRegistryResult."""
+        if not evidence_registry:
+            return []
+        result = []
+        for record in getattr(evidence_registry, "records", []) or []:
+            src = getattr(record, "source", None)
+            result.append({
+                "evidence_id": record.evidence_id,
+                "block_id": src.block_id if src else None,
+                "evidence_role": record.evidence_role,
+            })
+        return result
+
+    @staticmethod
+    def _available_equations_index(equations) -> list[dict]:
+        """Build available equation ID list from EquationSemanticsResult."""
+        if not equations:
+            return []
+        result = []
+        for record in getattr(equations, "equations", []) or []:
+            result.append({
+                "equation_id": record.equation_id,
+                "block_id": record.block_id,
+                "role": record.equation_role.primary,
+                "confidence": record.equation_role.confidence,
+            })
+        return result
+
+    @staticmethod
+    def _available_dsl_nodes(dsl) -> list[dict]:
+        if not dsl:
+            return []
+        return [{"node_id": n.node_id} for n in dsl.nodes]
+
+    @staticmethod
+    def _available_dsl_edges(dsl) -> list[dict]:
+        if not dsl:
+            return []
+        return [{"edge_id": e.edge_id} for e in dsl.edges]
+
+    @staticmethod
+    def _available_derivation_ids(derivations) -> list[str]:
+        if not derivations:
+            return []
+        ids = []
+        for chain in getattr(derivations, "chains", []) or []:
+            chain_id = getattr(chain, "chain_id", None)
+            if chain_id:
+                ids.append(chain_id)
+            for step in getattr(chain, "steps", []) or []:
+                step_id = getattr(step, "step_id", None)
+                if step_id:
+                    ids.append(step_id)
+        return ids

--- a/src/episteme_graph/agents/component_assembly/prompt.py
+++ b/src/episteme_graph/agents/component_assembly/prompt.py
@@ -20,6 +20,15 @@ Important constraints:
 - Use accepted claims, equation semantics, thesis structure, and DSL graph evidence.
 - Do not let prior work or meta discourse dominate component cores.
 
+ID constraints (CRITICAL):
+- For evidence_refs.claim_ids: use ONLY IDs from available_claims list.
+- For evidence_refs.evidence_ids: use ONLY IDs from available_evidence list.
+- For evidence_refs.equation_ids: use ONLY IDs from available_equations list.
+- For evidence_refs.dsl_refs.node_ids: use ONLY IDs from available_dsl_nodes list.
+- For evidence_refs.dsl_refs.edge_ids: use ONLY IDs from available_dsl_edges list.
+- Do NOT generate, invent, or guess IDs not present in the available_* lists.
+- A source-backed component MUST have at least one claim_id or evidence_id in evidence_refs.
+
 internal_flow requirement:
 - For RelationComponent / PaperRelationComponent / CorrectionComponent /
   DiagnosticComponent / MethodComponent, internal_flow MUST NOT be empty.
@@ -110,11 +119,26 @@ class ComponentAssemblyPromptFactory:
             "dsl_edges": llm_input.dsl_edges,
             "normalized_terms": llm_input.normalized_terms,
         }
-        return "\n".join([
+        available = {
+            "available_claims": llm_input.available_claims,
+            "available_evidence": llm_input.available_evidence,
+            "available_equations": llm_input.available_equations,
+            "available_dsl_nodes": llm_input.available_dsl_nodes,
+            "available_dsl_edges": llm_input.available_dsl_edges,
+            "available_derivation_ids": llm_input.available_derivation_ids,
+        }
+        parts = [
             "## Task",
             "Assemble reusable knowledge components. Return ONLY JSON.",
             "\n## Input Materials",
             json.dumps(payload, ensure_ascii=False, indent=2),
+        ]
+        if any(v for v in available.values()):
+            parts += [
+                "\n## Available Artifact IDs (use ONLY these IDs in evidence_refs)",
+                json.dumps(available, ensure_ascii=False, indent=2),
+            ]
+        parts += [
             "\n## Allowed Component Types",
             ", ".join(llm_input.allowed_component_types),
             "\n## Allowed Dependency Types",
@@ -126,9 +150,12 @@ class ComponentAssemblyPromptFactory:
             "\n## Constraints",
             "- Avoid section-summary components\n"
             "- Each strong component should include evidence_refs\n"
+            "- Use ONLY IDs from the available_* lists above in evidence_refs\n"
+            "- Do NOT invent or guess IDs not present in available_* lists\n"
             "- Derivation-like components need outputs and usually preconditions\n"
             "- Correction/uncertainty/diagnostic components should remain distinct when evidence supports separation\n"
             "- Relation/Correction/Diagnostic/Method components MUST include internal_flow\n"
             "- internal_flow explains how inputs are combined/transformed into outputs\n"
             "- Return ONLY valid JSON, no markdown fences",
-        ])
+        ]
+        return "\n".join(parts)

--- a/src/episteme_graph/agents/component_assembly/repair.py
+++ b/src/episteme_graph/agents/component_assembly/repair.py
@@ -43,7 +43,7 @@ class ComponentAssemblyRepairer:
                 logger.warning("Repair LLM call failed: %s", exc)
                 break
             result = self._cleanup.cleanup(_parse_raw(raw_output, llm_input.document_id, llm_input.cartridge_id))
-            remaining = validator.validate(result, cartridge)  # type: ignore[attr-defined]
+            remaining = validator.validate(result, cartridge, llm_input=llm_input)  # type: ignore[attr-defined]
             if not [i for i in remaining if i.severity == "error"]:
                 result.validation_issues = remaining
                 return result

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -60,6 +60,13 @@ class ComponentAssemblyLLMInput:
     allowed_component_types: list[str]
     allowed_dependency_types: list[str]
     normalized_terms: list[dict] | None = None
+    # Deterministic artifact ID lists for cross-reference validation
+    available_claims: list[dict] = field(default_factory=list)
+    available_evidence: list[dict] = field(default_factory=list)
+    available_equations: list[dict] = field(default_factory=list)
+    available_dsl_nodes: list[dict] = field(default_factory=list)
+    available_dsl_edges: list[dict] = field(default_factory=list)
+    available_derivation_ids: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/episteme_graph/agents/component_assembly/validator.py
+++ b/src/episteme_graph/agents/component_assembly/validator.py
@@ -8,10 +8,25 @@ from .schema import (
     CORE_DEPENDENCY_TYPES,
     INTERNAL_FLOW_REQUIRED_TYPES,
     CartridgeContext,
+    ComponentAssemblyLLMInput,
     ComponentAssemblyResult,
     ComponentRecord,
     ValidationIssue,
 )
+
+
+def _build_available_id_index(llm_input: ComponentAssemblyLLMInput | None) -> dict[str, set[str]]:
+    """Build a dict of available ID sets from the LLM input for cross-reference validation."""
+    if not llm_input:
+        return {}
+    return {
+        "claim_ids": {c["claim_id"] for c in (llm_input.available_claims or []) if c.get("claim_id")},
+        "evidence_ids": {e["evidence_id"] for e in (llm_input.available_evidence or []) if e.get("evidence_id")},
+        "equation_ids": {e["equation_id"] for e in (llm_input.available_equations or []) if e.get("equation_id")},
+        "dsl_node_ids": {n["node_id"] for n in (llm_input.available_dsl_nodes or []) if n.get("node_id")},
+        "dsl_edge_ids": {e["edge_id"] for e in (llm_input.available_dsl_edges or []) if e.get("edge_id")},
+        "derivation_ids": set(llm_input.available_derivation_ids or []),
+    }
 
 
 class ComponentAssemblyValidator:
@@ -19,6 +34,7 @@ class ComponentAssemblyValidator:
         self,
         result: ComponentAssemblyResult,
         cartridge: CartridgeContext | None = None,
+        llm_input: ComponentAssemblyLLMInput | None = None,
     ) -> list[ValidationIssue]:
         issues: list[ValidationIssue] = []
         if not result.components:
@@ -27,10 +43,13 @@ class ComponentAssemblyValidator:
         allowed_components = set(ComponentAssemblyInputBuilder.allowed_component_types(cartridge))
         allowed_dependencies = set(ComponentAssemblyInputBuilder.allowed_dependency_types(cartridge))
         component_ids = {c.component_id for c in result.components}
+        available = _build_available_id_index(llm_input)
 
         for component in result.components:
             issues += self._check_component(component, allowed_components, allowed_dependencies, component_ids)
             issues += self._check_required_fields(component, cartridge)
+            if available:
+                issues += self._check_id_references(component, available)
         issues += self._check_hints(result, component_ids)
         issues += self._check_duplicates(result)
         if not (0.0 <= result.confidence <= 1.0):
@@ -144,6 +163,103 @@ class ComponentAssemblyValidator:
                 f"{component.component_id} has multiple inputs/outputs but no internal_flow",
                 f"components[{component.component_id}].internal_flow",
             ))
+        return issues
+
+    def _check_id_references(
+        self,
+        component: ComponentRecord,
+        available: dict[str, set[str]],
+    ) -> list[ValidationIssue]:
+        """Cross-reference evidence_refs against known artifact IDs."""
+        issues: list[ValidationIssue] = []
+        refs = component.evidence_refs or {}
+
+        # Check claim_ids
+        known_claims = available.get("claim_ids", set())
+        if known_claims:
+            unknown = [cid for cid in (refs.get("claim_ids") or []) if cid not in known_claims]
+            for cid in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_claim_id",
+                    "error",
+                    f"{component.component_id}.evidence_refs.claim_ids contains unresolved ID: {cid!r}",
+                    f"components[{component.component_id}].evidence_refs.claim_ids",
+                ))
+
+        # Check evidence_ids
+        known_evidence = available.get("evidence_ids", set())
+        if known_evidence:
+            unknown = [eid for eid in (refs.get("evidence_ids") or []) if eid not in known_evidence]
+            for eid in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_evidence_id",
+                    "error",
+                    f"{component.component_id}.evidence_refs.evidence_ids contains unresolved ID: {eid!r}",
+                    f"components[{component.component_id}].evidence_refs.evidence_ids",
+                ))
+
+        # Check equation_ids
+        known_equations = available.get("equation_ids", set())
+        if known_equations:
+            unknown = [eqid for eqid in (refs.get("equation_ids") or []) if eqid not in known_equations]
+            for eqid in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_equation_id",
+                    "error",
+                    f"{component.component_id}.evidence_refs.equation_ids contains unresolved ID: {eqid!r}",
+                    f"components[{component.component_id}].evidence_refs.equation_ids",
+                ))
+
+        # Check DSL node/edge refs
+        dsl_refs = refs.get("dsl_refs") or {}
+        known_dsl_nodes = available.get("dsl_node_ids", set())
+        if known_dsl_nodes:
+            unknown = [nid for nid in (dsl_refs.get("node_ids") or []) if nid not in known_dsl_nodes]
+            for nid in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_dsl_node_id",
+                    "error",
+                    f"{component.component_id}.evidence_refs.dsl_refs.node_ids contains unresolved ID: {nid!r}",
+                    f"components[{component.component_id}].evidence_refs.dsl_refs.node_ids",
+                ))
+        known_dsl_edges = available.get("dsl_edge_ids", set())
+        if known_dsl_edges:
+            unknown = [eid for eid in (dsl_refs.get("edge_ids") or []) if eid not in known_dsl_edges]
+            for eid in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_dsl_edge_id",
+                    "error",
+                    f"{component.component_id}.evidence_refs.dsl_refs.edge_ids contains unresolved ID: {eid!r}",
+                    f"components[{component.component_id}].evidence_refs.dsl_refs.edge_ids",
+                ))
+
+        # Detect summary-only component: no claim_ids and no evidence_ids
+        has_claim_link = bool(refs.get("claim_ids"))
+        has_evidence_link = bool(refs.get("evidence_ids"))
+        if not has_claim_link and not has_evidence_link:
+            issues.append(ValidationIssue(
+                "summary_only_component",
+                "warning",
+                f"{component.component_id} has no claim_ids or evidence_ids in evidence_refs (summary-only)",
+                f"components[{component.component_id}].evidence_refs",
+            ))
+
+        # Propagate review_status: if any referenced claim has non-auto review, flag component
+        known_claim_reviews = available.get("_claim_review_map", {})
+        if known_claim_reviews:
+            for cid in refs.get("claim_ids") or []:
+                review = known_claim_reviews.get(cid)
+                if review and review != "auto_accepted":
+                    comp_review = getattr(component, "review_notes", []) or []
+                    if not any("teacher_review" in n for n in comp_review):
+                        issues.append(ValidationIssue(
+                            "review_required_claim_in_component",
+                            "warning",
+                            f"{component.component_id} references claim {cid!r} with review_status={review!r}",
+                            f"components[{component.component_id}].evidence_refs.claim_ids",
+                        ))
+                        break
+
         return issues
 
     def _check_required_fields(

--- a/src/tests/agents/component_assembly/test_validator.py
+++ b/src/tests/agents/component_assembly/test_validator.py
@@ -144,3 +144,165 @@ def test_cartridge_component_and_relation_types_are_allowed():
         dependencies=[{"dependency_type": "requires", "component_refs": [], "reason": "cartridge relation"}],
     )
     assert not [i for i in VALIDATOR.validate(_result(components=[component]), cartridge) if i.severity == "error"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for cross-reference ID validation (issue #249)
+# ---------------------------------------------------------------------------
+
+from episteme_graph.agents.component_assembly.schema import ComponentAssemblyLLMInput
+from episteme_graph.agents.component_assembly.validator import _build_available_id_index
+
+
+def _make_llm_input(
+    available_claims=None,
+    available_evidence=None,
+    available_equations=None,
+    available_dsl_nodes=None,
+    available_dsl_edges=None,
+):
+    return ComponentAssemblyLLMInput(
+        document_id="doc",
+        cartridge_id=None,
+        accepted_claims=[],
+        equations=[],
+        thesis_nodes=[],
+        dsl_nodes=[],
+        dsl_edges=[],
+        allowed_component_types=["RelationComponent"],
+        allowed_dependency_types=["requires"],
+        available_claims=available_claims or [],
+        available_evidence=available_evidence or [],
+        available_equations=available_equations or [],
+        available_dsl_nodes=available_dsl_nodes or [],
+        available_dsl_edges=available_dsl_edges or [],
+    )
+
+
+def test_valid_linkage_no_errors():
+    """Component referencing real IDs → no cross-reference errors."""
+    llm_input = _make_llm_input(
+        available_claims=[{"claim_id": "claim_span_001"}],
+        available_evidence=[{"evidence_id": "ev_0001"}],
+        available_equations=[{"equation_id": "eq_001"}],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": ["claim_span_001"],
+            "evidence_ids": ["ev_0001"],
+            "equation_ids": ["eq_001"],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]), llm_input=llm_input)
+    cross_errors = [i for i in issues if i.rule_id in (
+        "unresolved_claim_id", "unresolved_evidence_id", "unresolved_equation_id"
+    )]
+    assert cross_errors == []
+
+
+def test_unresolved_claim_id_is_error():
+    """Component referencing a non-existent claim ID → unresolved_claim_id error."""
+    llm_input = _make_llm_input(
+        available_claims=[{"claim_id": "claim_real"}],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": ["claim_MISSING"],
+            "evidence_ids": [],
+            "equation_ids": [],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]), llm_input=llm_input)
+    error_ids = [i.rule_id for i in issues if i.severity == "error"]
+    assert "unresolved_claim_id" in error_ids
+
+
+def test_unresolved_evidence_id_is_error():
+    """Component referencing a non-existent evidence ID → unresolved_evidence_id error."""
+    llm_input = _make_llm_input(
+        available_evidence=[{"evidence_id": "ev_real"}],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": [],
+            "evidence_ids": ["ev_MISSING"],
+            "equation_ids": [],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]), llm_input=llm_input)
+    error_ids = [i.rule_id for i in issues if i.severity == "error"]
+    assert "unresolved_evidence_id" in error_ids
+
+
+def test_unresolved_equation_id_is_error():
+    """Component referencing a non-existent equation ID → unresolved_equation_id error."""
+    llm_input = _make_llm_input(
+        available_equations=[{"equation_id": "eq_real"}],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": [],
+            "evidence_ids": [],
+            "equation_ids": ["eq_MISSING"],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]), llm_input=llm_input)
+    error_ids = [i.rule_id for i in issues if i.severity == "error"]
+    assert "unresolved_equation_id" in error_ids
+
+
+def test_summary_only_component_is_warning():
+    """Component with no claim_ids and no evidence_ids → summary_only_component warning."""
+    llm_input = _make_llm_input(
+        available_claims=[{"claim_id": "claim_real"}],
+        available_evidence=[{"evidence_id": "ev_real"}],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": [],
+            "evidence_ids": [],
+            "equation_ids": [],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]), llm_input=llm_input)
+    warning_ids = [i.rule_id for i in issues if i.severity == "warning"]
+    assert "summary_only_component" in warning_ids
+
+
+def test_no_cross_ref_validation_without_llm_input():
+    """Without llm_input, no cross-reference errors are raised."""
+    component = _component(
+        evidence_refs={
+            "claim_ids": ["any_claim"],
+            "evidence_ids": ["any_ev"],
+            "equation_ids": [],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        }
+    )
+    issues = VALIDATOR.validate(_result(components=[component]))
+    cross_errors = [i for i in issues if i.rule_id in (
+        "unresolved_claim_id", "unresolved_evidence_id"
+    )]
+    assert cross_errors == []
+
+
+def test_build_available_id_index():
+    """_build_available_id_index extracts the correct sets."""
+    llm_input = _make_llm_input(
+        available_claims=[{"claim_id": "c1"}, {"claim_id": "c2"}],
+        available_evidence=[{"evidence_id": "ev1"}],
+        available_equations=[{"equation_id": "eq1"}],
+        available_dsl_nodes=[{"node_id": "n1"}],
+        available_dsl_edges=[{"edge_id": "e1"}],
+    )
+    idx = _build_available_id_index(llm_input)
+    assert idx["claim_ids"] == {"c1", "c2"}
+    assert idx["evidence_ids"] == {"ev1"}
+    assert idx["equation_ids"] == {"eq1"}
+    assert idx["dsl_node_ids"] == {"n1"}
+    assert idx["dsl_edge_ids"] == {"e1"}

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1,0 +1,347 @@
+"""Tests for ExportValidationGate (issue #248)."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import os
+
+import pytest
+
+# Import the gate module directly to avoid pulling in sqlalchemy via __init__.py
+_GATE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "../../../backend/core/document_pipeline/export_validation_gate.py",
+)
+_spec = importlib.util.spec_from_file_location("export_validation_gate", _GATE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["export_validation_gate"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+ExportValidationGate = _mod.ExportValidationGate
+ExportValidationResult = _mod.ExportValidationResult
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+class _DslNode:
+    def __init__(self, node_id: str):
+        self.node_id = node_id
+
+
+class _DslEdge:
+    def __init__(self, edge_id: str, from_node_id: str, to_node_id: str):
+        self.edge_id = edge_id
+        self.from_node_id = from_node_id
+        self.to_node_id = to_node_id
+
+
+class _DslResult:
+    def __init__(self, nodes, edges):
+        self.nodes = nodes
+        self.edges = edges
+
+
+class _ComponentRecord:
+    def __init__(self, component_id: str, evidence_refs: dict | None = None):
+        self.component_id = component_id
+        self.evidence_refs = evidence_refs or {}
+
+
+class _ComponentResult:
+    def __init__(self, components):
+        self.components = components
+
+
+class _ClaimObject:
+    def __init__(self, claim_id: str):
+        self.claim_id = claim_id
+
+
+class _ClaimObjectResult:
+    def __init__(self, claims):
+        self.claims = claims
+
+
+class _EvidenceSource:
+    def __init__(self, block_id: str):
+        self.block_id = block_id
+        self.page = None
+        self.section_id = None
+
+
+class _EvidenceRecord:
+    def __init__(self, evidence_id: str):
+        self.evidence_id = evidence_id
+        self.source = _EvidenceSource("blk_001")
+
+
+class _EvidenceResult:
+    def __init__(self, records):
+        self.records = records
+
+
+class _CourseTopic:
+    def __init__(self, linked_component_ids=None):
+        self.linked_component_ids = linked_component_ids or []
+
+
+class _CourseMappingResult:
+    def __init__(self, topics):
+        self.topics = topics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_artifacts(**kwargs):
+    """Create an artifacts dict with optional stage entries."""
+    base = {
+        "document_structure": {"blocks": [], "sections": []},
+        "source_chunking": [{"text": "chunk"}],
+        "claim_qualification": {"qualified_spans": []},
+        "component_assembly": {"components": [], "validation_issues": []},
+    }
+    base.update(kwargs)
+    return base
+
+
+def _run_gate(artifacts=None, component_result=None, course_mapping=None,
+              claim_objects=None, evidence=None, dsl=None):
+    gate = ExportValidationGate()
+    return gate.run(
+        artifacts=artifacts or _make_artifacts(),
+        component_result=component_result,
+        course_mapping=course_mapping,
+        claim_objects=claim_objects,
+        evidence=evidence,
+        dsl=dsl,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: status determination
+# ---------------------------------------------------------------------------
+
+def test_passed_clean_artifacts():
+    """No issues in any artifact → passed."""
+    result = _run_gate()
+    assert result.status == "passed"
+    assert result.exportable is True
+    assert result.publish_ready is True
+    assert result.errors == []
+    assert result.warnings == []
+
+
+def test_passed_with_warnings_soft_error():
+    """Errors from soft stages are downgraded to warnings."""
+    artifacts = _make_artifacts(
+        equation_semantics={
+            "validation_issues": [
+                {"rule_id": "some_soft_rule", "severity": "error", "message": "soft error"}
+            ]
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert result.status == "passed_with_warnings"
+    assert result.exportable is True
+    assert result.publish_ready is False
+    assert len(result.warnings) == 1
+
+
+def test_failed_validation_hard_error_from_component_assembly():
+    """Errors from component_assembly → failed_validation."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [],
+            "validation_issues": [
+                {"rule_id": "unresolved_claim_id", "severity": "error", "message": "bad ref"}
+            ]
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert result.status == "failed_validation"
+    assert result.exportable is False
+    assert result.publish_ready is False
+    assert result.summary.error_count >= 1
+
+
+def test_needs_review_summary_only():
+    """summary_only_component rule → needs_review."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [],
+            "validation_issues": [
+                {"rule_id": "summary_only_component", "severity": "warning", "message": "no refs"}
+            ]
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert result.status == "needs_review"
+    assert result.exportable is True
+    assert result.publish_ready is False
+    assert result.summary.review_required_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing required artifact
+# ---------------------------------------------------------------------------
+
+def test_missing_required_artifact():
+    """Missing document_structure artifact → failed_validation."""
+    artifacts = _make_artifacts()
+    del artifacts["document_structure"]
+    result = _run_gate(artifacts=artifacts)
+    assert result.status == "failed_validation"
+    codes = [e.code for e in result.errors]
+    assert "MISSING_REQUIRED_ARTIFACT" in codes
+
+
+# ---------------------------------------------------------------------------
+# Tests: cross-artifact component ID resolution
+# ---------------------------------------------------------------------------
+
+def test_component_with_valid_claim_id():
+    """Component referencing a real claim ID → no cross-ref error."""
+    comp = _ComponentRecord("comp_001", {"claim_ids": ["claim_abc"], "evidence_ids": ["ev_001"]})
+    comp_result = _ComponentResult([comp])
+    claims = _ClaimObjectResult([_ClaimObject("claim_abc")])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_001")])
+
+    result = _run_gate(
+        component_result=comp_result,
+        claim_objects=claims,
+        evidence=evidence,
+    )
+    cross_errors = [e for e in result.errors if "UNRESOLVED_COMPONENT_CLAIM_ID" in e.code]
+    assert cross_errors == []
+
+
+def test_component_with_unresolved_claim_id():
+    """Component referencing a non-existent claim ID → cross-ref error."""
+    comp = _ComponentRecord("comp_001", {"claim_ids": ["claim_MISSING"]})
+    comp_result = _ComponentResult([comp])
+    claims = _ClaimObjectResult([_ClaimObject("claim_real")])
+    evidence = _EvidenceResult([])
+
+    result = _run_gate(
+        component_result=comp_result,
+        claim_objects=claims,
+        evidence=evidence,
+    )
+    codes = [e.code for e in result.errors]
+    assert "UNRESOLVED_COMPONENT_CLAIM_ID" in codes
+    assert result.status == "failed_validation"
+
+
+def test_component_with_unresolved_evidence_id():
+    """Component referencing a non-existent evidence ID → cross-ref error."""
+    comp = _ComponentRecord("comp_001", {"evidence_ids": ["ev_MISSING"]})
+    comp_result = _ComponentResult([comp])
+    claims = _ClaimObjectResult([])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_real")])
+
+    result = _run_gate(
+        component_result=comp_result,
+        claim_objects=claims,
+        evidence=evidence,
+    )
+    codes = [e.code for e in result.errors]
+    assert "UNRESOLVED_COMPONENT_EVIDENCE_ID" in codes
+
+
+def test_summary_only_component_cross_validation():
+    """Component with empty claim_ids and evidence_ids → SUMMARY_ONLY_COMPONENT warning."""
+    comp = _ComponentRecord("comp_001", {"claim_ids": [], "evidence_ids": []})
+    comp_result = _ComponentResult([comp])
+    claims = _ClaimObjectResult([_ClaimObject("claim_real")])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_real")])
+
+    result = _run_gate(
+        component_result=comp_result,
+        claim_objects=claims,
+        evidence=evidence,
+    )
+    codes = [w.code for w in result.warnings]
+    assert "SUMMARY_ONLY_COMPONENT" in codes
+
+
+# ---------------------------------------------------------------------------
+# Tests: DSL edge validation
+# ---------------------------------------------------------------------------
+
+def test_dsl_edges_valid():
+    """Valid DSL edges with real node IDs → no error."""
+    nodes = [_DslNode("n1"), _DslNode("n2")]
+    edges = [_DslEdge("e1", "n1", "n2")]
+    dsl = _DslResult(nodes, edges)
+
+    result = _run_gate(dsl=dsl)
+    dsl_errors = [e for e in result.errors if "GRAPH_EDGE" in e.code]
+    assert dsl_errors == []
+
+
+def test_dsl_edge_empty_source():
+    """DSL edge with empty from_node_id → EMPTY_GRAPH_EDGE_SOURCE error."""
+    nodes = [_DslNode("n1")]
+    edges = [_DslEdge("e1", "", "n1")]
+    dsl = _DslResult(nodes, edges)
+
+    result = _run_gate(dsl=dsl)
+    codes = [e.code for e in result.errors]
+    assert "EMPTY_GRAPH_EDGE_SOURCE" in codes
+
+
+def test_dsl_edge_unresolved_target():
+    """DSL edge referencing non-existent to_node_id → UNRESOLVED_GRAPH_EDGE_TARGET error."""
+    nodes = [_DslNode("n1")]
+    edges = [_DslEdge("e1", "n1", "n_MISSING")]
+    dsl = _DslResult(nodes, edges)
+
+    result = _run_gate(dsl=dsl)
+    codes = [e.code for e in result.errors]
+    assert "UNRESOLVED_GRAPH_EDGE_TARGET" in codes
+
+
+# ---------------------------------------------------------------------------
+# Tests: course mapping validation
+# ---------------------------------------------------------------------------
+
+def test_course_mapping_valid_component_id():
+    """Course topic referencing a real component ID → no error."""
+    comp = _ComponentRecord("comp_001")
+    comp_result = _ComponentResult([comp])
+    course = _CourseMappingResult([_CourseTopic(["comp_001"])])
+
+    result = _run_gate(component_result=comp_result, course_mapping=course)
+    codes = [e.code for e in result.errors]
+    assert "UNRESOLVED_COMPONENT_ID" not in codes
+
+
+def test_course_mapping_unresolved_component_id():
+    """Course topic referencing a missing component ID → UNRESOLVED_COMPONENT_ID error."""
+    comp = _ComponentRecord("comp_real")
+    comp_result = _ComponentResult([comp])
+    course = _CourseMappingResult([_CourseTopic(["comp_MISSING"])])
+
+    result = _run_gate(component_result=comp_result, course_mapping=course)
+    codes = [e.code for e in result.errors]
+    assert "UNRESOLVED_COMPONENT_ID" in codes
+
+
+# ---------------------------------------------------------------------------
+# Tests: result structure
+# ---------------------------------------------------------------------------
+
+def test_result_to_dict():
+    """ExportValidationResult.to_dict() returns a plain dict."""
+    result = _run_gate()
+    d = result.to_dict()
+    assert isinstance(d, dict)
+    assert "status" in d
+    assert "exportable" in d
+    assert "errors" in d
+    assert "warnings" in d
+    assert "summary" in d


### PR DESCRIPTION
## Summary
Introduces a deterministic validation gate that runs after the Blueprint stage and before persistence. This gate aggregates validation issues from all pipeline artifacts, performs cross-artifact ID resolution checks, and determines whether the pipeline result is exportable.

## Key Changes

### New ExportValidationGate Module
- **`backend/core/document_pipeline/export_validation_gate.py`**: Core validation gate implementation with:
  - `ExportValidationResult` dataclass defining four export statuses: `passed`, `passed_with_warnings`, `needs_review`, `failed_validation`
  - Deterministic status logic: errors block export, review items allow export but block publishing, warnings allow export
  - Cross-artifact ID validation ensuring components reference only real artifact IDs (claims, evidence, equations, DSL nodes/edges)
  - Course mapping validation verifying topic component references
  - DSL graph edge completeness checks
  - Required artifact presence validation
  - Severity-aware issue aggregation with stage-specific error classification

### Component Assembly Validator Enhancement
- **`src/episteme_graph/agents/component_assembly/validator.py`**: Added cross-reference validation:
  - `_build_available_id_index()` helper to extract available ID sets from LLM input
  - `_check_id_references()` method validating component evidence_refs against known artifact IDs
  - New validation rules: `unresolved_claim_id`, `unresolved_evidence_id`, `unresolved_equation_id`, `unresolved_dsl_node_id`, `unresolved_dsl_edge_id`, `summary_only_component`
  - Comprehensive test coverage for cross-reference validation scenarios

### Component Assembly Input Builder Enhancement
- **`src/episteme_graph/agents/component_assembly/input_builder.py`**: Added artifact ID list building:
  - `_available_claims()` extracts claim metadata from ClaimObjectBuildResult
  - `_available_evidence()` extracts evidence metadata from EvidenceRegistryResult
  - `_available_equations_index()` extracts equation metadata from EquationSemanticsResult
  - `_available_dsl_nodes()` and `_available_dsl_edges()` extract DSL graph structure
  - `_available_derivation_ids()` extracts derivation identifiers
  - These lists are passed to ComponentAssemblyLLMInput for validator use

### Component Assembly Agent & Schema Updates
- **`src/episteme_graph/agents/component_assembly/agent.py`**: Updated `run()` signature to accept `claim_objects`, `evidence_registry`, `derivations` parameters
- **`src/episteme_graph/agents/component_assembly/schema.py`**: Extended `ComponentAssemblyLLMInput` with new fields for available artifact IDs
- **`src/episteme_graph/agents/component_assembly/prompt.py`**: Added critical ID constraints section instructing LLM to use only IDs from available_* lists

### Orchestrator Integration
- **`backend/core/document_pipeline/orchestrator.py`**: 
  - Added `export_validation` stage to pipeline sequence
  - Integrated ExportValidationGate execution after Blueprint stage
  - Passes all relevant artifacts and results to the gate
  - Graceful error handling with fallback validation result
  - Artifact persistence for validation results

### Test Coverage
- **`src/tests/agents/test_export_validation_gate.py`**: Comprehensive test suite (347 lines) covering:
  - Status determination logic (passed, passed_with_warnings, needs_review, failed_validation)
  - Cross-artifact ID resolution validation
  - DSL edge validation
  - Course mapping validation
  - Required artifact presence checks
  - Result serialization (to_dict, to_json)

- **`src/tests/agents/component_assembly/test_validator.py`**: Extended validator tests for:
  - Valid linkage scenarios
  - Unresolved ID detection (claims, evidence, equations)
  - Summary-only component warnings
  - ID index building

## Implementation Details

- **Severity Classification**: Hard errors from specific stages (component_assembly, course_mapping, dsl_linking,

https://claude.ai/code/session_018YNM8NxSueDuWDCcuJrPQJ