### PR TITLE
Refactor equation semantics schema to use new record structure

### DIFF
--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -105,18 +105,21 @@ class ComponentAssemblyInputBuilder:
             return []
         result = []
         for record in equations.equations[:limit]:
+            src = record.source_extraction
+            sem = record.semantics
+            block_id = src.source_location.get("block_id", "")
             result.append({
                 "equation_id": record.equation_id,
-                "block_id": record.block_id,
-                "role": record.equation_role.primary,
-                "summary": record.summary,
+                "block_id": block_id,
+                "role": sem.equation_type,
+                "summary": sem.summary,
                 "defined_symbols": [
                     {"symbol": s.symbol, "definition_status": s.definition_status}
-                    for s in record.defined_symbols
+                    for s in sem.defined_symbols
                 ],
-                "local_assumptions": [a.text for a in record.local_assumptions],
-                "from_equations": record.derivation_links.from_equations,
-                "confidence": record.equation_role.confidence,
+                "local_assumptions": list(sem.assumptions),
+                "from_equations": list(sem.input_equation_ids),
+                "confidence": sem.confidence,
             })
         return result
 
@@ -229,11 +232,13 @@ class ComponentAssemblyInputBuilder:
             return []
         result = []
         for record in getattr(equations, "equations", []) or []:
+            src = record.source_extraction
+            sem = record.semantics
             result.append({
                 "equation_id": record.equation_id,
-                "block_id": record.block_id,
-                "role": record.equation_role.primary,
-                "confidence": record.equation_role.confidence,
+                "block_id": src.source_location.get("block_id", ""),
+                "role": sem.equation_type,
+                "confidence": sem.confidence,
             })
         return result
 

--- a/src/tests/agents/component_assembly/test_agent.py
+++ b/src/tests/agents/component_assembly/test_agent.py
@@ -9,10 +9,12 @@ from episteme_graph.agents.component_assembly.schema import ComponentAssemblyRes
 from episteme_graph.agents.dsl_linking.schema import DSLEdge, DSLLinkingResult, DSLNode, DSL_VERSION
 from episteme_graph.agents.equation_semantics.schema import (
     DefinedSymbol,
-    DerivationLinks,
-    EquationRolePrediction,
-    EquationSemanticsRecord,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
     EquationSemanticsResult,
+    EquationSourceExtraction,
 )
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult, THESIS_VERSION
 
@@ -54,29 +56,53 @@ def _qualified():
     )
 
 
