### PR TITLE
Support legacy edge format and add LLM evidence validation

### DIFF
--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -617,11 +617,17 @@ def run_document_pipeline(
                     {"claim_id": c.claim_id, "text": c.text}
                     for c in (getattr(claim_objects, "claims", []) or [])
                 ]
+                # Flatten evidence records for Material 4 context
+                flat_evidence = [
+                    {"evidence_id": r.evidence_id, "evidence_text": r.evidence_text}
+                    for r in (getattr(evidence, "records", []) or [])
+                ]
                 component_graph_result = cg_agent.run(
                     components=component_result,
                     dsl=dsl,
                     derivations=derivations,
                     claims=flat_claims,
+                    evidence_snippets=flat_evidence,
                     cartridge_id=cartridge_id,
                 )
             except Exception as exc:

--- a/src/episteme_graph/agents/component_graph/merger.py
+++ b/src/episteme_graph/agents/component_graph/merger.py
@@ -59,11 +59,17 @@ class ComponentGraphMerger:
         for idx, e in enumerate(graph.get("edges") or []):
             if not isinstance(e, dict):
                 continue
-            source = str(e.get("source") or e.get("source_component_id") or "").strip()
-            target = str(e.get("target") or e.get("target_component_id") or "").strip()
+            source = str(
+                e.get("source") or e.get("source_component_id") or e.get("from") or ""
+            ).strip()
+            target = str(
+                e.get("target") or e.get("target_component_id") or e.get("to") or ""
+            ).strip()
             if not source or not target:
                 continue
-            edge_type = str(e.get("edge_type") or e.get("relation") or "RELATED_TO").strip().upper()
+            edge_type = str(
+                e.get("edge_type") or e.get("relation") or e.get("type") or "RELATED_TO"
+            ).strip().upper()
             support_status = str(e.get("support_status") or "io_matched")
             evidence_obj = e.get("evidence") or {}
             evidence_claims: list[str] = []

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -115,6 +115,13 @@ class ComponentGraphValidator:
                 f"{eid}: evidence_claims must be a list",
                 f"edges[{eid}].evidence_claims",
             ))
