### PR TITLE
Extend derivation chains to support claims, evidence, and assumptions

### DIFF
--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -77,26 +77,59 @@ def build_equations_export(
 ) -> list[dict]:
     """Convert the equation_semantics artifact into equations/equations.json shape.
 
-    Each output entry follows the schema defined in issue #242 §3:
-    equation_id, label, latex, plain_text, source_location, equation_type,
-    defined_symbols, used_symbols, derivation_links, source_evidence_ids,
-    extraction_source, extraction_status, needs_math_review, review_reason,
-    candidate_trace_ids.
+    Reads from the current nested EquationRecord schema (issue #258):
+    source_extraction.*, reconstruction.*, semantics.*, confidence_policy.*
+
+    Falls back to legacy flat format for compatibility.
     """
+    from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
+
     eq = _coerce_dict(equation_artifact)
-    records = eq.get("equations") if isinstance(eq.get("equations"), list) else []
-    structure = _coerce_dict(structure_artifact)
-    block_lookup = _section_id_to_block_lookup(structure)
     evidence_index = evidence_index or {}
     claim_index = claim_index or {}
 
+    # Prefer structured deserialization via EquationSemanticsResult when the artifact
+    # has the nested schema (equations[].source_extraction present).
+    records_raw = eq.get("equations") if isinstance(eq.get("equations"), list) else []
+    first = records_raw[0] if records_raw else {}
+    has_nested = isinstance(first, dict) and "source_extraction" in first
+
+    if has_nested:
+        try:
+            sem_result = EquationSemanticsResult.from_dict({
+                "document_id": eq.get("document_id", document_id),
+                "cartridge_id": eq.get("cartridge_id"),
+                "equation_candidates": eq.get("equation_candidates", []),
+                "equations": records_raw,
+                "validation_issues": eq.get("validation_issues", []),
+            })
+            exported = sem_result.to_equations_export(
+                evidence_index=evidence_index,
+                claim_index=claim_index,
+            )
+            # Validate and annotate
+            _validate_equations_export(exported)
+            return exported
+        except Exception:
+            pass  # fall through to legacy path
+
+    # Legacy flat format (older artifacts)
+    structure = _coerce_dict(structure_artifact)
+    block_lookup = _section_id_to_block_lookup(structure)
+
     out: list[dict] = []
-    for r in records:
+    seen_ids: set[str] = set()
+
+    for r in records_raw:
         if not isinstance(r, dict):
             continue
         equation_id = str(r.get("equation_id") or "").strip()
         if not equation_id:
             continue
+        if equation_id in seen_ids:
+            continue
+        seen_ids.add(equation_id)
+
         block_id = str(r.get("block_id") or "")
         section_id = r.get("section_id")
         block = block_lookup.get(block_id, {})
