### PR TITLE
Fix source-backed claim evidence linkage validation (issue #257)

### DIFF
--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -323,14 +323,18 @@ def build_evidence_export(
             })
         return out
 
-    # Fallback: synthesise evidence rows from claim.evidence_text. The text
-    # may be LLM commentary, so we mark needs_review=true and surface it as
-    # analysis_note to keep the source-backed contract honest.
+    # Fallback: synthesise evidence rows from claim.evidence_text.
+    # Legacy DB rows may store LLM commentary (qualification reason) in evidence_text
+    # rather than PDF-derived text (#257). To preserve the source-backed contract,
+    # we move the text to analysis_note and leave evidence_text empty.
+    # Consumers must check extraction_status=reconstructed and needs_review=true.
     for i, claim in enumerate(fallback_claims or []):
         text = claim.get("evidence_text") or ""
         if not text:
             continue
         scope = claim.get("source_scope") or {}
+        # qualification_reason stored in source_scope by persist_theory_claims (#257)
+        qualification_reason = scope.get("qualification_reason", "") if isinstance(scope, dict) else ""
         out.append({
             "evidence_id": f"evidence_{i+1:04d}",
             "document_id": claim.get("document_id") or document_id,
@@ -338,16 +342,18 @@ def build_evidence_export(
             "section_id": scope.get("section_id", ""),
             "block_id": scope.get("chunk_id", ""),
             "span_start": 0,
-            "span_end": len(text),
-            "evidence_text": text,
+            "span_end": 0,
+            # evidence_text is intentionally empty: text from legacy claim.evidence_text
+            # is not verified as PDF-derived and is surfaced in analysis_note instead.
+            "evidence_text": "",
             "evidence_role": "section_summary",
-            "analysis_note": "",
-            "review_note": "",
+            "analysis_note": text,
+            "review_note": qualification_reason,
             "extraction_source": "reconstructed",
             "extraction_status": "reconstructed",
             "public_export_policy": "location_only",
             "needs_review": True,
-            "review_reason": ["evidence_not_source_verified"],
+            "review_reason": ["evidence_not_source_verified", "legacy_evidence_text_in_analysis_note"],
             "claim_id": claim.get("claim_id") or "",
         })
     return out

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -929,7 +929,9 @@ def _is_low_value_claim_text(text: str) -> bool:
 def _normalize_claim_payload(raw: dict, chunk: dict, strict: bool = True) -> dict | None:
     if not isinstance(raw, dict):
         raise ValueError("claim item must be an object")
-    required = ("claim_type", "text", "support_status", "evidence_text")
+    # evidence_text は不要フィールド化 (#257)。
+    # source_evidence_ids / source_scope を source-backed 判定の正規参照とする。
+    required = ("claim_type", "text", "support_status")
     missing = [field for field in required if raw.get(field) in (None, "")]
     if strict and missing:
         raise ValueError(f"claim missing required fields: {', '.join(missing)}")
@@ -939,14 +941,17 @@ def _normalize_claim_payload(raw: dict, chunk: dict, strict: bool = True) -> dic
     text = _clean_pg_text(raw.get("text") or raw.get("normalized_text") or "").strip()
     if _is_low_value_claim_text(text):
         return None
+    # evidence_text はオプション。空文字は許容する (#257)。
     evidence = _clean_pg_text(raw.get("evidence_text") or "").strip()
-    if not evidence and strict:
-        raise ValueError("claim missing required field: evidence_text")
-    if not evidence and not strict:
-        evidence = text[:360]
     support_status = str(raw.get("support_status") or "").strip()
     if support_status not in _SUPPORT_STATUS_VALUES:
         raise ValueError(f"invalid support_status: {support_status}")
+    # source_backed だが evidence_text も source_evidence_ids も両方空の場合は警告 (#257)
+    source_evidence_ids = [str(i) for i in (raw.get("source_evidence_ids") or []) if i]
+    if support_status == "source_backed" and not evidence and not source_evidence_ids:
+        logger.warning(
+            "source_backed claim has neither evidence_text nor source_evidence_ids: %.60s", text
+        )
     review_status = str(raw.get("review_status") or "teacher_review_required").strip()
     if review_status not in ("teacher_review_required", "needs_revision", "rejected"):
         review_status = "teacher_review_required"

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -153,6 +153,10 @@ class ExportValidationGate:
         # 5. Required artifact presence
         self._check_required_artifacts(artifacts, errors)
 
+        # 6. source-backed claim must reference EvidenceRegistry (#257)
+        if claim_objects and evidence:
+            self._check_source_backed_claims(claim_objects, evidence, warnings)
+
         # 6. Determine status
         summary = ValidationSummary(
             error_count=len(errors),
@@ -382,6 +386,53 @@ class ExportValidationGate:
                     path=f"$.edges[{edge.edge_id}].to_node_id",
                     source_stage="export_validation",
                 ))