-def _equations():
-    return EquationSemanticsResult(
-        "doc_test",
-        None,
-        [
-            EquationSemanticsRecord(
-                equation_id="eq_3_14",
-                block_id="e1",
-                section_id="sec_1",
-                section_title="Derivation",
-                label="3.14",
-                text="R Lambda c = RD + RD*",
-                latex=None,
-                plain_text="R Lambda c = RD + RD*",
-                equation_role=EquationRolePrediction("equation_relation", ["equation_result"], 0.9, "relation"),
-                defined_symbols=[DefinedSymbol("R Lambda c", "used", None)],
-                local_assumptions=[],
-                derivation_links=DerivationLinks(["eq_1_2"], [], []),
-                summary="Total-rate sum rule relation.",
-                review_flags=[],
-            )
-        ],
+def _make_equation_record(equation_id, block_id, label, text, equation_type, summary, defined_symbol, input_eq_ids):
+    source_extraction = EquationSourceExtraction(
+        raw_text=text,
+        latex=None,
+        plain_text=text,
+        source_location={"page": 1, "section_id": "sec_1", "block_id": block_id, "bbox": None},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
     )
+    reconstruction = EquationReconstruction.make_none()
+    semantics = EquationSemantics(
+        equation_type=equation_type,
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason=summary,
+        defined_symbols=[DefinedSymbol(defined_symbol, "used", None)] if defined_symbol else [],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=input_eq_ids,
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary=summary,
+        review_flags=[],
+    )
+    confidence_policy = EquationConfidencePolicy.derive(source_extraction, reconstruction, semantics)
+    return EquationRecord(
+        equation_id=equation_id,
+        document_id="doc_test",
+        label=label,
+        candidate_trace_ids=[],
+        source_extraction=source_extraction,
+        reconstruction=reconstruction,
+        semantics=semantics,
+        confidence_policy=confidence_policy,
+    )
+
+
+def _equations():
+    record = _make_equation_record(
+        "eq_3_14", "e1", "3.14", "R Lambda c = RD + RD*",
+        "relation", "Total-rate sum rule relation.",
+        "R Lambda c", ["eq_1_2"],
+    )
+    return EquationSemanticsResult("doc_test", None, [], [record])
 
 
 def _thesis():

--- a/src/tests/agents/component_assembly/test_input_builder.py
+++ b/src/tests/agents/component_assembly/test_input_builder.py
@@ -3,7 +3,15 @@ from episteme_graph.agents.claim_qualification.schema import ClaimQualificationR
 from episteme_graph.agents.component_assembly.input_builder import ComponentAssemblyInputBuilder
 from episteme_graph.agents.component_assembly.schema import CartridgeContext
 from episteme_graph.agents.dsl_linking.schema import DSLEdge, DSLLinkingResult, DSLNode, DSL_VERSION
-from episteme_graph.agents.equation_semantics.schema import DefinedSymbol, DerivationLinks, EquationRolePrediction, EquationSemanticsRecord, EquationSemanticsResult
+from episteme_graph.agents.equation_semantics.schema import (
+    DefinedSymbol,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
+    EquationSemanticsResult,
+    EquationSourceExtraction,
+)
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult, THESIS_VERSION
 
 BUILDER = ComponentAssemblyInputBuilder()
@@ -22,13 +30,44 @@ def _qualified():
 
 
 def _equations():
-    record = EquationSemanticsRecord(
-        "eq_1_1", "e1", "sec_1", "Derivation", "1.1", "R = A", None, "R = A",
-        EquationRolePrediction("equation_relation", [], 0.9, "relation"),
-        [DefinedSymbol("R", "used", None)], [], DerivationLinks([], [], []),
-        "Relation for R.", []
+    source_extraction = EquationSourceExtraction(
+        raw_text="R = A",
+        latex=None,
+        plain_text="R = A",
+        source_location={"page": 1, "section_id": "sec_1", "block_id": "e1", "bbox": None},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
     )
-    return EquationSemanticsResult("doc", None, [record])
+    reconstruction = EquationReconstruction.make_none()
+    semantics = EquationSemantics(
+        equation_type="relation",
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason="Relation for R.",
+        defined_symbols=[DefinedSymbol("R", "used", None)],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary="Relation for R.",
+        review_flags=[],
+    )
+    confidence_policy = EquationConfidencePolicy.derive(source_extraction, reconstruction, semantics)
+    record = EquationRecord(
+        equation_id="eq_1_1",
+        document_id="doc",
+        label="1.1",
+        candidate_trace_ids=[],
+        source_extraction=source_extraction,
+        reconstruction=reconstruction,
+        semantics=semantics,
+        confidence_policy=confidence_policy,
+    )
+    return EquationSemanticsResult("doc", None, [], [record])
 
 
 def _thesis():
@@ -57,6 +96,8 @@ def test_build_packages_inputs_and_allowed_vocabularies():
     llm_input = BUILDER.build(_qualified(), _equations(), _thesis(), _dsl(), cartridge)
     assert llm_input.accepted_claims[0]["claim_id"] == "claim:b1:s1"
     assert llm_input.equations[0]["equation_id"] == "eq_1_1"
+    assert llm_input.equations[0]["block_id"] == "e1"
+    assert llm_input.equations[0]["role"] == "relation"
     assert llm_input.dsl_nodes[0]["node_id"] == "n1"
     assert "PaperRelationComponent" in llm_input.allowed_component_types
     assert "requires" in llm_input.allowed_dependency_types


### PR DESCRIPTION
## Summary
This PR updates the equation semantics schema usage across the codebase to use the new `EquationRecord` structure with nested `EquationSourceExtraction`, `EquationReconstruction`, and `EquationSemantics` objects, replacing the flat `EquationSemanticsRecord` structure.

## Key Changes
- **Schema Migration**: Updated imports to use new equation semantics classes (`EquationRecord`, `EquationSourceExtraction`, `EquationReconstruction`, `EquationSemantics`, `EquationConfidencePolicy`) instead of deprecated ones (`EquationSemanticsRecord`, `DerivationLinks`, `EquationRolePrediction`)

- **Test Updates**: 
  - Added `_make_equation_record()` helper function in `test_agent.py` to construct properly structured `EquationRecord` objects
  - Updated test fixtures in both `test_agent.py` and `test_input_builder.py` to use the new nested structure
  - Added assertions to verify `block_id` and `role` fields are correctly extracted

- **Input Builder Refactoring**: Updated `input_builder.py` to extract data from the new nested structure:
  - `block_id` now extracted from `source_extraction.source_location`
  - `role` now extracted from `semantics.equation_type` (was `equation_role.primary`)
  - `summary` now extracted from `semantics.summary`
  - `defined_symbols` now extracted from `semantics.defined_symbols`
  - `local_assumptions` now extracted from `semantics.assumptions`
  - `from_equations` now extracted from `semantics.input_equation_ids` (was `derivation_links.from_equations`)
  - `confidence` now extracted from `semantics.confidence` (was `equation_role.confidence`)

## Implementation Details
- The new structure provides better separation of concerns with distinct objects for source extraction, reconstruction, and semantic analysis
- `EquationConfidencePolicy.derive()` is used to compute confidence policies from the component parts
- All equation record construction now follows a consistent pattern across test files

https://claude.ai/code/session_01Sek8GLUPRdajAGn5PcuDxk