@@ -136,8 +169,6 @@ def build_equations_export(
         review_flags = list(r.get("review_flags") or [])
         needs_math_review = bool(review_flags) or not bool(latex) or "low_confidence" in review_flags
 
-        # extraction_source: heuristic — prefer pdf_text_layer when block text is
-        # present, else flag llm_reconstruction (e.g. agent fallback).
         if block.get("text"):
             extraction_source = "pdf_text_layer"
             extraction_status = "parsed" if latex else "partially_parsed"
@@ -145,10 +176,13 @@ def build_equations_export(
             extraction_source = "llm_reconstruction"
             extraction_status = "reconstructed" if latex or plain_text else "unparsed"
 
+        candidate_trace_ids = list(r.get("candidate_trace_ids") or [f"eqcand_{equation_id}"])
+
         out.append({
             "equation_id": equation_id,
             "document_id": document_id,
             "label": r.get("label"),
+            "raw_text": r.get("raw_text") or text,
             "latex": latex,
             "plain_text": plain_text,
             "source_location": {
@@ -159,25 +193,75 @@ def build_equations_export(
                 "span_end": len(text or ""),
                 "bbox": list(bbox) if isinstance(bbox, (list, tuple)) else [],
             },
-            "equation_type": primary_role,
-            "defined_symbols": defined_symbols,
-            "used_symbols": used_symbols,
-            "symbol_definitions": symbol_definitions,
-            "assumptions": [
-                a.get("text", "") for a in (r.get("local_assumptions") or [])
-                if isinstance(a, dict) and a.get("text")
-            ],
-            "input_equation_ids": from_eqs,
-            "output_equation_ids": to_eqs,
-            "source_evidence_ids": list(evidence_index.get(block_id, [])),
-            "linked_claim_ids": list(claim_index.get(equation_id, [])),
             "extraction_source": extraction_source,
             "extraction_status": extraction_status,
             "needs_math_review": needs_math_review,
             "review_reason": review_flags,
-            "candidate_trace_ids": [f"eqcand_{equation_id}"],
+            "candidate_trace_ids": candidate_trace_ids,
+            "reconstruction": {"status": "none"},
+            "equation_role": {"primary": primary_role, "secondary": []},
+            "semantic_kind": None,
+            "equation_type": primary_role,
+            "secondary_types": [],
+            "semantic_status": "unknown",
+            "defined_symbols": defined_symbols,
+            "used_symbols": used_symbols,
+            "introduced_symbols": defined_symbols,
+            "symbol_definitions": symbol_definitions,
+            "local_assumptions": [
+                a.get("text", "") for a in (r.get("local_assumptions") or [])
+                if isinstance(a, dict) and a.get("text")
+            ],
+            "derivation_links": {"from_equations": from_eqs, "to_equations": to_eqs},
+            "input_equation_ids": from_eqs,
+            "output_equation_ids": to_eqs,
+            "source_evidence_ids": list(evidence_index.get(block_id, [])),
+            "linked_claim_ids": list(claim_index.get(equation_id, [])),
+            "confidence_policy": {},
         })
     return out
+
+
+def _validate_equations_export(records: list[dict]) -> None:
+    """In-place annotation of validation issues on exported equation records.
+
+    Checks issue #258 criteria:
+    - duplicate equation_id → mark error
+    - source-backed equation with empty block_id → mark error
+    - empty candidate_trace_ids → mark warning
+    - reconstruction-based equation not flagged as such → mark error
+    """
+    seen_ids: set[str] = set()
+    for r in records:
+        eq_id = r.get("equation_id", "")
+        validation = r.setdefault("_export_validation", [])
+
+        if not eq_id:
+            validation.append({"severity": "error", "rule": "eq_id_empty"})
+        elif eq_id in seen_ids:
+            validation.append({"severity": "error", "rule": "eq_id_duplicate", "equation_id": eq_id})
+        seen_ids.add(eq_id)
+
+        src_loc = r.get("source_location") or {}
+        block_id = src_loc.get("block_id", "")
+        extraction_status = r.get("extraction_status") or r.get("source_extraction", {}).get("extraction_status", "")
+        if extraction_status not in ("missing", "label_only", "fragment_only") and not block_id:
+            validation.append({"severity": "error", "rule": "source_backed_missing_block_id"})
+
+        candidate_trace_ids = r.get("candidate_trace_ids") or []
+        if not candidate_trace_ids:
+            validation.append({"severity": "warning", "rule": "candidate_trace_ids_empty"})
+
+        cp = r.get("confidence_policy") or {}
+        must_not = cp.get("must_not_treat_as_source_extracted", False)
+        rec = r.get("reconstruction") or {}
+        rec_status = rec.get("status", "none")
+        if rec_status != "none" and not must_not:
+            validation.append({
+                "severity": "warning",
+                "rule": "reconstruction_based_not_flagged",
+                "reconstruction_status": rec_status,
+            })
 
 
 # ---------------------------------------------------------------------------
@@ -191,58 +275,95 @@ def build_equation_candidates_export(
     document_id: str,
     structure_artifact: Any = None,
 ) -> list[dict]:
-    """Build equations/equation_candidates.json from available signals.
+    """Build equations/equation_candidates.json.
 
-    The current pipeline doesn't run a dedicated candidate detector, so we
-    reconstruct a minimal trace from the equation_semantics records and the
-    document_structure equation_blocks. Both produce auditable rows so the
-    downstream `eq_*` references can be traced back to a PDF span.
+    Prefers the EquationSemanticsResult.equation_candidates list (issue #258/#259).
+    Falls back to reconstructing from equation_semantics records and
+    document_structure equation_blocks.
+
+    rejection_reason is always populated on rejected candidates.
     """
+    eq = _coerce_dict(equation_artifact)
     structure = _coerce_dict(structure_artifact)
     block_lookup = _section_id_to_block_lookup(structure)
 
+    # Prefer first-class candidate list from the agent (issue #258)
+    agent_candidates = eq.get("equation_candidates")
+    if isinstance(agent_candidates, list) and agent_candidates:
+        out: list[dict] = []
+        for c in agent_candidates:
+            if not isinstance(c, dict):
+                continue
+            candidate_id = str(c.get("candidate_id") or "").strip()
+            if not candidate_id:
+                continue
+            rejection_reason = c.get("rejection_reason") or c.get("review_reason")
+            if isinstance(rejection_reason, list):
+                rejection_reason = "; ".join(rejection_reason) if rejection_reason else None
+            acceptance = c.get("acceptance_status", "rejected")
+            if acceptance in ("rejected", "context_only") and not rejection_reason:
+                rejection_reason = "candidate_not_accepted"
+            out.append({
+                "candidate_id": candidate_id,
+                "document_id": c.get("document_id") or document_id,
+                "source_location": c.get("source_location") or {},
+                "raw_text": c.get("raw_text") or "",
+                "matched_label": c.get("matched_label"),
+                "detection_method": list(c.get("detection_method") or []),
+                "candidate_score": c.get("candidate_score"),
+                "extraction_status": c.get("extraction_status", "unparsed"),
+                "acceptance_status": acceptance,
+                "accepted_equation_id": c.get("accepted_equation_id"),
+                "merge_target_hint": c.get("merge_target_hint"),
+                "rejection_reason": rejection_reason,
+                "needs_math_review": bool(c.get("needs_math_review", True)),
+                "review_reason": list(c.get("review_reason") or []),
+            })
+        return out
+
+    # Fallback: reconstruct from equation records + document_structure blocks
     candidates: list[dict] = []
     accepted_block_ids: set[str] = set()
 
-    eq = _coerce_dict(equation_artifact)
     for r in eq.get("equations") or []:
         if not isinstance(r, dict):
             continue
         equation_id = str(r.get("equation_id") or "")
         if not equation_id:
             continue
-        block_id = str(r.get("block_id") or "")
+
+        # Support nested schema
+        src = r.get("source_extraction") or {}
+        src_loc = src.get("source_location") or {}
+        block_id = str(src_loc.get("block_id") or r.get("block_id") or "")
         accepted_block_ids.add(block_id)
+
+        raw_text = src.get("raw_text") or r.get("raw_text") or ""
+        review_flags = list((src.get("review_reason") or r.get("review_flags") or []))
+        needs_review = bool(src.get("needs_math_review") or review_flags or not src.get("latex"))
+
         block = block_lookup.get(block_id, {})
-        text = block.get("text") if isinstance(block, dict) else ""
-        text = text or r.get("text") or ""
-        page = block.get("page") if isinstance(block, dict) else None
-        bbox = block.get("bbox") if isinstance(block, dict) else None
-        review_flags = list(r.get("review_flags") or [])
         candidates.append({
             "candidate_id": f"eqcand_{equation_id}",
             "document_id": document_id,
-            "source_location": {
-                "page": page,
+            "source_location": src_loc or {
+                "page": block.get("page") if isinstance(block, dict) else None,
                 "section_id": r.get("section_id"),
                 "block_id": block_id,
-                "span_start": 0,
-                "span_end": len(text or ""),
-                "bbox": list(bbox) if isinstance(bbox, (list, tuple)) else [],
             },
-            "raw_text": text or "",
+            "raw_text": raw_text or (block.get("text") if isinstance(block, dict) else "") or "",
             "detection_method": ["document_structure_equation_block", "llm_semantic_classification"],
             "matched_label": r.get("label"),
             "candidate_score": None,
+            "extraction_status": src.get("extraction_status") or "complete",
             "acceptance_status": "accepted",
             "accepted_equation_id": equation_id,
+            "merge_target_hint": None,
             "rejection_reason": None,
-            "needs_math_review": bool(review_flags) or not bool(r.get("latex")),
+            "needs_math_review": needs_review,
             "review_reason": review_flags,
         })
 
-    # Also surface document_structure equation_blocks that did not become
-    # first-class equations — these are rejected candidates worth auditing.
     for block in structure.get("blocks", []) or []:
         if not isinstance(block, dict):
             continue
@@ -266,8 +387,10 @@ def build_equation_candidates_export(
             "detection_method": ["document_structure_equation_block"],
             "matched_label": block.get("equation_label"),
             "candidate_score": float(block.get("confidence") or 0.0),
+            "extraction_status": "unparsed",
             "acceptance_status": "rejected",
             "accepted_equation_id": None,
+            "merge_target_hint": None,
             "rejection_reason": "not_promoted_by_equation_semantics_agent",
             "needs_math_review": True,
             "review_reason": ["not_promoted"],

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -13,9 +13,11 @@ import re
 from typing import Callable, Iterable, Optional
 
 from .schema import (
+    CLAIM_TYPE_ONTOLOGY,
     ClaimConcept,
     ClaimObjectBuildResult,
     ClaimObjectRecord,
+    EQUATION_CLAIM_TYPES,
     REVIEW_STATUSES,
     SUPPORT_STATUSES,
     ValidationIssue,
@@ -39,6 +41,8 @@ class ClaimObjectBuilder:
         指定がない場合は cartridge ontology から alias マッチで抽出する。
     cartridge_ontology:
         cartridge の ontology dict（オプション）。
+    equation_semantics_result:
+        EquationSemanticsResult（オプション）。source_location proximity で equation を link する (issue #260)。
     """
 
     def __init__(
@@ -47,6 +51,7 @@ class ClaimObjectBuilder:
         equation_index: dict[str, object] | None = None,
         concept_resolver: Optional[Callable] = None,
         cartridge_ontology: dict | None = None,
+        equation_semantics_result: object | None = None,
     ) -> None:
         self._evidence_registry = evidence_registry
         self._equation_index = equation_index or {}
@@ -58,6 +63,22 @@ class ClaimObjectBuilder:
                 bid = getattr(r.source, "block_id", None)
                 if bid:
                     self._span_to_evidence.setdefault(bid, []).append(r.evidence_id)
+
+        # Build proximity index: block_id → [equation_id], section_id → [equation_id]
+        self._block_to_equations: dict[str, list[str]] = {}
+        self._section_to_equations: dict[str, list[str]] = {}
+        for eq_record in getattr(equation_semantics_result, "equations", []) or []:
+            eq_id = getattr(eq_record, "equation_id", None)
+            if not eq_id:
+                continue
+            src = getattr(eq_record, "source_extraction", None)
+            loc = getattr(src, "source_location", {}) or {} if src else {}
+            bid = loc.get("block_id")
+            sid = loc.get("section_id")
+            if bid:
+                self._block_to_equations.setdefault(bid, []).append(eq_id)
+            if sid:
+                self._section_to_equations.setdefault(sid, []).append(eq_id)
 
     # ------------------------------------------------------------------
     def build(
@@ -77,18 +98,93 @@ class ClaimObjectBuilder:
                 continue
 
             counter += 1
-            claim_id = self._make_claim_id(document_id, counter, span)
+            base_claim_id = self._make_claim_id(document_id, counter, span)
+            text = self._extract_normalized_text(span)
+            claim_type = self._normalize_claim_type(qual.get("claim_type_candidate"))
+            block_id = getattr(span, "block_id", None)
+            section_id = getattr(span, "section_id", None)
+            role_labels = list(getattr(span, "role_labels", []) or [])
+            span_id = getattr(span, "span_id", None)
+            confidence = float(getattr(span, "confidence", 0.0) or 0.0)
+
+            evidence_ids = self._resolve_evidence_ids(block_id)
+            review_note = self._extract_review_note(span)
+            review_status = self._derive_review_status(qual)
+
+            # Handle split claims (atomicity — issue #260)
+            edits = getattr(span, "edit_suggestions", {}) or {}
+            split_candidates = edits.get("split_claims") or []
+            if split_candidates and isinstance(split_candidates, list):
+                parent_id = base_claim_id
+                if parent_id in seen_claim_ids:
+                    parent_id = f"{parent_id}_{counter}"
+                seen_claim_ids.add(parent_id)
+                subclaim_ids: list[str] = []
+                for sub_idx, sub in enumerate(split_candidates, start=1):
+                    sub_text = str(sub.get("text", "")).strip() if isinstance(sub, dict) else text
+                    if not sub_text:
+                        continue
+                    sub_type = self._normalize_claim_type(
+                        (sub.get("claim_type") if isinstance(sub, dict) else None)
+                        or claim_type
+                    )
+                    sub_id = f"{parent_id}_sub{sub_idx:02d}"
+                    if sub_id in seen_claim_ids:
+                        sub_id = f"{sub_id}_{counter}"
+                    seen_claim_ids.add(sub_id)
+                    subclaim_ids.append(sub_id)
+                    sub_concepts = self._resolve_concepts(sub_text, role_labels)
+                    sub_eqs = self._link_equations(sub_text, sub_type, role_labels, block_id, section_id)
+                    claims.append(ClaimObjectRecord(
+                        claim_id=sub_id,
+                        document_id=document_id,
+                        claim_type=sub_type,
+                        text=sub_text,
+                        source_evidence_ids=evidence_ids,
+                        source_span_ids=[span_id] if span_id else [],
+                        concepts=sub_concepts,
+                        equation_ids=sub_eqs,
+                        figure_ids=[],
+                        table_ids=[],
+                        support_status="source_backed" if evidence_ids else "inferred",
+                        review_status=review_status,
+                        review_note=review_note,
+                        section_id=section_id,
+                        confidence=confidence,
+                        atomicity="atomic",
+                        parent_claim_id=parent_id,
+                        subclaim_ids=[],
+                    ))
+                # Compound parent record (no text of its own, just tracks subclaims)
+                claims.append(ClaimObjectRecord(
+                    claim_id=parent_id,
+                    document_id=document_id,
+                    claim_type=claim_type,
+                    text=text,
+                    source_evidence_ids=evidence_ids,
+                    source_span_ids=[span_id] if span_id else [],
+                    concepts=self._resolve_concepts(text, role_labels),
+                    equation_ids=self._link_equations(text, claim_type, role_labels, block_id, section_id),
+                    figure_ids=[],
+                    table_ids=[],
+                    support_status="source_backed" if evidence_ids else "inferred",
+                    review_status=review_status,
+                    review_note=review_note,
+                    section_id=section_id,
+                    confidence=confidence,
+                    atomicity="compound",
+                    parent_claim_id=None,
+                    subclaim_ids=subclaim_ids,
+                ))
+                self._add_issues_for_record(parent_id, evidence_ids, self._resolve_concepts(text, role_labels), claim_type, self._link_equations(text, claim_type, role_labels, block_id, section_id), issues)
+                continue
+
+            # Single atomic claim
+            claim_id = base_claim_id
             if claim_id in seen_claim_ids:
                 claim_id = f"{claim_id}_{counter}"
             seen_claim_ids.add(claim_id)
 
-            text = self._extract_normalized_text(span)
-            claim_type = qual.get("claim_type_candidate") or _DEFAULT_CLAIM_TYPE
-            block_id = getattr(span, "block_id", None)
-            section_id = getattr(span, "section_id", None)
-            role_labels = list(getattr(span, "role_labels", []) or [])
-
-            evidence_ids = self._resolve_evidence_ids(block_id)
             if not evidence_ids:
                 issues.append(ValidationIssue(
                     rule_id="claim_missing_evidence",
@@ -106,21 +202,16 @@ class ClaimObjectBuilder:
                     field=claim_id,
                 ))
 
-            equation_ids = self._link_equations(text, claim_type, role_labels)
+            equation_ids = self._link_equations(text, claim_type, role_labels, block_id, section_id)
             if self._claim_type_implies_equation(claim_type) and not equation_ids:
                 issues.append(ValidationIssue(
                     rule_id="claim_missing_equation_ref",
                     severity="warning",
-                    message=(
-                        f"claim {claim_id} of type {claim_type} should reference equations"
-                    ),
+                    message=f"claim {claim_id} of type {claim_type} should reference equations",
                     field=claim_id,
                 ))
 
             figure_ids, table_ids = self._link_figures_tables(role_labels, claim_type)
-
-            review_note = self._extract_review_note(span)
-            review_status = self._derive_review_status(qual)
 
             record = ClaimObjectRecord(
                 claim_id=claim_id,
@@ -128,7 +219,7 @@ class ClaimObjectBuilder:
                 claim_type=claim_type,
                 text=text,
                 source_evidence_ids=evidence_ids,
-                source_span_ids=[getattr(span, "span_id", "")] if getattr(span, "span_id", None) else [],
+                source_span_ids=[span_id] if span_id else [],
                 concepts=concepts,
                 equation_ids=equation_ids,
                 figure_ids=figure_ids,
@@ -137,7 +228,10 @@ class ClaimObjectBuilder:
                 review_status=review_status,
                 review_note=review_note,
                 section_id=section_id,
-                confidence=float(getattr(span, "confidence", 0.0) or 0.0),
+                confidence=confidence,
+                atomicity="atomic",
+                parent_claim_id=None,
+                subclaim_ids=[],
             )
             claims.append(record)
 
@@ -147,6 +241,37 @@ class ClaimObjectBuilder:
             claims=claims,
             validation_issues=issues,
         )
+
+    def _add_issues_for_record(
+        self,
+        claim_id: str,
+        evidence_ids: list[str],
+        concepts: list,
+        claim_type: str,
+        equation_ids: list[str],
+        issues: list[ValidationIssue],
+    ) -> None:
+        if not evidence_ids:
+            issues.append(ValidationIssue(
+                rule_id="claim_missing_evidence",
+                severity="warning",
+                message=f"claim {claim_id} has no source evidence",
+                field=claim_id,
+            ))
+        if not concepts:
+            issues.append(ValidationIssue(
+                rule_id="claim_concepts_empty",
+                severity="warning",
+                message=f"claim {claim_id} has no concepts",
+                field=claim_id,
+            ))
+        if self._claim_type_implies_equation(claim_type) and not equation_ids:
+            issues.append(ValidationIssue(
+                rule_id="claim_missing_equation_ref",
+                severity="warning",
+                message=f"claim {claim_id} of type {claim_type} should reference equations",
+                field=claim_id,
+            ))
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -199,32 +324,69 @@ class ClaimObjectBuilder:
                     break
         return found
 
-    def _link_equations(self, text: str, claim_type: str, role_labels: list[str]) -> list[str]:
-        if not self._equation_index:
-            return []
-        # Match by equation label e.g. "(3.14)" or "Eq. 3.14"
+    @staticmethod
+    def _normalize_claim_type(raw: str | None) -> str:
+        """Map raw claim type candidate to ontology value (issue #260)."""
+        if not raw:
+            return _DEFAULT_CLAIM_TYPE
+        canonical = raw.strip().lower()
+        if canonical in CLAIM_TYPE_ONTOLOGY:
+            return canonical
+        # Fuzzy match common variants (approximation has its own ontology entry)
+        _ALIASES: dict[str, str] = {
+            "constraint": "incompatibility_or_constraint",
+            "equation": "equation_relation",
+            "derivation_step": "equation_transformation",
+            "update": "measurement_or_update",
+            "observation": "observable_definition",
+        }
+        return _ALIASES.get(canonical, _DEFAULT_CLAIM_TYPE)
+
+    def _link_equations(
+        self,
+        text: str,
+        claim_type: str,
+        role_labels: list[str],
+        block_id: str | None = None,
+        section_id: str | None = None,
+    ) -> list[str]:
         ids: list[str] = []
+        seen: set[str] = set()
+
+        # 1. Label-based matching (primary)
         for eq_id, eq in self._equation_index.items():
             label = getattr(eq, "label", None) or (eq.get("label") if isinstance(eq, dict) else None)
             if not label:
                 continue
-            if label and (
+            if (
                 f"({label})" in text
                 or f"Eq. {label}" in text
                 or f"eq. {label}" in text
                 or f"equation {label}" in text.lower()
             ):
-                ids.append(eq_id)
+                if eq_id not in seen:
+                    ids.append(eq_id)
+                    seen.add(eq_id)
+
+        # 2. Source proximity: same block (issue #260)
+        if block_id and self._claim_type_implies_equation(claim_type):
+            for eq_id in self._block_to_equations.get(block_id, []):
+                if eq_id not in seen:
+                    ids.append(eq_id)
+                    seen.add(eq_id)
+
+        # 3. Source proximity: same section (only for equation claim types when no block match)
+        if not ids and section_id and self._claim_type_implies_equation(claim_type):
+            for eq_id in self._section_to_equations.get(section_id, [])[:3]:
+                if eq_id not in seen:
+                    ids.append(eq_id)
+                    seen.add(eq_id)
+
         return ids
 
     @staticmethod
     def _claim_type_implies_equation(claim_type: str) -> bool:
-        return claim_type in {
-            "equation_definition",
-            "equation_relation",
-            "equation_transformation",
-            "derivation_step",
-        }
+        return claim_type in EQUATION_CLAIM_TYPES
 
     @staticmethod
     def _link_figures_tables(role_labels: list[str], claim_type: str) -> tuple[list[str], list[str]]:

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -18,12 +18,48 @@ REVIEW_STATUSES = [
     "rejected",
 ]
 
+# Domain-neutral claim type ontology (issue #260)
+CLAIM_TYPE_ONTOLOGY = [
+    "definition",
+    "criterion",
+    "assumption",
+    "approximation",
+    "setup",
+    "observable_definition",
+    "operator_relation",
+    "equation_definition",
+    "equation_relation",
+    "equation_transformation",
+    "measurement_or_update",
+    "causal_or_dependency_claim",
+    "incompatibility_or_constraint",
+    "comparison",
+    "result",
+    "conclusion",
+    "limitation",
+    "method_choice",
+    "background",
+    "prior_work",
+    "meta",
+    "unknown",
+]
+
+EQUATION_CLAIM_TYPES = {
+    "equation_definition",
+    "equation_relation",
+    "equation_transformation",
+    "derivation_step",
+    "operator_relation",
+    "measurement_or_update",
+}
+
 
 @dataclass
 class ClaimConcept:
     name: str
     normalized: str
     concept_type: str = "unknown"
+    role: str = "unknown"
 
 
 @dataclass
@@ -43,6 +79,10 @@ class ClaimObjectRecord:
     review_note: str = ""
     section_id: str | None = None
     confidence: float = 0.0
+    # Atomicity support (issue #260)
+    atomicity: str = "atomic"  # "atomic" | "compound" | "split_pending"
+    parent_claim_id: str | None = None
+    subclaim_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -73,7 +113,15 @@ class ClaimObjectBuildResult:
     def from_dict(cls, d: dict) -> "ClaimObjectBuildResult":
         claims = []
         for raw in d.get("claims", []):
-            concepts = [ClaimConcept(**c) for c in raw.get("concepts", [])]
+            concepts = [
+                ClaimConcept(
+                    name=c.get("name", ""),
+                    normalized=c.get("normalized", ""),
+                    concept_type=c.get("concept_type", "unknown"),
+                    role=c.get("role", "unknown"),
+                )
+                for c in raw.get("concepts", [])
+            ]
             claims.append(ClaimObjectRecord(
                 claim_id=raw["claim_id"],
                 document_id=raw["document_id"],
@@ -90,6 +138,9 @@ class ClaimObjectBuildResult:
                 review_note=raw.get("review_note", ""),
                 section_id=raw.get("section_id"),
                 confidence=float(raw.get("confidence", 0.0)),
+                atomicity=raw.get("atomicity", "atomic"),
+                parent_claim_id=raw.get("parent_claim_id"),
+                subclaim_ids=list(raw.get("subclaim_ids", [])),
             ))
         issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
         return cls(

--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -260,7 +260,8 @@ class ComponentAssemblyInputBuilder:
             return []
         ids = []
         for chain in getattr(derivations, "chains", []) or []:
-            chain_id = getattr(chain, "chain_id", None)
+            # DerivationChainRecord uses derivation_id, not chain_id (issue #262)
+            chain_id = getattr(chain, "derivation_id", None) or getattr(chain, "chain_id", None)
             if chain_id:
                 ids.append(chain_id)
             for step in getattr(chain, "steps", []) or []:

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -109,6 +109,18 @@ class ComponentRecord:
     confidence: float
     review_notes: list[str]
     internal_flow: list[dict] = field(default_factory=list)
+    # Typed linked IDs (issue #262)
+    linked_claim_ids: list[str] = field(default_factory=list)
+    linked_equation_ids: list[str] = field(default_factory=list)
+    linked_evidence_ids: list[str] = field(default_factory=list)
+    linked_derivation_ids: list[str] = field(default_factory=list)
+    linked_dsl_node_ids: list[str] = field(default_factory=list)
+    linked_dsl_edge_ids: list[str] = field(default_factory=list)
+    review_status: str = "teacher_review_required"
+    teaching_takeaway: str = ""
+    source_scope: dict = field(default_factory=dict)
+    assumptions: list[str] = field(default_factory=list)
+    approximations: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -138,7 +150,35 @@ class ComponentAssemblyResult:
 
     @classmethod
     def from_dict(cls, d: dict) -> "ComponentAssemblyResult":
-        components = [ComponentRecord(**c) for c in d.get("components", [])]
+        components = []
+        for c in d.get("components", []):
+            components.append(ComponentRecord(
+                component_id=c.get("component_id", ""),
+                component_type=c.get("component_type", ""),
+                label=c.get("label", ""),
+                summary=c.get("summary", ""),
+                inputs=list(c.get("inputs") or []),
+                outputs=list(c.get("outputs") or []),
+                preconditions=list(c.get("preconditions") or []),
+                cautions=list(c.get("cautions") or []),
+                dependencies=list(c.get("dependencies") or []),
+                evidence_refs=c.get("evidence_refs") or {},
+                reason=c.get("reason", ""),
+                confidence=float(c.get("confidence", 0.0)),
+                review_notes=list(c.get("review_notes") or []),
+                internal_flow=list(c.get("internal_flow") or []),
+                linked_claim_ids=list(c.get("linked_claim_ids") or []),
+                linked_equation_ids=list(c.get("linked_equation_ids") or []),
+                linked_evidence_ids=list(c.get("linked_evidence_ids") or []),
+                linked_derivation_ids=list(c.get("linked_derivation_ids") or []),
+                linked_dsl_node_ids=list(c.get("linked_dsl_node_ids") or []),
+                linked_dsl_edge_ids=list(c.get("linked_dsl_edge_ids") or []),
+                review_status=c.get("review_status", "teacher_review_required"),
+                teaching_takeaway=c.get("teaching_takeaway", ""),
+                source_scope=c.get("source_scope") or {},
+                assumptions=list(c.get("assumptions") or []),
+                approximations=list(c.get("approximations") or []),
+            ))
         issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
         return cls(
             document_id=d["document_id"],

--- a/src/episteme_graph/agents/component_assembly/validator.py
+++ b/src/episteme_graph/agents/component_assembly/validator.py
@@ -46,7 +46,7 @@ class ComponentAssemblyValidator:
         available = _build_available_id_index(llm_input)
 
         for component in result.components:
-            issues += self._check_component(component, allowed_components, allowed_dependencies, component_ids)
+            issues += self._check_component(component, allowed_components, allowed_dependencies, component_ids, available)
             issues += self._check_required_fields(component, cartridge)
             if available:
                 issues += self._check_id_references(component, available)
@@ -62,6 +62,7 @@ class ComponentAssemblyValidator:
         allowed_components: set[str],
         allowed_dependencies: set[str],
         component_ids: set[str],
+        available: dict[str, set[str]] | None = None,
     ) -> list[ValidationIssue]:
         issues = []
         if component.component_type not in allowed_components:
@@ -79,7 +80,7 @@ class ComponentAssemblyValidator:
                     f"{component.component_id}.{field} must be a list",
                     f"components[{component.component_id}].{field}",
                 ))
-        issues += self._check_internal_flow(component)
+        issues += self._check_internal_flow(component, available)
         if not (0.0 <= component.confidence <= 1.0):
             issues.append(ValidationIssue(
                 "confidence_out_of_range",
@@ -123,6 +124,7 @@ class ComponentAssemblyValidator:
     def _check_internal_flow(
         self,
         component: ComponentRecord,
+        available: dict[str, set[str]] | None = None,
     ) -> list[ValidationIssue]:
         issues: list[ValidationIssue] = []
         flow = component.internal_flow or []
@@ -135,6 +137,14 @@ class ComponentAssemblyValidator:
                 "expose how inputs are combined into outputs.",
                 f"components[{component.component_id}].internal_flow",
             ))
+
+        # Build a union of all known artifact IDs for from/to validation (issue #262)
+        all_known_ids: set[str] = set()
+        if available:
+            for id_set in available.values():
+                if isinstance(id_set, set):
+                    all_known_ids.update(id_set)
+
         for idx, step in enumerate(flow):
             if not isinstance(step, dict):
                 issues.append(ValidationIssue(
@@ -152,8 +162,23 @@ class ComponentAssemblyValidator:
                     f"{component.component_id}.internal_flow[{idx}] is missing {missing}",
                     f"components[{component.component_id}].internal_flow[{idx}]",
                 ))
+            # Check from/to against known artifact IDs (issue #262)
+            if all_known_ids:
+                for field_name in ("from", "to"):
+                    ref_val = step.get(field_name, "")
+                    if ref_val and ref_val not in all_known_ids:
+                        # Only warn if it looks like an artifact ID (not a human-readable label)
+                        if any(ref_val.startswith(pfx) for pfx in
+                               ("claim_", "eq_", "ev_", "node_", "edge_", "step_", "deriv")):
+                            issues.append(ValidationIssue(
+                                "internal_flow_unresolved_ref",
+                                "warning",
+                                f"{component.component_id}.internal_flow[{idx}].{field_name}={ref_val!r} "
+                                "not found in available artifact IDs",
+                                f"components[{component.component_id}].internal_flow[{idx}].{field_name}",
+                            ))
+
         # If component has multi-input or multi-output, internal_flow should be present
-        # to explain how they relate.
         if not flow and (
             len(component.inputs) >= 2 or len(component.outputs) >= 2
         ) and component.component_type not in ("ClaimBundleComponent",):
@@ -170,95 +195,134 @@ class ComponentAssemblyValidator:
         component: ComponentRecord,
         available: dict[str, set[str]],
     ) -> list[ValidationIssue]:
-        """Cross-reference evidence_refs against known artifact IDs."""
+        """Cross-reference evidence_refs and typed linked IDs against known artifact IDs (issue #262)."""
         issues: list[ValidationIssue] = []
         refs = component.evidence_refs or {}
 
-        # Check claim_ids
+        # Check legacy evidence_refs.claim_ids
         known_claims = available.get("claim_ids", set())
         if known_claims:
-            unknown = [cid for cid in (refs.get("claim_ids") or []) if cid not in known_claims]
+            all_claim_ids = list(refs.get("claim_ids") or []) + list(component.linked_claim_ids or [])
+            unknown = [cid for cid in all_claim_ids if cid not in known_claims]
             for cid in unknown:
                 issues.append(ValidationIssue(
                     "unresolved_claim_id",
                     "error",
-                    f"{component.component_id}.evidence_refs.claim_ids contains unresolved ID: {cid!r}",
-                    f"components[{component.component_id}].evidence_refs.claim_ids",
+                    f"{component.component_id} contains unresolved claim ID: {cid!r}",
+                    f"components[{component.component_id}].linked_claim_ids",
                 ))
 
         # Check evidence_ids
         known_evidence = available.get("evidence_ids", set())
         if known_evidence:
-            unknown = [eid for eid in (refs.get("evidence_ids") or []) if eid not in known_evidence]
+            all_ev_ids = list(refs.get("evidence_ids") or []) + list(component.linked_evidence_ids or [])
+            unknown = [eid for eid in all_ev_ids if eid not in known_evidence]
             for eid in unknown:
                 issues.append(ValidationIssue(
                     "unresolved_evidence_id",
                     "error",
-                    f"{component.component_id}.evidence_refs.evidence_ids contains unresolved ID: {eid!r}",
-                    f"components[{component.component_id}].evidence_refs.evidence_ids",
+                    f"{component.component_id} contains unresolved evidence ID: {eid!r}",
+                    f"components[{component.component_id}].linked_evidence_ids",
                 ))
 
-        # Check equation_ids
+        # Check equation_ids (typed field takes priority)
         known_equations = available.get("equation_ids", set())
         if known_equations:
-            unknown = [eqid for eqid in (refs.get("equation_ids") or []) if eqid not in known_equations]
+            all_eq_ids = list(refs.get("equation_ids") or []) + list(component.linked_equation_ids or [])
+            unknown = [eqid for eqid in all_eq_ids if eqid not in known_equations]
             for eqid in unknown:
                 issues.append(ValidationIssue(
                     "unresolved_equation_id",
                     "error",
-                    f"{component.component_id}.evidence_refs.equation_ids contains unresolved ID: {eqid!r}",
-                    f"components[{component.component_id}].evidence_refs.equation_ids",
+                    f"{component.component_id} contains unresolved equation ID: {eqid!r}",
+                    f"components[{component.component_id}].linked_equation_ids",
+                ))
+
+        # Check derivation IDs (issue #262)
+        known_derivations = available.get("derivation_ids", set())
+        if known_derivations and component.linked_derivation_ids:
+            unknown = [did for did in component.linked_derivation_ids if did not in known_derivations]
+            for did in unknown:
+                issues.append(ValidationIssue(
+                    "unresolved_derivation_id",
+                    "error",
+                    f"{component.component_id} contains unresolved derivation ID: {did!r}",
+                    f"components[{component.component_id}].linked_derivation_ids",
                 ))
 
         # Check DSL node/edge refs
         dsl_refs = refs.get("dsl_refs") or {}
         known_dsl_nodes = available.get("dsl_node_ids", set())
         if known_dsl_nodes:
-            unknown = [nid for nid in (dsl_refs.get("node_ids") or []) if nid not in known_dsl_nodes]
+            all_node_ids = list(dsl_refs.get("node_ids") or []) + list(component.linked_dsl_node_ids or [])
+            unknown = [nid for nid in all_node_ids if nid not in known_dsl_nodes]
             for nid in unknown:
                 issues.append(ValidationIssue(
                     "unresolved_dsl_node_id",
                     "error",
-                    f"{component.component_id}.evidence_refs.dsl_refs.node_ids contains unresolved ID: {nid!r}",
-                    f"components[{component.component_id}].evidence_refs.dsl_refs.node_ids",
+                    f"{component.component_id} contains unresolved DSL node ID: {nid!r}",
+                    f"components[{component.component_id}].linked_dsl_node_ids",
                 ))
         known_dsl_edges = available.get("dsl_edge_ids", set())
         if known_dsl_edges:
-            unknown = [eid for eid in (dsl_refs.get("edge_ids") or []) if eid not in known_dsl_edges]
+            all_edge_ids = list(dsl_refs.get("edge_ids") or []) + list(component.linked_dsl_edge_ids or [])
+            unknown = [eid for eid in all_edge_ids if eid not in known_dsl_edges]
             for eid in unknown:
                 issues.append(ValidationIssue(
                     "unresolved_dsl_edge_id",
                     "error",
-                    f"{component.component_id}.evidence_refs.dsl_refs.edge_ids contains unresolved ID: {eid!r}",
-                    f"components[{component.component_id}].evidence_refs.dsl_refs.edge_ids",
+                    f"{component.component_id} contains unresolved DSL edge ID: {eid!r}",
+                    f"components[{component.component_id}].linked_dsl_edge_ids",
                 ))
 
-        # Detect summary-only component: no claim_ids and no evidence_ids
-        has_claim_link = bool(refs.get("claim_ids"))
-        has_evidence_link = bool(refs.get("evidence_ids"))
+        # Detect summary-only: no typed claim/evidence links in either legacy or new fields
+        has_claim_link = bool(refs.get("claim_ids")) or bool(component.linked_claim_ids)
+        has_evidence_link = bool(refs.get("evidence_ids")) or bool(component.linked_evidence_ids)
         if not has_claim_link and not has_evidence_link:
             issues.append(ValidationIssue(
                 "summary_only_component",
                 "warning",
-                f"{component.component_id} has no claim_ids or evidence_ids in evidence_refs (summary-only)",
+                f"{component.component_id} has no claim_ids or evidence_ids (summary-only)",
                 f"components[{component.component_id}].evidence_refs",
             ))
 
-        # Propagate review_status: if any referenced claim has non-auto review, flag component
-        known_claim_reviews = available.get("_claim_review_map", {})
+        # Component type-specific: equation/derivation dependency without linked IDs (issue #262)
+        eq_heavy_types = {"RelationComponent", "PaperRelationComponent", "DiagnosticComponent"}
+        deriv_types = {"RelationComponent", "MethodComponent"}
+        if component.component_type in eq_heavy_types and known_equations:
+            all_eq = list(refs.get("equation_ids") or []) + list(component.linked_equation_ids or [])
+            if not all_eq:
+                issues.append(ValidationIssue(
+                    "equation_dependent_component_missing_eq_ids",
+                    "warning",
+                    f"{component.component_id} ({component.component_type}) has no equation links",
+                    f"components[{component.component_id}].linked_equation_ids",
+                ))
+        if component.component_type in deriv_types and known_derivations:
+            if not component.linked_derivation_ids:
+                issues.append(ValidationIssue(
+                    "derivation_component_missing_derivation_ids",
+                    "warning",
+                    f"{component.component_id} ({component.component_type}) has no derivation links",
+                    f"components[{component.component_id}].linked_derivation_ids",
+                ))
+
+        # Propagate review_status from referenced claims to component (issue #262)
+        known_claim_reviews = available.get("_claim_review_map", {}) or {}
         if known_claim_reviews:
-            for cid in refs.get("claim_ids") or []:
+            all_claim_refs = list(refs.get("claim_ids") or []) + list(component.linked_claim_ids or [])
+            for cid in all_claim_refs:
                 review = known_claim_reviews.get(cid)
                 if review and review != "auto_accepted":
-                    comp_review = getattr(component, "review_notes", []) or []
-                    if not any("teacher_review" in n for n in comp_review):
+                    if component.review_status == "auto_accepted":
                         issues.append(ValidationIssue(
                             "review_required_claim_in_component",
                             "warning",
-                            f"{component.component_id} references claim {cid!r} with review_status={review!r}",
-                            f"components[{component.component_id}].evidence_refs.claim_ids",
+                            f"{component.component_id} references claim {cid!r} with review_status={review!r}"
+                            " but component.review_status is auto_accepted",
+                            f"components[{component.component_id}].review_status",
                         ))
-                        break
+                    break
 
         return issues
 

--- a/src/episteme_graph/agents/derivation_chain/agent.py
+++ b/src/episteme_graph/agents/derivation_chain/agent.py
@@ -3,6 +3,9 @@
 EquationSemanticsResult の derivation_links を統合し、終端式（leaf result equation）
 から逆方向に traversal して導出 chain を構築する。
 
+Issue #261: equation-only chain を Claim/Evidence/Assumption を含む推論チェーンへ拡張。
+- claim_build_result を受け取り、equation リンクがない場合は claim order / claim_type から chain を生成する。
+
 design:
 - LLM-first ではなく、equation_semantics の局所リンクから決定論的に組み立てる
 - LLM 補助は operation 名の正規化や teaching_takeaway 生成のために
@@ -11,7 +14,7 @@ design:
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Iterable, Optional
+from typing import Optional
 
 from episteme_graph.agents.equation_semantics.schema import (
     EquationRecord,
@@ -20,15 +23,35 @@ from episteme_graph.agents.equation_semantics.schema import (
 
 from .schema import (
     DEFAULT_OPERATION,
+    OPERATION_ONTOLOGY,
     DerivationChainRecord,
     DerivationChainResult,
     DerivationStep,
     ValidationIssue,
 )
 
+# Mapping from claim_type → preferred operation (issue #261)
+_CLAIM_TYPE_TO_OPERATION: dict[str, str] = {
+    "assumption": "state_assumption",
+    "definition": "apply_definition",
+    "equation_definition": "apply_definition",
+    "criterion": "apply_criterion",
+    "observable_definition": "introduce_observable",
+    "equation_relation": "apply_equation",
+    "operator_relation": "apply_equation",
+    "equation_transformation": "substitute",
+    "measurement_or_update": "apply_measurement_or_update",
+    "incompatibility_or_constraint": "apply_non_disturbance_or_independence",
+    "comparison": "compare",
+    "result": "infer_conclusion",
+    "conclusion": "infer_conclusion",
+    "causal_or_dependency_claim": "infer_intermediate_claim",
+    "limitation": "flag_limitation",
+}
+
 
 class DerivationChainAgent:
-    """EquationSemanticsResult から DerivationChain を組み立てる。"""
+    """EquationSemanticsResult (and optionally ClaimObjectBuildResult) から DerivationChain を組み立てる。"""
 
     def __init__(self) -> None:
         pass
@@ -39,9 +62,30 @@ class DerivationChainAgent:
         *,
         cartridge_id: str | None = None,
         claim_link_index: dict[str, list[str]] | None = None,
+        claim_build_result: object | None = None,
+        evidence_registry: object | None = None,
     ) -> DerivationChainResult:
         records: list[EquationRecord] = list(equations.equations)
+
+        # When no equations available, fall back to claim-based chain (issue #261)
         if not records:
+            claim_chains = self._build_claim_chains(
+                equations.document_id,
+                claim_build_result,
+                evidence_registry,
+                cartridge_id,
+            )
+            if claim_chains:
+                return DerivationChainResult(
+                    document_id=equations.document_id,
+                    cartridge_id=cartridge_id,
+                    chains=claim_chains,
+                    validation_issues=[ValidationIssue(
+                        rule_id="derivation_equation_only_fallback",
+                        severity="info",
+                        message="No equations; derivation chains built from claim source order.",
+                    )],
+                )
             return DerivationChainResult(
                 document_id=equations.document_id,
                 cartridge_id=cartridge_id,
@@ -113,23 +157,32 @@ class DerivationChainAgent:
                 },
             ))
 
-        # Quality checks (issue #237 acceptance criteria)
+        # Quality checks (issue #237 / #261 acceptance criteria)
         for chain in chains:
-            chain_has_any_assumption = any(s.assumption_refs for s in chain.steps)
-            chain_has_any_claim = any(s.required_claim_ids for s in chain.steps)
+            chain_has_any_assumption = any(
+                s.assumption_refs or s.assumption_ids for s in chain.steps
+            )
+            chain_has_any_claim = any(
+                s.required_claim_ids or s.input_claim_ids or s.output_claim_ids
+                for s in chain.steps
+            )
             for s in chain.steps:
-                if not s.input_equation_ids:
+                has_eq_input = bool(s.input_equation_ids)
+                has_claim_input = bool(s.input_claim_ids or s.required_claim_ids)
+                if not has_eq_input and not has_claim_input:
                     issues.append(ValidationIssue(
                         rule_id="derivation_step_missing_input",
                         severity="warning",
-                        message=f"step {s.step_id} has no input_equation_ids",
+                        message=f"step {s.step_id} has no input_equation_ids or input_claim_ids",
                         field=chain.derivation_id,
                     ))
-                if not s.output_equation_ids:
+                has_eq_output = bool(s.output_equation_ids)
+                has_claim_output = bool(s.output_claim_ids)
+                if not has_eq_output and not has_claim_output:
                     issues.append(ValidationIssue(
                         rule_id="derivation_step_missing_output",
                         severity="warning",
-                        message=f"step {s.step_id} has no output_equation_ids",
+                        message=f"step {s.step_id} has no output_equation_ids or output_claim_ids",
                         field=chain.derivation_id,
                     ))
                 if not s.operation or s.operation == DEFAULT_OPERATION:
@@ -139,6 +192,15 @@ class DerivationChainAgent:
                         message=f"step {s.step_id} uses generic operation {s.operation!r}",
                         field=chain.derivation_id,
                     ))