+
+    def _check_source_backed_claims(
+        self,
+        claim_objects,
+        evidence,
+        warnings: list,
+    ) -> None:
+        """Warn on source_backed claims that have no source_evidence_ids (#257).
+
+        A source_backed claim without source_evidence_ids means the claim cannot
+        be traced back to a PDF-derived Evidence record. This breaks the assumption
+        that source_backed ↔ EvidenceRegistry linkage is verified.
+        """
+        known_evidence_ids: set[str] = {
+            r.evidence_id
+            for r in (getattr(evidence, "records", []) or [])
+        }
+        for claim in getattr(claim_objects, "claims", []) or []:
+            support = getattr(claim, "support_status", "") or ""
+            if support != "source_backed":
+                continue
+            ev_ids = list(getattr(claim, "source_evidence_ids", []) or [])
+            if not ev_ids:
+                warnings.append(ValidationEntry(
+                    code="SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS",
+                    message=(
+                        f"source_backed claim {getattr(claim, 'claim_id', '?')!r} "
+                        "has no source_evidence_ids; PDF evidence cannot be verified"
+                    ),
+                    artifact="claim_object_builder",
+                    path=f"$.claims[{getattr(claim, 'claim_id', '?')}].source_evidence_ids",
+                    source_stage="export_validation",
+                ))
+            else:
+                # Warn if any referenced evidence_id is not in the registry
+                for eid in ev_ids:
+                    if known_evidence_ids and eid not in known_evidence_ids:
+                        warnings.append(ValidationEntry(
+                            code="SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID",
+                            message=(
+                                f"source_backed claim {getattr(claim, 'claim_id', '?')!r} "
+                                f"references evidence {eid!r} not in EvidenceRegistry"
+                            ),
+                            artifact="claim_object_builder",
+                            path=f"$.claims[{getattr(claim, 'claim_id', '?')}].source_evidence_ids",
+                            source_stage="export_validation",
+                        ))
 
     def _check_required_artifacts(
         self,

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -214,6 +214,9 @@ def persist_qualified_claims(
                     "section_id": getattr(span, "section_id", None),
                     "block_id": getattr(span, "block_id", None),
                     "span_id": getattr(span, "span_id", None),
+                    # span.reason は LLM 判定理由 (review note) であり PDF 原文根拠ではない。
+                    # source-backed 判定の根拠として evidence_text に保存しない (#257)。
+                    "qualification_reason": _strip_nuls(getattr(span, "reason", "") or ""),
                 }),
                 "claim_type": _normalize_claim_type(qualification),
                 "text": _strip_nuls(getattr(span, "text", "") or ""),