+        elif edge.support_status == "llm_inferred" and len(edge.evidence_claims) == 0:
+            issues.append(ValidationIssue(
+                "llm_inferred_no_evidence",
+                "warning",
+                f"{eid}: llm_inferred edge has no evidence_claims; teacher_review_required",
+                f"edges[{eid}].evidence_claims",
+            ))
 
         if edge.confidence < 0.0 or edge.confidence > 1.0:
             issues.append(ValidationIssue(

--- a/src/tests/agents/component_graph/test_merger.py
+++ b/src/tests/agents/component_graph/test_merger.py
@@ -140,3 +140,43 @@ class TestComponentGraphMerger:
         llm_result = _result([_node("c1"), _node("c2")], [_edge("c1", "c2")])
         merged = self.merger.merge(existing, llm_result)
         assert len(merged.edges) == 1
+
+    def test_parse_from_to_legacy_format(self):
+        """Merger reads old 'from'/'to'/'type' edge format."""
+        existing = {
+            "edges": [
+                {
+                    "from": "c1",
+                    "to": "c2",
+                    "type": "ENABLES",
+                    "support_status": "io_matched",
+                    "confidence": 0.7,
+                }
+            ]
+        }
+        llm_result = _result([_node("c1"), _node("c2"), _node("c3")], [_edge("c2", "c3")])
+        merged = self.merger.merge(existing, llm_result)
+        assert len(merged.edges) == 2
+        keys = {(e.source, e.target, e.edge_type) for e in merged.edges}
+        assert ("c1", "c2", "ENABLES") in keys
+
+    def test_from_to_type_dedup_with_llm_edge(self):
+        """from/to legacy edge deduplicates correctly against LLM edge with same key."""
+        existing = {
+            "edges": [
+                {
+                    "from": "c1",
+                    "to": "c2",
+                    "type": "REQUIRES",
+                    "support_status": "io_matched",
+                    "confidence": 0.6,
+                }
+            ]
+        }
+        llm_result = _result(
+            [_node("c1"), _node("c2")],
+            [_edge("c1", "c2", edge_type="REQUIRES", confidence=0.85)],
+        )
+        merged = self.merger.merge(existing, llm_result)
+        assert len(merged.edges) == 1
+        assert merged.edges[0].confidence == 0.85

--- a/src/tests/agents/component_graph/test_validator.py
+++ b/src/tests/agents/component_graph/test_validator.py
@@ -127,3 +127,43 @@ class TestComponentGraphValidator:
         issues = self.validator.validate(_result(nodes, edges))
         errors = [i for i in issues if i.severity == "error"]
         assert errors == []
+
+    def test_llm_inferred_empty_evidence_claims_warns(self):
+        """llm_inferred edge with no evidence_claims emits a warning."""
+        nodes = [_node("c1"), _node("c2")]
+        edge = ComponentGraphEdge(
+            edge_id="component_edge_0001",
+            source="c1",
+            target="c2",
+            edge_type="REQUIRES",
+            support_status="llm_inferred",
+            evidence_claims=[],
+            reasoning="",
+            confidence=0.8,
+        )
+        issues = self.validator.validate(_result(nodes, [edge]))
+        assert any(i.rule_id == "llm_inferred_no_evidence" for i in issues)
+        assert all(i.severity != "error" for i in issues if i.rule_id == "llm_inferred_no_evidence")
+
+    def test_non_llm_inferred_empty_evidence_claims_no_warn(self):
+        """io_matched edge with empty evidence_claims does NOT trigger the warning."""
+        nodes = [_node("c1"), _node("c2")]
+        edge = ComponentGraphEdge(
+            edge_id="component_edge_0001",
+            source="c1",
+            target="c2",
+            edge_type="REQUIRES",
+            support_status="io_matched",
+            evidence_claims=[],
+            reasoning="",
+            confidence=0.8,
+        )
+        issues = self.validator.validate(_result(nodes, [edge]))
+        assert not any(i.rule_id == "llm_inferred_no_evidence" for i in issues)
+
+    def test_llm_inferred_with_evidence_claims_no_warn(self):
+        """llm_inferred edge that has evidence_claims does NOT trigger the warning."""
+        nodes = [_node("c1"), _node("c2")]
+        edges = [_edge("c1", "c2")]  # _edge has evidence_claims=["claim:b1:s1"]
+        issues = self.validator.validate(_result(nodes, edges))
+        assert not any(i.rule_id == "llm_inferred_no_evidence" for i in issues)


### PR DESCRIPTION
## Summary
This PR adds backward compatibility for legacy edge format in the component graph merger and introduces validation for LLM-inferred edges to ensure they have supporting evidence claims.

## Key Changes

- **Legacy edge format support**: Updated `_parse_existing_edges()` in merger.py to recognize the old `from`/`to`/`type` edge format in addition to the current `source`/`target`/`edge_type` format. This ensures existing graphs using the legacy format can be properly merged with new LLM results.

- **LLM evidence validation**: Added a new validation rule in validator.py that warns when an `llm_inferred` edge has no `evidence_claims`. This helps identify edges that require teacher review due to lack of supporting evidence.

- **Enhanced context for Material 4**: Updated the document pipeline orchestrator to flatten and pass evidence records (`evidence_snippets`) to the component graph agent, providing richer context for edge inference.

## Implementation Details

- The merger now checks for `from`/`to`/`type` fields as fallbacks when the standard field names are not present, maintaining backward compatibility while preferring the newer format.
- The new validation rule only applies to `llm_inferred` edges; `io_matched` edges with empty evidence claims are not flagged.
- Added comprehensive test coverage for both the legacy format parsing and deduplication behavior, as well as the new validation rules.

https://claude.ai/code/session_01AS7oyANT87K5p8aYTt4v8A