+                # Unresolved step references (issue #261)
+                for ref in (s.input_equation_ids + s.output_equation_ids):
+                    if ref and ref not in eq_by_id:
+                        issues.append(ValidationIssue(
+                            rule_id="derivation_step_unresolved_eq_ref",
+                            severity="warning",
+                            message=f"step {s.step_id} references unknown equation {ref!r}",
+                            field=chain.derivation_id,
+                        ))
             if not chain_has_any_assumption:
                 issues.append(ValidationIssue(
                     rule_id="derivation_chain_missing_assumptions",
@@ -146,11 +208,11 @@ class DerivationChainAgent:
                     message=f"chain {chain.derivation_id} has no assumption_refs on any step",
                     field=chain.derivation_id,
                 ))
-            if not chain_has_any_claim and claim_link_index:
+            if not chain_has_any_claim and (claim_link_index or claim_build_result):
                 issues.append(ValidationIssue(
                     rule_id="derivation_chain_missing_claim_links",
                     severity="warning",
-                    message=f"chain {chain.derivation_id} has no required_claim_ids on any step",
+                    message=f"chain {chain.derivation_id} has no claim links on any step",
                     field=chain.derivation_id,
                 ))
             if not chain.teaching_takeaway:
@@ -207,15 +269,24 @@ class DerivationChainAgent:
                 assumptions = list(current_record.semantics.assumptions)
 
             operation = self._infer_operation(current_record)
