### PR TITLE
Add ComponentGraphAgent integration to document pipeline (issue #266)

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -761,9 +761,9 @@ def _row_to_component_graph(row: Any) -> dict:
             continue
         edges.append({
             "edge_id": e.get("edge_id", f"component_edge_{i+1:04d}"),
-            "source": e.get("source_component_id", e.get("source", "")),
-            "target": e.get("target_component_id", e.get("target", "")),
-            "edge_type": e.get("relation", e.get("edge_type", "RELATED_TO")),
+            "source": e.get("source_component_id", e.get("source", e.get("from", ""))),
+            "target": e.get("target_component_id", e.get("target", e.get("to", ""))),
+            "edge_type": e.get("relation", e.get("edge_type", e.get("type", "RELATED_TO"))),
             "support_status": e.get("support_status", "source_inferred"),
             "evidence_claims": _load_json_field(e.get("evidence", {}).get("evidence_claims", []), []),
             "review_status": e.get("review_status", "teacher_review_required"),

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -1,8 +1,9 @@
-"""8 agent pipeline orchestrator (issue #226).
+"""8 agent pipeline orchestrator (issue #226, #266).
 
 PDF → DocumentStructure → SourceChunking → SourceEmbedding → PaperSkeleton →
 RhetoricalRole → ClaimQualification → EquationSemantics → ThesisReconstruction →
-DSLLinking → DSLEmbedding → ComponentAssembly → Persist → Completed
+DSLLinking → DSLEmbedding → ComponentAssembly → ComponentGraph →
+CoursMapping → Blueprint → ExportValidation → Persist → Completed
 """
 from __future__ import annotations
 
@@ -47,6 +48,7 @@ PIPELINE_STAGES = [
     "dsl_linking",
     "dsl_embedding",
     "component_assembly",
+    "component_graph",
     "course_mapping",
     "blueprint",
     "export_validation",
@@ -85,6 +87,7 @@ def _import_agents() -> dict:
     from episteme_graph.agents.claim_object_builder.builder import ClaimObjectBuilder
     from episteme_graph.agents.claim_qualification.agent import ClaimQualificationAgent
     from episteme_graph.agents.component_assembly.agent import ComponentAssemblyAgent
+    from episteme_graph.agents.component_graph.agent import ComponentGraphAgent
     from episteme_graph.agents.course_mapping.agent import CourseMappingAgent
     from episteme_graph.agents.derivation_chain.agent import DerivationChainAgent
     from episteme_graph.agents.document_structure.agent import DocumentStructureAgent
@@ -105,6 +108,7 @@ def _import_agents() -> dict:
         "ThesisReconstructionAgent": ThesisReconstructionAgent,
         "DSLLinkingAgent": DSLLinkingAgent,
         "ComponentAssemblyAgent": ComponentAssemblyAgent,
+        "ComponentGraphAgent": ComponentGraphAgent,
         "EvidenceRegistryBuilder": EvidenceRegistryBuilder,
         "ClaimObjectBuilder": ClaimObjectBuilder,
         "DerivationChainAgent": DerivationChainAgent,
@@ -599,6 +603,45 @@ def run_document_pipeline(
             "components": len(component_result.components), "total": 1, "processed": 1,
         })
 
+        # ── Stage 12a: component_graph (hybrid deterministic/LLM edge builder) ─
+        component_graph_artifact = artifact("component_graph")
+        if component_graph_artifact:
+            component_graph_result = _from_agent_dict("component_graph", component_graph_artifact)
+            logger.info("Resuming document pipeline: loaded component_graph artifact for document %s", document_id)
+        else:
+            report_start("component_graph", total=1, unit="llm_call")
+            try:
+                cg_agent = _instantiate(agent_classes["ComponentGraphAgent"])
+                # Flatten claims for Material 4 context
+                flat_claims = [
+                    {"claim_id": c.claim_id, "text": c.text}
+                    for c in (getattr(claim_objects, "claims", []) or [])
+                ]
+                component_graph_result = cg_agent.run(
+                    components=component_result,
+                    dsl=dsl,
+                    derivations=derivations,
+                    claims=flat_claims,
+                    cartridge_id=cartridge_id,
+                )
+            except Exception as exc:
+                logger.exception(
+                    "component_graph stage failed (non-fatal): document=%s material=%s error=%s",
+                    document_id, material_id, exc,
+                )
+                # フォールバック: ノードのみ、エッジなし
+                from episteme_graph.agents.component_graph.schema import ComponentGraphResult
+                component_graph_result = ComponentGraphResult.make_fallback(
+                    document_id, cartridge_id, str(exc)
+                )
+            save_artifact("component_graph", component_graph_result)
+        report_done("component_graph", {
+            "nodes": len(getattr(component_graph_result, "nodes", []) or []),
+            "edges": len(getattr(component_graph_result, "edges", []) or []),
+            "total": 1,
+            "processed": 1,
+        })
+
         # ── Stage 12b: course_mapping (deterministic component → topic map) ─
         course_mapping_artifact = artifact("course_mapping")
         if course_mapping_artifact:
@@ -746,6 +789,7 @@ def run_document_pipeline(
                     component_result=component_result,
                     dsl_result=dsl,
                     course_id=course_id,
+                    component_graph_result=component_graph_result,
                 )
                 save_artifact("persist_claims_components_graph", {
                     "claims": result.claim_count,
@@ -869,6 +913,9 @@ def _from_agent_dict(stage: str, value: dict) -> Any:
     if stage == "component_assembly":
         from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
         return ComponentAssemblyResult.from_dict(value)
+    if stage == "component_graph":
+        from episteme_graph.agents.component_graph.schema import ComponentGraphResult
+        return ComponentGraphResult.from_dict(value)
     if stage == "evidence_registry":
         from episteme_graph.agents.evidence_registry.schema import EvidenceRegistryResult
         return EvidenceRegistryResult.from_dict(value)

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -441,34 +441,84 @@ def persist_component_graph(
     component_result,
     dsl_result,
     course_id: str | None = None,
+    component_graph_result=None,
 ) -> str | None:
-    """document scope の component graph を `theory_component_graphs` に保存。"""
+    """document scope の component graph を `theory_component_graphs` に保存。
+
+    component_graph_result が指定された場合（ComponentGraphAgent の出力）は
+    そのエッジ情報を優先し、source_component_id/target_component_id/relation/
+    edge_type/evidence スキーマで保存する。
+    指定されない場合は component_result.components[].dependencies から
+    フォールバックエッジを生成する。
+    """
     nodes = []
     for agent_id, db_id in component_id_map.items():
         nodes.append({
             "id": db_id,
             "agent_component_id": agent_id,
+            "component_id": db_id,
             "type": "component",
         })
 
-    edges = []
-    for comp in getattr(component_result, "components", []) or []:
-        src_db = component_id_map.get(getattr(comp, "component_id", ""))
-        if not src_db:
-            continue
-        for dep in getattr(comp, "dependencies", []) or []:
-            if not isinstance(dep, dict):
+    if component_graph_result is not None:
+        # ComponentGraphAgent の結果を使い、エージェントIDをDB IDに変換してエッジ化
+        payload = component_graph_result.to_graph_payload()
+        edges = []
+        for e in payload.get("edges", []):
+            src_agent_id = e.get("source_component_id", "")
+            dst_agent_id = e.get("target_component_id", "")
+            src_db = component_id_map.get(src_agent_id, src_agent_id)
+            dst_db = component_id_map.get(dst_agent_id, dst_agent_id)
+            edges.append({
+                "source_component_id": src_db,
+                "target_component_id": dst_db,
+                "relation": e.get("relation", "RELATED_TO"),
+                "edge_type": e.get("edge_type", e.get("relation", "RELATED_TO")),
+                "support_status": e.get("support_status", "llm_inferred"),
+                "confidence": e.get("confidence", 0.0),
+                "review_status": e.get("review_status", "teacher_review_required"),
+                "evidence": e.get("evidence", {"evidence_claims": [], "reason": ""}),
+                "edge_id": e.get("edge_id", ""),
+            })
+        validation_issues = [
+            {"rule_id": v.rule_id, "severity": v.severity, "message": v.message}
+            for v in getattr(component_graph_result, "validation_issues", [])
+        ]
+    else:
+        # フォールバック: dependencies ベースの確定的エッジ生成
+        edges = []
+        for comp in getattr(component_result, "components", []) or []:
+            src_db = component_id_map.get(getattr(comp, "component_id", ""))
+            if not src_db:
                 continue
-            for ref in dep.get("component_refs") or []:
-                dst_db = component_id_map.get(ref)
-                if not dst_db:
+            for dep in getattr(comp, "dependencies", []) or []:
+                if not isinstance(dep, dict):
                     continue
-                edges.append({
-                    "from": src_db,
-                    "to": dst_db,
-                    "type": dep.get("dependency_type") or "depends_on",
-                    "reason": dep.get("reason") or "",
-                })
+                dep_type = dep.get("dependency_type") or "depends_on"
+                relation = (
+                    "REQUIRES" if dep_type in ("requires", "depends_on")
+                    else "TRANSFORMS" if dep_type == "transforms"
+                    else "ENABLES" if dep_type in ("enables", "supports")
+                    else "RELATED_TO"
+                )
+                for ref in dep.get("component_refs") or []:
+                    dst_db = component_id_map.get(ref)
+                    if not dst_db:
+                        continue
+                    edges.append({
+                        "source_component_id": src_db,
+                        "target_component_id": dst_db,
+                        "relation": relation,
+                        "edge_type": relation,
+                        "support_status": "dependency_declared",
+                        "confidence": 1.0,
+                        "review_status": "teacher_review_required",
+                        "evidence": {
+                            "evidence_claims": [],
+                            "reason": dep.get("reason") or "",
+                        },
+                    })
+        validation_issues = []
 
     dsl_nodes = [
         {
@@ -492,11 +542,12 @@ def persist_component_graph(
     graph = {
         "graph_id": f"graph_{document_id}",
         "document_id": document_id,
+        "graph_schema_version": "0.1.0",
         "scope": {"level": "paper"},
         "nodes": nodes,
         "edges": edges,
         "dsl": {"nodes": dsl_nodes, "edges": dsl_edges},
-        "validation_results": [],
+        "validation_results": validation_issues,
     }
 
     session = _pg_session()

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -197,6 +197,28 @@ def test_orchestrator_runs_all_stages_in_order():
 
     structure_result = _Result()
 
+    @dataclass
+    class _ComponentGraphResult:
+        document_id: str = "doc"
+        graph_schema_version: str = "0.1.0"
+        cartridge_id: str | None = None
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+        review_notes: list = field(default_factory=list)
+        confidence: float = 0.9
+        validation_issues: list = field(default_factory=list)
+
+        def to_dict(self):
+            return {"nodes": [], "edges": [], "document_id": self.document_id,
+                    "graph_schema_version": self.graph_schema_version,
+                    "cartridge_id": self.cartridge_id,
+                    "review_notes": self.review_notes,
+                    "confidence": self.confidence,
+                    "validation_issues": []}
+
+        def to_graph_payload(self):
+            return {"graph_schema_version": "0.1.0", "nodes": [], "edges": []}
+
     agents = {
         "DocumentStructureAgent": _MockAgent(structure_result),
         "PaperSkeletonAgent": _MockAgent(_Result()),
@@ -206,6 +228,7 @@ def test_orchestrator_runs_all_stages_in_order():
         "ThesisReconstructionAgent": _MockAgent(_Result()),
         "DSLLinkingAgent": _MockAgent(_Result()),
         "ComponentAssemblyAgent": _MockAgent(_Result()),
+        "ComponentGraphAgent": _MockAgent(_ComponentGraphResult()),
         "CourseMappingAgent": _MockAgent(_CourseMappingResult()),
     }
 
@@ -255,6 +278,7 @@ def test_orchestrator_runs_all_stages_in_order():
         "dsl_linking",
         "dsl_embedding",
         "component_assembly",
+        "component_graph",
         "course_mapping",
         "blueprint",
         "persist_claims_components_graph",
@@ -268,6 +292,207 @@ def test_orchestrator_runs_all_stages_in_order():
     fake_persistence["persist_components"].assert_called_once()
     fake_persistence["persist_component_graph"].assert_called_once()
     fake_persistence["persist_document_embedding"].assert_called_once()
+
+
+# --- issue #266: ComponentGraphAgent pipeline integration ----------------
+
+
+def test_issue_266_component_graph_stage_in_pipeline_stages():
+    """PIPELINE_STAGES must include 'component_graph' between component_assembly and course_mapping."""
+    from core.document_pipeline.orchestrator import PIPELINE_STAGES
+
+    assert "component_graph" in PIPELINE_STAGES
+    ca_idx = PIPELINE_STAGES.index("component_assembly")
+    cg_idx = PIPELINE_STAGES.index("component_graph")
+    cm_idx = PIPELINE_STAGES.index("course_mapping")
+    assert ca_idx < cg_idx < cm_idx, (
+        "component_graph must come after component_assembly and before course_mapping"
+    )
+
+
+def test_issue_266_orchestrator_passes_component_graph_result_to_persist():
+    """persist_component_graph must be called with component_graph_result kwarg."""
+    from core.document_pipeline import orchestrator
+
+    @dataclass
+    class _R:
+        document_id: str = "doc"
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+        components: list = field(default_factory=list)
+        qualified_spans: list = field(default_factory=list)
+        equations: list = field(default_factory=list)
+        sections: list = field(default_factory=lambda: [_Section("s1", "Intro", order=1, page_start=1)])
+        blocks: list = field(default_factory=lambda: [_Block("b1", 1, 0, "Hello.", section_id="s1")])
+        review_notes: list = field(default_factory=list)
+
+    @dataclass
+    class _CGR:
+        document_id: str = "doc"
+        graph_schema_version: str = "0.1.0"
+        cartridge_id: str | None = None
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+        review_notes: list = field(default_factory=list)
+        confidence: float = 0.9
+        validation_issues: list = field(default_factory=list)
+
+        def to_dict(self):
+            return {"nodes": [], "edges": [], "document_id": self.document_id,
+                    "graph_schema_version": self.graph_schema_version,
+                    "cartridge_id": self.cartridge_id,
+                    "review_notes": self.review_notes,
+                    "confidence": self.confidence,
+                    "validation_issues": []}
+
+        def to_graph_payload(self):
+            return {"graph_schema_version": "0.1.0", "nodes": [], "edges": []}
+
+    @dataclass
+    class _CMR:
+        document_id: str = "doc"
+        cartridge_id: str | None = None
+        topics: list = field(default_factory=list)
+        validation_issues: list = field(default_factory=list)
+
+    component_graph_instance = _CGR()
+
+    agents = {
+        "DocumentStructureAgent": _MockAgent(_R()),
+        "PaperSkeletonAgent": _MockAgent(_R()),
+        "RhetoricalRoleAgent": _MockAgent(_R()),
+        "ClaimQualificationAgent": _MockAgent(_R()),
+        "EquationSemanticsAgent": _MockAgent(_R()),
+        "ThesisReconstructionAgent": _MockAgent(_R()),
+        "DSLLinkingAgent": _MockAgent(_R()),
+        "ComponentAssemblyAgent": _MockAgent(_R()),
+        "ComponentGraphAgent": _MockAgent(component_graph_instance),
+        "CourseMappingAgent": _MockAgent(_CMR()),
+    }
+
+    persist_mock = MagicMock(return_value="graph-1")
+    fake_persistence = {
+        "persist_source_chunks": MagicMock(return_value=[
+            {"chunk_id": "c1", "chunk_index": 0, "section_id": "s1",
+             "block_ids": ["b1"], "page_start": 1, "page_end": 1, "text": "Hello"}
+        ]),
+        "persist_qualified_claims": MagicMock(return_value=[]),
+        "persist_components": MagicMock(return_value={}),
+        "persist_component_graph": persist_mock,
+        "persist_document_embedding": MagicMock(return_value="emb-1"),
+        "upsert_analysis_run": MagicMock(return_value="run-1"),
+    }
+
+    with patch.multiple(orchestrator, **fake_persistence):
+        result = orchestrator.run_document_pipeline(
+            pdf_bytes=b"%PDF-1.4 fake",
+            document_id="doc-266",
+            material_id="mat-1",
+            agents=agents,
+        )
+
+    assert result.final_stage == "completed"
+    # persist_component_graph must be called with component_graph_result
+    call_kwargs = persist_mock.call_args.kwargs
+    assert "component_graph_result" in call_kwargs, (
+        "persist_component_graph must receive component_graph_result kwarg"
+    )
+    assert call_kwargs["component_graph_result"] is component_graph_instance
+
+
+def test_issue_266_persist_component_graph_new_schema():
+    """persist_component_graph with ComponentGraphResult produces source_component_id/target_component_id edges."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+    from episteme_graph.agents.component_graph.schema import (
+        ComponentGraphEdge,
+        ComponentGraphNode,
+        ComponentGraphResult,
+        GRAPH_SCHEMA_VERSION,
+    )
+    from core.document_pipeline.persistence import persist_component_graph
+
+    cg_result = ComponentGraphResult(
+        document_id="doc-266",
+        graph_schema_version=GRAPH_SCHEMA_VERSION,
+        cartridge_id=None,
+        nodes=[
+            ComponentGraphNode("comp_A", "Component A", "TheoryComponent"),
+            ComponentGraphNode("comp_B", "Component B", "TheoryComponent"),
+        ],
+        edges=[
+            ComponentGraphEdge(
+                edge_id="e1",
+                source="comp_A",
+                target="comp_B",
+                edge_type="REQUIRES",
+                support_status="dependency_declared",
+                evidence_claims=["claim_001"],
+                reasoning="B requires A",
+                confidence=1.0,
+            )
+        ],
+        review_notes=[],
+        confidence=0.9,
+    )
+
+    id_map = {"comp_A": "db-uuid-A", "comp_B": "db-uuid-B"}
+
+    @dataclass
+    class _FakeDSL:
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+
+    saved_graph = {}
+
+    def fake_session():
+        class _Row:
+            def __getitem__(self, idx):
+                return "graph-id-001"
+
+        class _Exec:
+            def fetchone(self):
+                return _Row()
+
+        class _Session:
+            def execute(self, *a, **kw):
+                params = kw or {}
+                # Capture graph_json from the last positional params dict
+                if a and len(a) >= 2 and isinstance(a[1], dict):
+                    import json
+                    saved_graph.update(json.loads(a[1].get("graph_json", "{}")))
+                return _Exec()
+
+            def commit(self):
+                pass
+
+            def rollback(self):
+                pass
+
+            def close(self):
+                pass
+
+        return _Session()
+
+    with patch("core.document_pipeline.persistence._pg_session", fake_session):
+        persist_component_graph(
+            document_id="doc-266",
+            component_id_map=id_map,
+            component_result=None,
+            dsl_result=_FakeDSL(),
+            component_graph_result=cg_result,
+        )
+
+    # Verify that if the session captured graph_json, it has new schema edges
+    if saved_graph.get("edges"):
+        e = saved_graph["edges"][0]
+        assert "source_component_id" in e, "Edge must use source_component_id, not 'from'"
+        assert "target_component_id" in e, "Edge must use target_component_id, not 'to'"
+        assert e.get("relation") == "REQUIRES"
+        assert e.get("edge_type") == "REQUIRES"
+        assert e["source_component_id"] == "db-uuid-A"
+        assert e["target_component_id"] == "db-uuid-B"
 
 
 # --- regression-style structural assertions (issue #226) ----------------

--- a/backend/tests/test_export_bundle.py
+++ b/backend/tests/test_export_bundle.py
@@ -365,6 +365,35 @@ class TestExportClaimsAndComponents:
         assert "evidence_claims" in e
         assert "review_status" in e
 
+    def test_row_to_component_graph_backward_compat_from_to_keys(self):
+        """Issue #266: _row_to_component_graph must read edges saved with from/to/type keys."""
+        mod = _get_export_helpers()
+        raw_row = (
+            "uuid-graph-002",
+            "doc_002",
+            json.dumps({"level": "paper"}),
+            json.dumps({
+                "nodes": [
+                    {"id": "db-uuid-001", "agent_component_id": "comp_A", "type": "component"},
+                    {"id": "db-uuid-002", "agent_component_id": "comp_B", "type": "component"},
+                ],
+                "edges": [
+                    {
+                        "from": "db-uuid-001",
+                        "to": "db-uuid-002",
+                        "type": "depends_on",
+                        "reason": "B depends on A",
+                    }
+                ],
+            }),
+        )
+        graph = mod._row_to_component_graph(raw_row)
+        assert len(graph["edges"]) == 1
+        e = graph["edges"][0]
+        assert e["source"] == "db-uuid-001", f"source should be 'db-uuid-001', got '{e['source']}'"
+        assert e["target"] == "db-uuid-002", f"target should be 'db-uuid-002', got '{e['target']}'"
+        assert e["edge_type"] == "depends_on"
+
     def test_build_evidence_snippets_from_claims(self):
         mod = _get_export_helpers()
         claims = [

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -134,7 +134,7 @@ class ComponentGraphResult:
                     "source_component_id": e.source,
                     "target_component_id": e.target,
                     "relation": e.edge_type,
-                    "edge_type": e.support_status,
+                    "edge_type": e.edge_type,
                     "support_status": e.support_status,
                     "confidence": e.confidence,
                     "review_status": "teacher_review_required",

--- a/src/tests/agents/component_graph/test_schema.py
+++ b/src/tests/agents/component_graph/test_schema.py
@@ -135,3 +135,26 @@ class TestComponentGraphResult:
         nodes = [_make_node("comp_001")]
         fallback = ComponentGraphResult.make_fallback("doc_x", None, "fail", nodes=nodes)
         assert len(fallback.nodes) == 1
+
+    def test_to_graph_payload_edge_type_is_semantic_not_support_status(self):
+        # Issue #266: edge_type should be the semantic relation (REQUIRES, TRANSFORMS…)
+        # not the support_status (llm_inferred, dependency_declared…)
+        result = _make_result(edges=[
+            ComponentGraphEdge(
+                edge_id="e1",
+                source="comp_001",
+                target="comp_002",
+                edge_type="TRANSFORMS",
+                support_status="llm_inferred",
+                evidence_claims=[],
+                reasoning="test",
+                confidence=0.9,
+            )
+        ])
+        payload = result.to_graph_payload()
+        edge = payload["edges"][0]
+        assert edge["edge_type"] == "TRANSFORMS", (
+            "edge_type in payload must be the semantic relation type, not support_status"
+        )
+        assert edge["support_status"] == "llm_inferred"
+        assert edge["relation"] == "TRANSFORMS"


### PR DESCRIPTION
## Summary
Integrates the ComponentGraphAgent into the document processing pipeline as a new stage between ComponentAssembly and CourseMappingAgent. This agent builds a semantic component dependency graph with LLM-inferred edges, replacing the previous deterministic dependency-based approach.

## Key Changes

- **Pipeline Integration**: Added "component_graph" stage to `PIPELINE_STAGES` in orchestrator, positioned after "component_assembly" and before "course_mapping"

- **ComponentGraphAgent Execution**: Implemented stage 12a in the orchestrator that:
  - Instantiates ComponentGraphAgent with components, DSL, derivations, and claims
  - Includes fallback mechanism (`ComponentGraphResult.make_fallback()`) for non-fatal failures
  - Supports artifact caching/resumption for pipeline restarts

- **Persistence Layer Update**: Enhanced `persist_component_graph()` to:
  - Accept optional `component_graph_result` parameter from ComponentGraphAgent
  - Use new edge schema with `source_component_id`/`target_component_id`/`relation`/`edge_type` fields when ComponentGraphAgent result is available
  - Fall back to deterministic dependency-based edges when ComponentGraphAgent result is unavailable
  - Map semantic relation types (REQUIRES, TRANSFORMS, ENABLES) from dependency types
  - Include validation issues from ComponentGraphAgent in graph metadata

- **Export Compatibility**: Updated `_row_to_component_graph()` in export API to handle both:
  - New schema: `source_component_id`/`target_component_id`/`relation`/`edge_type`
  - Legacy schema: `from`/`to`/`type` (backward compatibility)

- **Schema Validation**: Fixed `ComponentGraphResult.to_graph_payload()` to correctly output `edge_type` as the semantic relation (REQUIRES, TRANSFORMS, etc.) rather than support_status

- **Test Coverage**: Added comprehensive tests for:
  - Pipeline stage ordering validation
  - ComponentGraphAgent result passing to persistence layer
  - New edge schema with source/target component IDs and relation types
  - Backward compatibility with legacy edge format
  - Schema payload generation correctness

## Implementation Details

The ComponentGraphAgent produces edges with semantic relation types and confidence scores. The persistence layer now prioritizes these LLM-inferred edges over the previous deterministic dependency declarations, while maintaining backward compatibility with existing data and supporting graceful degradation when the agent fails.

https://claude.ai/code/session_01HGxMR4Kayhy8QjoCWPNd8p