### PR TITLE
fix: Hide broken equation text in equation semantics prompt when needs_reconstruction is True

### DIFF
--- a/src/episteme_graph/agents/equation_semantics/prompt.py
+++ b/src/episteme_graph/agents/equation_semantics/prompt.py
@@ -137,7 +137,8 @@ class EquationSemanticsPromptFactory:
                 "\n** Source extraction is INSUFFICIENT for this equation "
                 f"(extraction_status={llm_input.extraction_status}). "
                 "You MUST include a 'reconstruction' block in your output. "
-                "Reconstruct from surrounding context. "
+                "The original broken text has been hidden to avoid confusing you. "
+                "Instead, reconstruct the LaTeX purely from the logical flow, variables defined in the surrounding text, and neighboring blocks. "
                 "Set reconstruction.status to 'inferred_from_context' or 'reconstructed_from_neighbors'. "
                 "Set reconstruction.method and supporting_refs from the context blocks below. "
                 "Set confidence based on how confident you are. "
@@ -147,11 +148,16 @@ class EquationSemanticsPromptFactory:
         if llm_input.prev_texts:
             parts.append("\n## Previous Text Blocks")
             parts.extend(llm_input.prev_texts)
+
         parts.append("\n## Equation Text")
-        parts.append(llm_input.equation_text)
-        if llm_input.plain_text:
-            parts.append("\n## Plain Text")
-            parts.append(llm_input.plain_text)
+        if llm_input.needs_reconstruction:
+            parts.append("[OMITTED - The original text is broken/insufficient. Reconstruct entirely from context]")
+        else:
+            parts.append(llm_input.equation_text)
+            if llm_input.plain_text:
+                parts.append("\n## Plain Text")
+                parts.append(llm_input.plain_text)
+
         if llm_input.next_texts:
             parts.append("\n## Next Text Blocks")
             parts.extend(llm_input.next_texts)


### PR DESCRIPTION
The `equation_semantics` agent was previously including broken/fragmented text extracted from the PDF in its prompt, even when `needs_reconstruction` was marked as `True`. This caused the LLM to be misled by the garbage text, reducing the quality of the generated LaTeX.

This fix:
1. Conditionally hides `equation_text` and `plain_text` in the prompt when `needs_reconstruction` is True.
2. Replaces the hidden text with an explicit `[OMITTED - The original text is broken/insufficient. Reconstruct entirely from context]` placeholder.
3. Updates the prompt instructions to explicitly tell the LLM that the text was hidden to avoid confusion and that it should reconstruct the LaTeX purely from logical flow, neighboring blocks, and defined variables.

---
*PR created automatically by Jules for task [6443430391149590758](https://jules.google.com/task/6443430391149590758) started by @urashin*