+            linked_claims = list(claim_link_index.get(current, []))
+            sem_claims = list(current_record.semantics.linked_claim_ids) if current_record else []
+            all_claim_ids = sorted(set(linked_claims + sem_claims))
+            ev_ids = list(current_record.semantics.source_evidence_ids) if current_record else []
             step = DerivationStep(
                 step_id=f"step_{step_counter:03d}",
                 input_equation_ids=list(sources),
                 operation=operation,
                 output_equation_ids=[current],
-                required_claim_ids=list(claim_link_index.get(current, [])),
+                required_claim_ids=all_claim_ids,
                 assumption_refs=assumptions,
                 reason=current_record.semantics.summary if current_record else "",
                 confidence=current_record.semantics.confidence if current_record else 0.0,
+                input_claim_ids=[],
+                output_claim_ids=[],
+                assumption_ids=assumptions,
+                source_evidence_ids=ev_ids,
+                review_status="teacher_review_required",
             )
             steps.append(step)
             for s in sources:
@@ -228,6 +299,90 @@ class DerivationChainAgent:
         for idx, s in enumerate(steps, start=1):
             s.step_id = f"step_{idx:03d}"
         return steps, sections
+
+    def _build_claim_chains(
+        self,
+        document_id: str,
+        claim_build_result: object | None,
+        evidence_registry: object | None,
+        cartridge_id: str | None,
+    ) -> list[DerivationChainRecord]:
+        """Claim type/source order ベースで軽量な chain を生成する (issue #261)."""
+        if not claim_build_result:
+            return []
+        claims = getattr(claim_build_result, "claims", []) or []
+        if not claims:
+            return []
+
+        # Build evidence lookup: evidence_id → evidence record
+        ev_by_block: dict[str, list[str]] = {}
+        for ev_rec in getattr(evidence_registry, "records", []) or []:
+            src = getattr(ev_rec, "source", None)
+            bid = getattr(src, "block_id", None) if src else None
+            ev_id = getattr(ev_rec, "evidence_id", None)
+            if bid and ev_id:
+                ev_by_block.setdefault(bid, []).append(ev_id)
+
+        # Group claims by section, preserve order
+        section_groups: dict[str, list] = {}
+        no_section: list = []
+        for c in claims:
+            sid = getattr(c, "section_id", None) or ""
+            if sid:
+                section_groups.setdefault(sid, []).append(c)
+            else:
+                no_section.append(c)
+
+        chains: list[DerivationChainRecord] = []
+        chain_counter = 0
+
+        for section_id, section_claims in section_groups.items():
+            if len(section_claims) < 2:
+                continue
+            chain_counter += 1
+            steps: list[DerivationStep] = []
+            prev_claim_id: str | None = None
+
+            for step_idx, claim in enumerate(section_claims, start=1):
+                claim_id = getattr(claim, "claim_id", None) or f"claim_{step_idx}"
+                claim_type = getattr(claim, "claim_type", "unknown") or "unknown"
+                operation = _CLAIM_TYPE_TO_OPERATION.get(claim_type, "infer_intermediate_claim")
+
+                # Evidence IDs for this claim
+                source_ev_ids: list[str] = list(getattr(claim, "source_evidence_ids", []) or [])
+
+                steps.append(DerivationStep(
+                    step_id=f"step_{step_idx:03d}",
+                    input_equation_ids=[],
+                    operation=operation,
+                    output_equation_ids=[],
+                    required_claim_ids=[prev_claim_id] if prev_claim_id else [],
+                    assumption_refs=list(claim_id for c2 in section_claims[:step_idx - 1]
+                                        if getattr(c2, "claim_type", "") == "assumption"
+                                        for claim_id in [getattr(c2, "claim_id", "")]),
+                    reason=getattr(claim, "review_note", "") or "",
+                    confidence=float(getattr(claim, "confidence", 0.5) or 0.5),
+                    input_claim_ids=[prev_claim_id] if prev_claim_id else [],
+                    output_claim_ids=[claim_id],
+                    assumption_ids=[],
+                    source_evidence_ids=source_ev_ids,
+                    review_status="teacher_review_required",
+                ))
+                prev_claim_id = claim_id
+
+            chains.append(DerivationChainRecord(
+                derivation_id=f"derivation_claim_{chain_counter:04d}",
+                document_id=document_id,
+                source_section_ids=[section_id],
+                steps=steps,
+                teaching_takeaway=f"Logical progression through {len(steps)} claims in section {section_id}",
+                blackbox_policy_suggestion={},
+                source_scope={"section_id": section_id},
+                linked_component_ids=[],
+                chain_type="claim_chain",
+            ))
+
+        return chains
 
     @staticmethod
     def _generate_takeaway(

--- a/src/episteme_graph/agents/derivation_chain/schema.py
+++ b/src/episteme_graph/agents/derivation_chain/schema.py
@@ -1,4 +1,7 @@
-"""DerivationChain data models."""
+"""DerivationChain data models.
+
+Issue #261: equation-only chain を Claim/Evidence/Assumption を含む推論チェーンへ拡張。
+"""
 from __future__ import annotations
 
 import json
@@ -6,6 +9,37 @@ from dataclasses import asdict, dataclass, field
 
 
 DEFAULT_OPERATION = "transform"
+
+# Domain-neutral operation ontology (issue #261)
+OPERATION_ONTOLOGY = [
+    "state_assumption",
+    "apply_definition",
+    "apply_criterion",
+    "introduce_observable",
+    "apply_equation",
+    "substitute",
+    "normalize",
+    "approximate",
+    "compare",
+    "branch_on_condition",
+    "apply_measurement_or_update",
+    "apply_non_disturbance_or_independence",
+    "infer_intermediate_claim",
+    "infer_conclusion",
+    "flag_limitation",
+    # Retained from existing ontology
+    "define",
+    "relate",
+    "transform",
+    "derive_result",
+    "apply_constraint",
+]
+
+STEP_REVIEW_STATUSES = [
+    "auto_accepted",
+    "teacher_review_required",
+    "needs_verification",
+]
 
 
 @dataclass
@@ -18,6 +52,12 @@ class DerivationStep:
     assumption_refs: list[str] = field(default_factory=list)
     reason: str = ""
     confidence: float = 0.0
+    # Extended fields for Claim/Evidence/Assumption (issue #261)
+    input_claim_ids: list[str] = field(default_factory=list)
+    output_claim_ids: list[str] = field(default_factory=list)
+    assumption_ids: list[str] = field(default_factory=list)
+    source_evidence_ids: list[str] = field(default_factory=list)
+    review_status: str = "teacher_review_required"
 
 
 @dataclass
@@ -28,6 +68,10 @@ class DerivationChainRecord:
     steps: list[DerivationStep]
     teaching_takeaway: str = ""
     blackbox_policy_suggestion: dict = field(default_factory=dict)
+    # Extended fields (issue #261)
+    source_scope: dict = field(default_factory=dict)
+    linked_component_ids: list[str] = field(default_factory=list)
+    chain_type: str = "equation_chain"  # "equation_chain" | "claim_chain" | "mixed_chain"
 
 
 @dataclass
@@ -55,7 +99,23 @@ class DerivationChainResult:
     def from_dict(cls, d: dict) -> "DerivationChainResult":
         chains = []
         for c in d.get("chains", []):
-            steps = [DerivationStep(**s) for s in c.get("steps", [])]
+            steps = []
+            for s in c.get("steps", []):
+                steps.append(DerivationStep(
+                    step_id=s.get("step_id", ""),
+                    input_equation_ids=list(s.get("input_equation_ids") or []),
+                    operation=s.get("operation", DEFAULT_OPERATION),
+                    output_equation_ids=list(s.get("output_equation_ids") or []),
+                    required_claim_ids=list(s.get("required_claim_ids") or []),
+                    assumption_refs=list(s.get("assumption_refs") or []),
+                    reason=s.get("reason", ""),
+                    confidence=float(s.get("confidence", 0.0)),
+                    input_claim_ids=list(s.get("input_claim_ids") or []),
+                    output_claim_ids=list(s.get("output_claim_ids") or []),
+                    assumption_ids=list(s.get("assumption_ids") or []),
+                    source_evidence_ids=list(s.get("source_evidence_ids") or []),
+                    review_status=s.get("review_status", "teacher_review_required"),
+                ))
             chains.append(DerivationChainRecord(
                 derivation_id=c["derivation_id"],
                 document_id=c["document_id"],
@@ -63,6 +123,9 @@ class DerivationChainResult:
                 steps=steps,
                 teaching_takeaway=c.get("teaching_takeaway", ""),
                 blackbox_policy_suggestion=c.get("blackbox_policy_suggestion", {}),
+                source_scope=c.get("source_scope", {}),
+                linked_component_ids=list(c.get("linked_component_ids") or []),
+                chain_type=c.get("chain_type", "equation_chain"),
             ))
         issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
         return cls(

--- a/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
+++ b/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
@@ -1,6 +1,7 @@
 """EquationAcceptanceGate: candidate acceptance / rejection / merge classification.
 
 Issue #245 で定義された受け入れ基準に従い、EquationCandidate を決定論的に分類する。
+Issue #259: high-signal 候補を provisional として保持する。
 LLM を使用しない。
 """
 from __future__ import annotations
@@ -67,13 +68,23 @@ class EquationAcceptanceGate:
             return self._mark(candidate, "missing", "context_only", True, ["equation_body_missing"])
 
         if _LABEL_ONLY_RE.match(text):
+            # High-signal: has a matched_label or display math → provisional (issue #259)
+            if self._is_high_signal(candidate):
+                return self._mark(candidate, "label_only", "provisional", True,
+                                  ["label_only_candidate", "needs_math_review"])
             return self._mark(candidate, "label_only", "rejected", True, ["label_only_candidate"])
 
         if self._is_operator_only(text):
+            if self._is_high_signal(candidate):
+                return self._mark(candidate, "fragment_only", "provisional", True,
+                                  ["fragment_only_candidate", "needs_merge"])
             return self._mark(candidate, "fragment_only", "needs_merge", True,
                               ["fragment_only_candidate", "needs_merge"])
 
         if self._is_too_short_without_relation(text):
+            if self._is_high_signal(candidate):
+                return self._mark(candidate, "fragment_only", "provisional", True,
+                                  ["fragment_only_candidate", "needs_merge"])
             return self._mark(candidate, "fragment_only", "needs_merge", True,
                               ["fragment_only_candidate", "needs_merge"])
 
@@ -88,8 +99,28 @@ class EquationAcceptanceGate:
             candidate.needs_math_review = False
             return candidate
 
-        # 何も合致しない → unparsed
+        # 何も合致しない → unparsed; high-signal candidates get provisional
+        if self._is_high_signal(candidate):
+            return self._mark(candidate, "unparsed", "provisional", True, ["ambiguous_math_text"])
         return self._mark(candidate, "unparsed", "context_only", True, ["ambiguous_math_text"])
+
+    @staticmethod
+    def _is_high_signal(candidate: EquationCandidate) -> bool:
+        """High-signal 判定: 以下のいずれかを満たす候補は provisional として保持する (issue #259).
+
+        - matched_label が non-empty (式番号参照あり) — 最も強い信号
+        - detection_method に equation_number_pattern が含まれる (label pattern-matched)
+
+        注意: document_structure_equation_block は全 equation block のデフォルト検出法のため、
+        これ単体では high-signal とみなさない。candidate_score はブロック検出信頼度であり
+        式本体の完全性とは独立しているため、high-signal 判定には使わない。
+        """
+        if candidate.matched_label:
+            return True
+        dm = candidate.detection_method or []
+        if "equation_number_pattern" in dm:
+            return True
+        return False
 
     @staticmethod
     def _is_operator_only(text: str) -> bool:

--- a/src/episteme_graph/agents/equation_semantics/agent.py
+++ b/src/episteme_graph/agents/equation_semantics/agent.py
@@ -19,12 +19,71 @@ from .repair import EquationSemanticsRepairer, _fallback_record, _parse_record
 from .schema import (
     CartridgeContext,
     EquationCandidate,
+    EquationConfidencePolicy,
     EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
     EquationSemanticsResult,
+    EquationSourceExtraction,
 )
 from .validator import EquationSemanticsValidator
 
 logger = logging.getLogger(__name__)
+
+
+def _make_provisional_record(candidate: EquationCandidate) -> EquationRecord:
+    """Create a minimal reviewable EquationRecord for a provisional candidate (issue #259).
+
+    confidence_policy.can_support_claim is always False for provisional records.
+    """
+    src_loc = dict(candidate.source_location) if candidate.source_location else {}
+    source_extraction = EquationSourceExtraction(
+        raw_text=candidate.raw_text,
+        latex=None,
+        plain_text=candidate.raw_text or None,
+        source_location=src_loc,
+        extraction_source="pdf_text_layer",
+        extraction_status=candidate.extraction_status,
+        needs_math_review=True,
+        review_reason=list(candidate.review_reason),
+    )
+    reconstruction = EquationReconstruction.make_none()
+    semantics = EquationSemantics(
+        equation_type="unknown",
+        secondary_types=[],
+        semantic_status="unknown",
+        confidence=0.0,
+        reason="provisional_candidate_no_llm_analysis",
+        defined_symbols=[],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary="",
+        review_flags=["needs_reconstruction", "partial_extraction"],
+    )
+    confidence_policy = EquationConfidencePolicy(
+        can_support_claim=False,
+        can_be_used_in_derivation=False,
+        can_be_displayed_in_course=True,
+        display_requires_note=True,
+        must_not_treat_as_source_extracted=True,
+    )
+    eq_id = f"eq_provisional_{candidate.candidate_id}"
+    candidate.accepted_equation_id = eq_id
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id=candidate.document_id,
+        label=candidate.matched_label,
+        candidate_trace_ids=[candidate.candidate_id],
+        source_extraction=source_extraction,
+        reconstruction=reconstruction,
+        semantics=semantics,
+        confidence_policy=confidence_policy,
+    )
 
 
 class EquationSemanticsAgent:
@@ -61,13 +120,19 @@ class EquationSemanticsAgent:
                 structure.document_id, cartridge_id, None, "No equation blocks for semantics"
             )
 