@@ -221,7 +224,10 @@ def persist_qualified_claims(
                 "concepts": _json_dumps([]),
                 "equation": _json_dumps({}),
                 "support_status": "source_backed",
-                "evidence_text": _strip_nuls(getattr(span, "reason", "") or ""),
+                # PDF 原文根拠は EvidenceRegistry artifact に委任する (#257)。
+                # span.reason を evidence_text に保存すると LLM 判定理由が
+                # source-backed evidence として扱われるため空文字に変更。
+                "evidence_text": "",
                 "review_status": "teacher_review_required",
             }
             row = session.execute(

--- a/backend/tests/test_export_artifacts.py
+++ b/backend/tests/test_export_artifacts.py
@@ -217,6 +217,55 @@ class TestEvidenceExport:
         # LLM-style commentary should not be silently treated as a source quote.
         assert "evidence_not_source_verified" in evs[0]["review_reason"]
 
+    def test_fallback_evidence_moves_text_to_analysis_note_not_evidence_text(self):
+        """Issue #257: legacy claim.evidence_text (may be span.reason) must not
+        pollute evidence_text in the export bundle. It goes to analysis_note."""
+        ea = _import_artifacts()
+        llm_reason = "This claim is an approximation valid in the heavy-quark limit."
+        evs = ea.build_evidence_export(None, document_id="doc_001", fallback_claims=[
+            {"claim_id": "c2", "evidence_text": llm_reason,
+             "document_id": "doc_001", "source_scope": {"section_id": "sec_1"}},
+        ])
+        assert len(evs) == 1
+        ev = evs[0]
+        # evidence_text must be empty — the text is NOT PDF-derived (#257)
+        assert ev["evidence_text"] == ""
+        # text is preserved in analysis_note for audit purposes
+        assert ev["analysis_note"] == llm_reason
+        assert ev["needs_review"] is True
+        assert ev["extraction_source"] == "reconstructed"
+        assert "legacy_evidence_text_in_analysis_note" in ev["review_reason"]
+
+    def test_fallback_evidence_qualification_reason_in_review_note(self):
+        """Issue #257: qualification_reason stored in source_scope by persist_theory_claims
+        should appear in review_note of the fallback evidence row."""
+        ea = _import_artifacts()
+        q_reason = "LLM classified this as an approximation with confidence 0.9"
+        evs = ea.build_evidence_export(None, document_id="doc_001", fallback_claims=[
+            {
+                "claim_id": "c3",
+                "evidence_text": "some evidence text",
+                "document_id": "doc_001",
+                "source_scope": {
+                    "section_id": "sec_2",
+                    "block_id": "blk_007",
+                    "qualification_reason": q_reason,
+                },
+            },
+        ])
+        assert len(evs) == 1
+        assert evs[0]["review_note"] == q_reason
+
+    def test_fallback_skips_claims_with_empty_evidence_text(self):
+        """Issue #257: after persist_theory_claims fix, new DB rows have empty
+        evidence_text. Fallback should produce no evidence rows for those."""
+        ea = _import_artifacts()
+        evs = ea.build_evidence_export(None, document_id="doc_001", fallback_claims=[
+            {"claim_id": "c4", "evidence_text": "",
+             "document_id": "doc_001", "source_scope": {}},
+        ])
+        assert evs == []
+
 
 # ---------------------------------------------------------------------------
 # Derivation chains

--- a/backend/tests/test_theory_components.py
+++ b/backend/tests/test_theory_components.py
@@ -277,3 +277,54 @@ class TestNulCharacterSanitization:
         assert "_clean_pg_text(raw.get(\"text\")" in source or "_clean_pg_text(raw.get('text')" in source
         assert "_clean_pg_text(raw.get(\"evidence_text\")" in source or "_clean_pg_text(raw.get('evidence_text')" in source
         assert "return _strip_nul({" in source
+
+
+class TestNormalizeClaimPayloadEvidenceContract:
+    """Issue #257: evidence_text is optional; source_evidence_ids is the
+    authoritative source-backed reference."""
+
+    def test_evidence_text_not_in_required_fields(self):
+        """_normalize_claim_payload must NOT list evidence_text as required (#257)."""
+        source = _read(ROUTES)
+        import re as _re
+        # Find the required = (...) tuple inside _normalize_claim_payload
+        match = _re.search(
+            r'def _normalize_claim_payload.*?required = \((.*?)\)',
+            source, _re.DOTALL
+        )
+        assert match, "_normalize_claim_payload or required tuple not found"
+        required_tuple = match.group(1)
+        assert "evidence_text" not in required_tuple, (
+            "evidence_text must not be in required fields; source_evidence_ids / "
+            "source_scope are the authoritative reference for source-backed claims (#257)"
+        )
+
+    def test_source_evidence_ids_warning_present(self):
+        """Source code must contain warning for source_backed with no evidence refs."""
+        source = _read(ROUTES)
+        assert "source_evidence_ids" in source
+        assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" in source or (
+            "source_backed" in source and "source_evidence_ids" in source
+            and "warning" in source.lower()
+        ), "No warning for source_backed claim without source_evidence_ids"
+
+    def test_span_reason_not_used_as_evidence_text_in_persistence(self):
+        """persistence.py must not write span.reason into evidence_text (#257)."""
+        persistence_source = _read(
+            Path(__file__).resolve().parents[2]
+            / "backend" / "core" / "document_pipeline" / "persistence.py"
+        )
+        # The old buggy pattern: "evidence_text": _strip_nuls(getattr(span, "reason" ...
+        assert '"evidence_text": _strip_nuls(getattr(span, "reason"' not in persistence_source, (
+            'persist_theory_claims must not copy span.reason into evidence_text (#257)'
+        )
+        # qualification_reason must be stored in source_scope instead
+        assert "qualification_reason" in persistence_source
+
+    def test_evidence_text_empty_string_in_persistence(self):
+        """persistence.py must set evidence_text to empty string (#257)."""
+        persistence_source = _read(
+            Path(__file__).resolve().parents[2]
+            / "backend" / "core" / "document_pipeline" / "persistence.py"
+        )
+        assert '"evidence_text": ""' in persistence_source

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -55,8 +55,15 @@ class _ComponentResult:
 
 
 class _ClaimObject:
