### PR TITLE
Refactor equation schema to use nested structure

### DIFF
--- a/src/episteme_graph/agents/dsl_linking/input_builder.py
+++ b/src/episteme_graph/agents/dsl_linking/input_builder.py
@@ -65,24 +65,26 @@ class DSLLinkingInputBuilder:
             return []
         result = []
         for record in equations.equations[:limit]:
+            loc = record.source_extraction.source_location
+            sem = record.semantics
             result.append({
                 "equation_id": record.equation_id,
-                "block_id": record.block_id,
-                "section_id": record.section_id,
+                "block_id": loc.get("block_id", ""),
+                "section_id": loc.get("section_id", ""),
                 "label": record.label,
-                "role": record.equation_role.primary,
-                "secondary_roles": record.equation_role.secondary,
-                "summary": record.summary,
+                "role": sem.equation_type,
+                "secondary_roles": sem.secondary_types,
+                "summary": sem.summary,
                 "defined_symbols": [
                     {
                         "symbol": s.symbol,
                         "definition_status": s.definition_status,
                     }
-                    for s in record.defined_symbols
+                    for s in sem.defined_symbols
                 ],
-                "local_assumptions": [a.text for a in record.local_assumptions],
-                "from_equations": record.derivation_links.from_equations,
-                "confidence": record.equation_role.confidence,
+                "local_assumptions": sem.assumptions,
+                "from_equations": sem.input_equation_ids,
+                "confidence": sem.confidence,
             })
         return result
 

--- a/src/tests/agents/dsl_linking/test_input_builder.py
+++ b/src/tests/agents/dsl_linking/test_input_builder.py
@@ -3,10 +3,12 @@ from episteme_graph.agents.claim_qualification.schema import ClaimQualificationR
 from episteme_graph.agents.dsl_linking.input_builder import DSLLinkingInputBuilder
 from episteme_graph.agents.equation_semantics.schema import (
     DefinedSymbol,
-    DerivationLinks,
-    EquationRolePrediction,
-    EquationSemanticsRecord,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
     EquationSemanticsResult,
+    EquationSourceExtraction,
 )
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult, THESIS_VERSION
 
@@ -49,23 +51,50 @@ def _qualified():
 
 
 def _equations():
-    record = EquationSemanticsRecord(
-        equation_id="eq_3_14",
-        block_id="e1",
-        section_id="sec_1",
-        section_title="Derivation",
-        label="3.14",
-        text="R Lambda c = RD + RD*",
+    src = EquationSourceExtraction(
+        raw_text="R Lambda c = RD + RD*",
         latex=None,
         plain_text="R Lambda c = RD + RD*",
-        equation_role=EquationRolePrediction("equation_relation", [], 0.9, "relation"),
+        source_location={"page": 3, "section_id": "sec_1", "block_id": "e1", "bbox": []},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type="equation_relation",
+        secondary_types=[],
+        semantic_status="source_extracted",
+        confidence=0.9,
+        reason="relation",
         defined_symbols=[DefinedSymbol("R Lambda c", "used", None)],
-        local_assumptions=[],
-        derivation_links=DerivationLinks(["eq_1_2"], [], []),
+        used_symbols=["R Lambda c", "RD"],
+        assumptions=[],
+        input_equation_ids=["eq_1_2"],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
         summary="Sum rule relation.",
         review_flags=[],
     )
-    return EquationSemanticsResult("doc", None, [record])
+    policy = EquationConfidencePolicy(
+        can_support_claim=True,
+        can_be_used_in_derivation=True,
+        can_be_displayed_in_course=True,
+        display_requires_note=False,
+        must_not_treat_as_source_extracted=False,
+    )
+    record = EquationRecord(
+        equation_id="eq_3_14",
+        document_id="doc",
+        label="3.14",
+        candidate_trace_ids=[],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=policy,
+    )
+    return EquationSemanticsResult("doc", None, [], [record])
 
 
 def _thesis():
@@ -93,6 +122,17 @@ def test_build_packages_claim_equation_and_thesis_materials():
     assert llm_input.equations[0]["equation_id"] == "eq_3_14"
     assert any(n["thesis_ref"] == "central_thesis" for n in llm_input.thesis_nodes)
     assert llm_input.excluded_from_core[0]["category"] == "prior_work"
+
+
+def test_equation_fields_map_to_nested_schema():
+    llm_input = BUILDER.build(_qualified(), equations=_equations())
+    eq = llm_input.equations[0]
+    assert eq["block_id"] == "e1"
+    assert eq["section_id"] == "sec_1"
+    assert eq["role"] == "equation_relation"
+    assert eq["summary"] == "Sum rule relation."
+    assert eq["from_equations"] == ["eq_1_2"]
+    assert eq["confidence"] == 0.9
 
 
 def test_limits_claims():


### PR DESCRIPTION
## Summary
Refactored the equation semantics schema to use a nested structure with separate objects for source extraction, reconstruction, and semantics, replacing the flat `EquationSemanticsRecord` structure.

## Key Changes
- **Schema restructuring**: Replaced `EquationSemanticsRecord` with a new `EquationRecord` that composes:
  - `EquationSourceExtraction`: Handles raw text, latex, and source location metadata
  - `EquationReconstruction`: Manages equation reconstruction state
  - `EquationSemantics`: Contains semantic information (type, confidence, symbols, derivation links)
  - `EquationConfidencePolicy`: Defines how the equation can be used

- **Field migrations**:
  - Moved `block_id`, `section_id` from top-level to `source_extraction.source_location`
  - Moved `equation_role` to `semantics.equation_type` and related fields
  - Moved `defined_symbols`, `local_assumptions`, `derivation_links` to `semantics`
  - Moved `summary` to `semantics`
  - Added `document_id` and `candidate_trace_ids` to top-level record

- **Input builder updates**: Updated `DSLLinkingInputBuilder._equations()` to navigate the new nested structure when building LLM input, extracting values from `source_extraction.source_location` and `semantics` objects

- **Test updates**: Updated test fixtures to construct the new nested schema and added a new test `test_equation_fields_map_to_nested_schema()` to verify the input builder correctly maps nested fields to the expected output format

https://claude.ai/code/session_01K3YtcPyY19ss5QH7aQcGJY