-        # Step 2: Acceptance gate (accepted / rejected / needs_merge / context_only を分類)
+        # Step 2: Acceptance gate (accepted / rejected / needs_merge / context_only / provisional を分類)
         classified_candidates = self._acceptance_gate.process(candidates)
         accepted = [c for c in classified_candidates if c.acceptance_status == "accepted"]
+        provisional = [c for c in classified_candidates if c.acceptance_status == "provisional"]
+
+        # Provisional candidates → minimal EquationRecord without LLM (issue #259)
+        provisional_records: list[EquationRecord] = [
+            _make_provisional_record(c) for c in provisional
+        ]
 
         if not accepted:
             logger.info(
-                "document=%s: all %d equation candidates were rejected by acceptance gate",
+                "document=%s: all %d equation candidates were rejected/provisional by acceptance gate",
                 structure.document_id,
                 len(classified_candidates),
             )
@@ -75,7 +140,7 @@ class EquationSemanticsAgent:
                 document_id=structure.document_id,
                 cartridge_id=cartridge.cartridge_id if cartridge else cartridge_id,
                 equation_candidates=classified_candidates,
-                equations=[],
+                equations=provisional_records,
             )
             result.validation_issues = self._validator.validate(result, cartridge)
             return result
@@ -142,7 +207,7 @@ class EquationSemanticsAgent:
             document_id=structure.document_id,
             cartridge_id=cartridge.cartridge_id if cartridge else cartridge_id,
             equation_candidates=classified_candidates,