-    def __init__(self, claim_id: str):
+    def __init__(
+        self,
+        claim_id: str,
+        support_status: str = "source_backed",
+        source_evidence_ids: list | None = None,
+    ):
         self.claim_id = claim_id
+        self.support_status = support_status
+        self.source_evidence_ids = source_evidence_ids or []
 
 
 class _ClaimObjectResult:
@@ -345,3 +352,59 @@ def test_result_to_dict():
     assert "errors" in d
     assert "warnings" in d
     assert "summary" in d
+
+
+# ---------------------------------------------------------------------------
+# Tests: source-backed claim ↔ EvidenceRegistry validation (issue #257)
+# ---------------------------------------------------------------------------
+
+def test_source_backed_claim_with_evidence_ids_no_warning():
+    """source_backed claim that has source_evidence_ids → no SOURCE_BACKED warning."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_001", support_status="source_backed",
+                     source_evidence_ids=["ev_001"]),
+    ])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_001")])
+
+    result = _run_gate(claim_objects=claims, evidence=evidence)
+    codes = [w.code for w in result.warnings]
+    assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" not in codes
+
+
+def test_source_backed_claim_without_evidence_ids_warns():
+    """source_backed claim with empty source_evidence_ids → SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS warning."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_002", support_status="source_backed",
+                     source_evidence_ids=[]),
+    ])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_001")])
+
+    result = _run_gate(claim_objects=claims, evidence=evidence)
+    codes = [w.code for w in result.warnings]
+    assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" in codes
+
+
+def test_source_backed_claim_with_unresolved_evidence_id_warns():
+    """source_backed claim referencing a missing evidence_id → SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID warning."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_003", support_status="source_backed",
+                     source_evidence_ids=["ev_MISSING"]),
+    ])
+    evidence = _EvidenceResult([_EvidenceRecord("ev_real")])
+
+    result = _run_gate(claim_objects=claims, evidence=evidence)
+    codes = [w.code for w in result.warnings]
+    assert "SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID" in codes
+
+
+def test_non_source_backed_claim_no_evidence_ids_is_silent():
+    """inferred / domain_inferred claims are not required to have evidence_ids."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_004", support_status="inferred",
+                     source_evidence_ids=[]),
+    ])
+    evidence = _EvidenceResult([])
+
+    result = _run_gate(claim_objects=claims, evidence=evidence)
+    codes = [w.code for w in result.warnings]
+    assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" not in codes


### PR DESCRIPTION
## Summary
This PR addresses issue #257 by establishing a proper contract between source-backed claims and the EvidenceRegistry. The changes ensure that source-backed claims are validated to have corresponding evidence references, and that legacy LLM commentary is not incorrectly treated as PDF-derived evidence.

## Key Changes

### Validation & Detection
- **Export validation gate**: Added `_check_source_backed_claims()` method to validate that source-backed claims either have `source_evidence_ids` or reference valid evidence records. Produces two new warning codes:
  - `SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS`: Warns when a source-backed claim has no evidence references
  - `SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID`: Warns when referenced evidence IDs don't exist in the registry

### Data Model Updates
- **ClaimObject test fixture**: Extended to support `support_status` and `source_evidence_ids` fields for proper testing

### Persistence Layer Fixes
- **persist_qualified_claims()**: Changed to store LLM qualification reasoning in `source_scope.qualification_reason` instead of `evidence_text`, keeping `evidence_text` empty. This prevents LLM commentary from being treated as PDF-derived evidence.

### API Route Changes
- **_normalize_claim_payload()**: Made `evidence_text` optional (removed from required fields). Added validation warning when a source-backed claim has neither `evidence_text` nor `source_evidence_ids`.
- **build_evidence_export()**: Updated fallback evidence synthesis to:
  - Keep `evidence_text` empty for reconstructed evidence (not PDF-verified)
  - Move legacy claim text to `analysis_note` for audit purposes
  - Store qualification reason in `review_note`
  - Add `legacy_evidence_text_in_analysis_note` to review reasons
  - Skip generating evidence rows for claims with empty `evidence_text`

### Test Coverage
- Added comprehensive tests for source-backed claim validation scenarios
- Added tests verifying the evidence contract in theory components and export artifacts
- Tests confirm that non-source-backed claims (inferred, domain_inferred) are not subject to evidence validation

## Implementation Details
- The validation is non-blocking (warnings only) to allow gradual migration of existing data
- The changes preserve backward compatibility while establishing the new contract going forward
- Comments in Japanese and English explain the rationale for the source-backed/evidence separation

https://claude.ai/code/session_014ia8NTMyR5cKuBCbWTPVvn