-            equations=records,
+            equations=provisional_records + records,
         )
         result.validation_issues = self._validator.validate(result, cartridge)
         return result

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -21,7 +21,7 @@ EXTRACTION_STATUSES = [
     "unparsed",
 ]
 
-ACCEPTANCE_STATUSES = ["accepted", "rejected", "needs_merge", "context_only"]
+ACCEPTANCE_STATUSES = ["accepted", "rejected", "needs_merge", "context_only", "provisional"]
 
 RECONSTRUCTION_STATUSES = [
     "none",

--- a/src/tests/agents/derivation_chain/test_agent.py
+++ b/src/tests/agents/derivation_chain/test_agent.py
@@ -1,148 +1,246 @@
-"""Tests for DerivationChainAgent."""
+"""Tests for DerivationChainAgent — updated for nested EquationRecord schema (issue #261)."""
 from __future__ import annotations
 
 from episteme_graph.agents.derivation_chain import DerivationChainAgent
+from episteme_graph.agents.derivation_chain.schema import OPERATION_ONTOLOGY
 from episteme_graph.agents.equation_semantics.schema import (
     DefinedSymbol,
-    DerivationLinks,
-    EquationRolePrediction,
-    EquationSemanticsRecord,
+    EquationCandidate,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
     EquationSemanticsResult,
-    LocalAssumption,
+    EquationSourceExtraction,
 )
 
 
 def _make_eq(
     eq_id: str,
     *,
-    role: str = "equation_relation",
+    role: str = "relation",
     from_eqs: list[str] | None = None,
     section_id: str = "doc_test:sec_3_1",
     summary: str = "",
-) -> EquationSemanticsRecord:
-    return EquationSemanticsRecord(
-        equation_id=eq_id,
-        block_id=f"blk_{eq_id}",
-        section_id=section_id,
-        section_title=None,
-        label=eq_id.replace("eq_", "").replace("_", "."),
-        text="LaTeX placeholder",
+    assumptions: list[str] | None = None,
+    linked_claim_ids: list[str] | None = None,
+    source_evidence_ids: list[str] | None = None,
+) -> EquationRecord:
+    src = EquationSourceExtraction(
+        raw_text="LaTeX placeholder",
         latex=None,
         plain_text=None,
-        equation_role=EquationRolePrediction(
-            primary=role, secondary=[], confidence=0.85, reason=""
-        ),
+        source_location={
+            "page": 1,
+            "section_id": section_id,
+            "block_id": f"blk_{eq_id}",
+            "bbox": [],
+        },
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+        needs_math_review=False,
+        review_reason=[],
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type=role,
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.85,
+        reason="",
         defined_symbols=[],
-        local_assumptions=[LocalAssumption(text="heavy_quark_limit", source_block_ids=[])],
-        derivation_links=DerivationLinks(
-            from_equations=list(from_eqs or []),
-            to_equations=[],
-            linked_text_spans=[],
-        ),
+        used_symbols=[],
+        assumptions=list(assumptions if assumptions is not None else ["heavy_quark_limit"]),
+        input_equation_ids=list(from_eqs or []),
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=list(source_evidence_ids or []),
+        linked_claim_ids=list(linked_claim_ids or []),
         summary=summary,
         review_flags=[],
+    )
+    cp = EquationConfidencePolicy.derive(src, rec, sem)
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id="doc_test",
+        label=eq_id.replace("eq_", "").replace("_", "."),
+        candidate_trace_ids=[f"eqcand_blk_{eq_id}"],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=cp,
+    )
+
+
+def _make_result(eqs: list[EquationRecord]) -> EquationSemanticsResult:
+    return EquationSemanticsResult(
+        document_id="doc_test",
+        cartridge_id="particle_physics",
+        equation_candidates=[],
+        equations=eqs,
     )
 
 
 def test_chain_walks_back_from_leaf_result():
-    equations = EquationSemanticsResult(
-        document_id="doc_test",
-        cartridge_id="particle_physics",
-        equations=[
-            _make_eq("eq_1_2", role="equation_definition"),
-            _make_eq("eq_3_1", from_eqs=["eq_1_2"], role="equation_transformation"),
-            _make_eq("eq_3_5", from_eqs=["eq_3_1"], role="equation_approximation"),
-            _make_eq("eq_3_14", from_eqs=["eq_3_5"], role="equation_result"),
-        ],
-    )
+    result = _make_result([
+        _make_eq("eq_1_2", role="definition"),
+        _make_eq("eq_3_1", from_eqs=["eq_1_2"], role="transformation"),
+        _make_eq("eq_3_5", from_eqs=["eq_3_1"], role="approximation"),
+        _make_eq("eq_3_14", from_eqs=["eq_3_5"], role="result"),
+    ])
     agent = DerivationChainAgent()
-    result = agent.run(equations)
+    chain_result = agent.run(result)
 
-    assert len(result.chains) == 1
-    chain = result.chains[0]
+    assert len(chain_result.chains) == 1
+    chain = chain_result.chains[0]
     assert chain.derivation_id == "derivation_eq_3_14"
-    # 3 steps: eq_1_2 -> eq_3_1 -> eq_3_5 -> eq_3_14
+    # Steps: eq_1_2→eq_3_1, eq_3_1→eq_3_5, eq_3_5→eq_3_14
     assert [s.output_equation_ids for s in chain.steps] == [
         ["eq_3_1"], ["eq_3_5"], ["eq_3_14"]
     ]
     assert chain.steps[0].input_equation_ids == ["eq_1_2"]
     assert chain.steps[-1].operation == "derive_result"
-    # Each step should have assumption_refs propagated
+    # Assumption refs propagated
     assert all(s.assumption_refs == ["heavy_quark_limit"] for s in chain.steps)
 
 
 def test_no_chains_when_no_links():
-    equations = EquationSemanticsResult(
-        document_id="doc_test",
-        cartridge_id=None,
-        equations=[_make_eq("eq_a"), _make_eq("eq_b")],
-    )
+    result = _make_result([_make_eq("eq_a"), _make_eq("eq_b")])
     agent = DerivationChainAgent()
-    result = agent.run(equations)
-    assert result.chains == []
+    chain_result = agent.run(result)
+    assert chain_result.chains == []
 
 
 def test_required_claim_ids_propagated():
-    equations = EquationSemanticsResult(
-        document_id="doc_test",
-        cartridge_id=None,
-        equations=[
-            _make_eq("eq_1"),
-            _make_eq("eq_2", from_eqs=["eq_1"], role="equation_result"),
-        ],
-    )
+    result = _make_result([
+        _make_eq("eq_1"),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result"),
+    ])
     agent = DerivationChainAgent()
-    result = agent.run(equations, claim_link_index={"eq_2": ["claim_xyz"]})
-    assert result.chains[0].steps[0].required_claim_ids == ["claim_xyz"]
+    chain_result = agent.run(result, claim_link_index={"eq_2": ["claim_xyz"]})
+    assert "claim_xyz" in chain_result.chains[0].steps[0].required_claim_ids
+
+
+def test_semantics_linked_claim_ids_propagated():
+    """EquationSemantics.linked_claim_ids も step に伝播する (issue #261)."""
+    result = _make_result([
+        _make_eq("eq_1"),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result", linked_claim_ids=["claim_abc"]),
+    ])
+    agent = DerivationChainAgent()
+    chain_result = agent.run(result)
+    assert "claim_abc" in chain_result.chains[0].steps[0].required_claim_ids
+
+
+def test_source_evidence_ids_propagated():
+    """EquationSemantics.source_evidence_ids が step に伝播する (issue #261)."""
+    result = _make_result([
+        _make_eq("eq_1"),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result", source_evidence_ids=["ev_0001"]),
+    ])
+    agent = DerivationChainAgent()
+    chain_result = agent.run(result)
+    assert "ev_0001" in chain_result.chains[0].steps[0].source_evidence_ids
 
 
 def test_teaching_takeaway_is_generated():
-    equations = EquationSemanticsResult(
-        document_id="doc_test",
-        cartridge_id=None,
-        equations=[
-            _make_eq("eq_1"),
-            _make_eq("eq_2", from_eqs=["eq_1"], role="equation_result"),
-        ],
-    )
+    result = _make_result([
+        _make_eq("eq_1"),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result"),
+    ])
     agent = DerivationChainAgent()
-    result = agent.run(equations)
-    assert result.chains[0].teaching_takeaway
-    assert "eq_2" in result.chains[0].teaching_takeaway
-    assert "eq_1" in result.chains[0].teaching_takeaway
+    chain_result = agent.run(result)
+    assert chain_result.chains[0].teaching_takeaway
+    assert "eq_2" in chain_result.chains[0].teaching_takeaway
+    assert "eq_1" in chain_result.chains[0].teaching_takeaway
 
 
 def test_chain_missing_assumptions_emits_warning():
-    def _no_assumption(eq_id, **kw):
-        rec = _make_eq(eq_id, **kw)
-        rec.local_assumptions = []
-        return rec
-
-    equations = EquationSemanticsResult(
-        document_id="doc_test",
-        cartridge_id=None,
-        equations=[
-            _no_assumption("eq_1"),
-            _no_assumption("eq_2", from_eqs=["eq_1"], role="equation_result"),
-        ],
-    )
+    result = _make_result([
+        _make_eq("eq_1", assumptions=[]),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result", assumptions=[]),
+    ])
     agent = DerivationChainAgent()
-    result = agent.run(equations)
-    rules = {i.rule_id for i in result.validation_issues}
+    chain_result = agent.run(result)
+    rules = {i.rule_id for i in chain_result.validation_issues}
     assert "derivation_chain_missing_assumptions" in rules
 
 
 def test_missing_claim_links_emits_warning_when_index_supplied():
-    equations = EquationSemanticsResult(
+    result = _make_result([
+        _make_eq("eq_a"),
+        _make_eq("eq_b", from_eqs=["eq_a"], role="result"),
+    ])
+    agent = DerivationChainAgent()
+    chain_result = agent.run(result, claim_link_index={"eq_xxx": ["c1"]})
+    rules = {i.rule_id for i in chain_result.validation_issues}
+    assert "derivation_chain_missing_claim_links" in rules
+
+
+def test_claim_chain_generated_when_no_equations():
+    """equation がない場合に claim order ベースの chain を生成する (issue #261)."""
+    from episteme_graph.agents.claim_object_builder.schema import ClaimObjectBuildResult, ClaimObjectRecord, ClaimConcept
+
+    claim_result = ClaimObjectBuildResult(
         document_id="doc_test",
         cartridge_id=None,
-        equations=[
-            _make_eq("eq_a"),
-            _make_eq("eq_b", from_eqs=["eq_a"], role="equation_result"),
+        claims=[
+            ClaimObjectRecord(
+                claim_id="claim_001",
+                document_id="doc_test",
+                claim_type="assumption",
+                text="Assume heavy quark limit.",
+                source_evidence_ids=["ev_0001"],
+                source_span_ids=["span_001"],
+                concepts=[],
+                section_id="doc_test:sec_1",
+            ),
+            ClaimObjectRecord(
+                claim_id="claim_002",
+                document_id="doc_test",
+                claim_type="result",
+                text="The decay rate is bounded.",
+                source_evidence_ids=[],
+                source_span_ids=["span_002"],
+                concepts=[],
+                section_id="doc_test:sec_1",
+            ),
         ],
     )
+    empty_equations = _make_result([])
     agent = DerivationChainAgent()
-    # claim_link_index supplied but no matching keys -> empty required_claim_ids
-    result = agent.run(equations, claim_link_index={"eq_xxx": ["c1"]})
-    rules = {i.rule_id for i in result.validation_issues}
-    assert "derivation_chain_missing_claim_links" in rules
+    chain_result = agent.run(empty_equations, claim_build_result=claim_result)
+
+    assert len(chain_result.chains) == 1
+    chain = chain_result.chains[0]
+    assert chain.chain_type == "claim_chain"
+    assert len(chain.steps) == 2
+    assert chain.steps[-1].operation == "infer_conclusion"
+
+
+def test_step_schema_has_extended_fields():
+    """DerivationStep に issue #261 拡張フィールドがある。"""
+    result = _make_result([
+        _make_eq("eq_x"),
+        _make_eq("eq_y", from_eqs=["eq_x"], role="result"),
+    ])
+    agent = DerivationChainAgent()
+    chain_result = agent.run(result)
+    step = chain_result.chains[0].steps[0]
+    assert hasattr(step, "input_claim_ids")
+    assert hasattr(step, "output_claim_ids")
+    assert hasattr(step, "assumption_ids")
+    assert hasattr(step, "source_evidence_ids")
+    assert hasattr(step, "review_status")
+
+
+def test_operation_ontology_is_valid():
+    """OPERATION_ONTOLOGY に期待するエントリが含まれる (issue #261)."""
+    required = [
+        "state_assumption", "apply_definition", "apply_criterion",
+        "introduce_observable", "apply_equation", "substitute",
+        "normalize", "approximate", "compare",
+        "infer_intermediate_claim", "infer_conclusion", "flag_limitation",
+    ]
+    for op in required:
+        assert op in OPERATION_ONTOLOGY, f"{op!r} missing from OPERATION_ONTOLOGY"

--- a/src/tests/agents/dsl_linking/test_agent.py
+++ b/src/tests/agents/dsl_linking/test_agent.py
@@ -8,10 +8,13 @@ from episteme_graph.agents.dsl_linking.agent import DSLLinkingAgent
 from episteme_graph.agents.dsl_linking.schema import DSLLinkingResult
 from episteme_graph.agents.equation_semantics.schema import (
     DefinedSymbol,
-    DerivationLinks,
-    EquationRolePrediction,
-    EquationSemanticsRecord,
+    EquationCandidate,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
     EquationSemanticsResult,
+    EquationSourceExtraction,
 )
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult, THESIS_VERSION
 
@@ -53,27 +56,60 @@ def _qualified():
     )
 
 
+def _make_eq_record(eq_id: str, label: str, block_id: str, section_id: str, from_eqs: list[str] | None = None) -> EquationRecord:
+    src = EquationSourceExtraction(
+        raw_text="R Lambda c = RD + RD*",
+        latex=None,
+        plain_text="R Lambda c = RD + RD*",
+        source_location={
+            "page": 1,
+            "section_id": section_id,
+            "block_id": block_id,
+            "bbox": [],
+        },
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+        needs_math_review=False,
+        review_reason=[],
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type="equation_relation",
+        secondary_types=["equation_result"],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason="relation",
+        defined_symbols=[DefinedSymbol("R Lambda c", "used", None)],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=list(from_eqs or []),
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary="Total-rate sum rule relation.",
+        review_flags=[],
+    )
+    cp = EquationConfidencePolicy.derive(src, rec, sem)
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id="doc_test",
+        label=label,
+        candidate_trace_ids=[f"eqcand_{block_id}"],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=cp,
+    )
+
+
 def _equations():
     return EquationSemanticsResult(
-        "doc_test",
-        None,
-        [
-            EquationSemanticsRecord(
-                equation_id="eq_3_14",
-                block_id="e1",
-                section_id="sec_1",
-                section_title="Derivation",
-                label="3.14",
-                text="R Lambda c = RD + RD*",
-                latex=None,
-                plain_text="R Lambda c = RD + RD*",
-                equation_role=EquationRolePrediction("equation_relation", ["equation_result"], 0.9, "relation"),
-                defined_symbols=[DefinedSymbol("R Lambda c", "used", None)],
-                local_assumptions=[],
-                derivation_links=DerivationLinks(["eq_1_2"], [], []),
-                summary="Total-rate sum rule relation.",
-                review_flags=[],
-            )
+        document_id="doc_test",
+        cartridge_id=None,
+        equation_candidates=[],
+        equations=[
+            _make_eq_record("eq_3_14", "3.14", "e1", "sec_1", from_eqs=["eq_1_2"]),
         ],
     )
 

--- a/src/tests/agents/equation_semantics/test_agent.py
+++ b/src/tests/agents/equation_semantics/test_agent.py
@@ -155,8 +155,13 @@ def test_fragment_only_blocks_are_not_processed_by_llm():
     assert mock_llm.generate.call_count == 1
 
 
-def test_label_only_blocks_are_rejected():
-    """Label-only equation blocks should be rejected by acceptance gate."""
+def test_label_only_blocks_with_matched_label_become_provisional():
+    """Label-only blocks with a matched label → provisional (issue #259).
+
+    The input_builder extracts the label "3.14" from "(3.14)" and sets
+    matched_label, making this a high-signal provisional candidate instead
+    of a rejected one.
+    """
     structure = DocumentStructureResult(
         document_id="doc_test",
         source_file="/tmp/test.pdf",
@@ -174,9 +179,16 @@ def test_label_only_blocks_are_rejected():
         result = agent.run(structure)
 
     label_candidates = [c for c in result.equation_candidates if c.source_location["block_id"] == "e_label"]
-    assert label_candidates[0].acceptance_status == "rejected"
     assert label_candidates[0].extraction_status == "label_only"
+    # matched_label present → provisional (high-signal, not outright rejected)
+    assert label_candidates[0].acceptance_status == "provisional"
+    # LLM is called only for accepted block, not for provisional
     assert mock_llm.generate.call_count == 1
+    # Provisional EquationRecord is generated with can_support_claim=False
+    provisional_records = [r for r in result.equations if r.confidence_policy.can_support_claim is False
+                           and r.equation_id.startswith("eq_provisional")]
+    assert len(provisional_records) == 1
+    assert provisional_records[0].label == "3.14"
 
 
 def test_relation_or_result_summary_is_preserved():
@@ -234,8 +246,12 @@ def test_llm_failure_returns_unknown_fallback_record():
     assert result.equations[0].confidence_policy.can_support_claim is False
 
 
-def test_all_rejected_returns_empty_equations():
-    """全候補が rejection gate で落とされた場合、equations は空。"""
+def test_no_accepted_returns_provisional_only_no_llm():
+    """全候補が accepted でない場合、LLM は呼ばれず provisional のみが返る (issue #259).
+
+    "(3.14)" → matched_label あり → provisional EquationRecord が生成される
+    "+"     → fragment, no matched_label → needs_merge (no EquationRecord)
+    """
     structure = DocumentStructureResult(
         document_id="doc_test",
         source_file="/tmp/test.pdf",
@@ -243,14 +259,17 @@ def test_all_rejected_returns_empty_equations():
         metadata=DocumentMetadata(title="Test", pages=1),
         sections=[Section("sec_1", "Results", 1, 1, 1)],
         blocks=[
-            _typed("e1", "(3.14)", "equation_block", 0),   # label_only → rejected
-            _typed("e2", "+", "equation_block", 1),         # fragment → needs_merge
+            _typed("e1", "(3.14)", "equation_block", 0),   # label_only + matched_label → provisional
+            _typed("e2", "+", "equation_block", 1),         # fragment → needs_merge (no record)
         ],
     )
     agent = EquationSemanticsAgent()
     with patch.object(agent._llm_client, "generate") as mock_llm:
         result = agent.run(structure)
 
-    assert result.equations == []
-    assert len(result.equation_candidates) == 2
     mock_llm.assert_not_called()
+    assert len(result.equation_candidates) == 2
+    # "(3.14)" gets a provisional EquationRecord; "+" does not
+    provisional_eq = [e for e in result.equations if e.confidence_policy.can_support_claim is False]
+    assert len(provisional_eq) == 1
+    assert provisional_eq[0].confidence_policy.must_not_treat_as_source_extracted is True


### PR DESCRIPTION
## Summary

This PR extends the derivation chain agent to support reasoning chains that include claims, evidence, and assumptions in addition to equations. It also refactors the equation semantics schema to use a nested structure (EquationRecord with source_extraction, reconstruction, semantics, and confidence_policy sub-objects) and adds support for provisional equation candidates.

## Key Changes

### Derivation Chain Agent (Issue #261)
- Extended `DerivationChainAgent` to build claim-based derivation chains when equations are unavailable
- Added `claim_build_result` and `evidence_registry` parameters to `run()` method
- Introduced `_CLAIM_TYPE_TO_OPERATION` mapping to convert claim types to derivation operations
- Extended `DerivationStep` schema with claim/evidence/assumption fields: `input_claim_ids`, `output_claim_ids`, `assumption_ids`, `source_evidence_ids`, `review_status`
- Added `chain_type` field to `DerivationChainRecord` to distinguish between "equation_chain", "claim_chain", and "mixed_chain"
- Propagated `linked_claim_ids` and `source_evidence_ids` from `EquationSemantics` to derivation steps
- Enhanced validation to check for unresolved equation references and support claim-based inputs/outputs

### Equation Semantics Schema Refactoring (Issue #258)
- Restructured `EquationRecord` to use nested composition:
  - `source_extraction`: EquationSourceExtraction (raw_text, latex, source_location, extraction_status, etc.)
  - `reconstruction`: EquationReconstruction (placeholder for future reconstruction data)
  - `semantics`: EquationSemantics (equation_type, defined_symbols, assumptions, derivation links, etc.)
  - `confidence_policy`: EquationConfidencePolicy (can_support_claim, can_be_used_in_derivation, etc.)
- Updated all test fixtures to use the new nested schema
- Added `EquationSourceExtraction.to_equations_export()` method for backward-compatible export

### Provisional Equation Candidates (Issue #259)
- Added "provisional" to `ACCEPTANCE_STATUSES` in equation semantics schema
- Modified `EquationAcceptanceGate` to classify high-signal label-only and fragment-only candidates as "provisional" instead of rejected
- Added `_make_provisional_record()` in `EquationSemanticsAgent` to create minimal reviewable records for provisional candidates
- Provisional records have `can_support_claim=False` and `can_be_used_in_derivation=False` in confidence policy

### Claim Object Builder Enhancements (Issue #260)
- Added support for split claims via `edit_suggestions.split_claims` in span data
- Implemented atomicity tracking: "atomic", "compound", "split_pending"
- Added `parent_claim_id` and `subclaim_ids` fields to `ClaimObjectRecord`
- Built proximity index for equations (block_id → equations, section_id → equations) for source-location-based linking
- Added `_link_equations()` method to link equations based on proximity and claim type
- Added `CLAIM_TYPE_ONTOLOGY` and `EQUATION_CLAIM_TYPES` constants

### Component Assembly Validator (Issue #262)
- Enhanced `_check_internal_flow()` to validate from/to references against known artifact IDs
- Added typed linked ID fields to `ComponentRecord`: `linked_claim_ids`, `linked_equation_ids`, `linked_evidence_ids`, `linked_derivation_ids`, etc.
- Improved validation to detect unresolved artifact references in internal flow

### Export and Backward Compatibility
- Updated `build_equations_export()` to prefer structured deserialization via `EquationSemanticsResult.to_equations_export()` when nested schema is detected
- Falls back to legacy flat format for older artifacts
- Added `_validate_equations_export()` to check for duplicate IDs, missing block_ids, and reconstruction status

## Notable Implementation Details

- The nested EquationRecord schema maintains backward compatibility through fallback logic in export functions
- Claim-based chain generation uses claim

https://claude.ai/code/session_01XHPbxYmyM4xK9so8iVb7jV