### PR TITLE
fix: 原稿スタジオの編集UIを改善

### DIFF
--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Episteme Graph — 管理画面</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
-  <link rel="stylesheet" href="/css/styles.css?v=component-graph-20260507-5">
+  <link rel="stylesheet" href="/css/styles.css?v=lecture-studio-wire-20260521-1">
   <script defer src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
 </head>
 <body>
@@ -187,10 +187,13 @@
     <!-- Lecture Script Studio tab (Issue #70) -->
     <div class="admin-panel" id="tab-lecture-studio">
       <div class="ls-container">
+        <div class="ls-studio-frame">
         <!-- Top bar: course selector + global actions -->
         <div class="ls-topbar">
           <div class="ls-topbar-left">
-            <label style="font-size:13px;color:var(--color-text-secondary)">コース:</label>
+            <button id="ls-course-reset-btn" class="ls-course-reset-btn" type="button" hidden>[選び直す]</button>
+            <span id="ls-course-current" class="ls-course-current" hidden>コース: -</span>
+            <label id="ls-course-select-label" style="font-size:13px;color:var(--color-text-secondary)">コース:</label>
             <select id="ls-course-select" style="flex:1;max-width:400px;padding:4px 8px;font-size:13px;border:1px solid var(--color-border);border-radius:4px;background:var(--color-bg-secondary);color:var(--color-text-primary)">
               <option value="">コースを選択...</option>
             </select>
@@ -208,15 +211,42 @@
         </div>
         <div id="ls-progress" class="upload-status" style="display:none;margin:8px 16px"></div>
 
-        <!-- Three-panel layout -->
-        <div class="ls-panels">
-          <!-- Left: navigation panel with 3 tabs (Issue #232) -->
-          <div class="ls-nav-panel">
+        <div id="ls-empty-course" class="ls-empty-course">
+          <div class="ls-empty-state">コースを選択すると表示されます</div>
+        </div>
+
+        <div id="ls-studio-workarea" class="ls-studio-workarea" hidden>
+          <div class="ls-studio-toolbar">
             <div class="ls-nav-tabs">
               <button class="ls-nav-tab active" data-ls-nav="course">コース</button>
               <button class="ls-nav-tab" data-ls-nav="document">文書構造</button>
               <button class="ls-nav-tab" data-ls-nav="components">コンポーネント</button>
             </div>
+            <div class="ls-toolbar-divider"></div>
+            <div class="ls-work-tabs" id="ls-work-tabs">
+              <button class="ls-work-tab active" data-ls-view="edit">原稿</button>
+              <button class="ls-work-tab" data-ls-view="structure" hidden>構造</button>
+              <button class="ls-work-tab" data-ls-view="claims" hidden>理論グラフ</button>
+            </div>
+            <div class="ls-work-tabs ls-theory-graph-tabs" id="ls-theory-graph-tabs" hidden>
+              <button class="ls-work-tab active" data-ls-view="claims">主張</button>
+              <button class="ls-work-tab" data-ls-view="theory">論理要素</button>
+              <button class="ls-work-tab" data-ls-view="graph">グラフ</button>
+            </div>
+            <div class="ls-toolbar-spacer"></div>
+            <button id="ls-right-pane-toggle" class="admin-action-btn ls-toolbar-btn" type="button" disabled>右ペインを隠す</button>
+            <button id="ls-ai-assistant-btn" class="admin-action-btn ls-toolbar-btn" type="button" disabled>AI アシスタント</button>
+            <button id="ls-save-btn" class="admin-action-btn ls-toolbar-btn ls-save-toolbar-btn" type="button" disabled>原稿を保存</button>
+          </div>
+          <div class="ls-work-meta-row">
+            <div id="ls-chunk-meta" class="ls-chunk-meta">トピックを選択してください</div>
+            <div id="ls-action-status" class="upload-status" style="display:none"></div>
+          </div>
+
+        <!-- Three-panel layout -->
+        <div class="ls-panels">
+          <!-- Left: navigation panel with 3 tabs (Issue #232) -->
+          <div class="ls-nav-panel">
             <!-- コースタブ -->
             <div id="ls-course-list" class="ls-chunk-list">
               <div style="padding:16px;color:var(--color-text-tertiary);font-size:13px">コースを選択してください</div>
@@ -233,20 +263,6 @@
 
           <!-- Center: editor -->
           <div class="ls-editor-panel">
-            <div class="ls-workbar">
-              <div class="ls-work-tabs" id="ls-work-tabs">
-                <button class="ls-work-tab active" data-ls-view="edit">原稿</button>
-                <button class="ls-work-tab" data-ls-view="structure" hidden>構造</button>
-                <button class="ls-work-tab" data-ls-view="claims" hidden>理論グラフ</button>
-              </div>
-              <div class="ls-work-tabs ls-theory-graph-tabs" id="ls-theory-graph-tabs" hidden>
-                <button class="ls-work-tab active" data-ls-view="claims">主張</button>
-                <button class="ls-work-tab" data-ls-view="theory">論理要素</button>
-                <button class="ls-work-tab" data-ls-view="graph">グラフ</button>
-              </div>
-              <div id="ls-chunk-meta" class="ls-chunk-meta">チャンクを選択してください</div>
-            </div>
-
             <div id="ls-workspace" class="ls-workspace">
               <div class="ls-empty-state">チャンクを選択すると編集ワークベンチが表示されます</div>
             </div>
@@ -275,12 +291,14 @@
                     <div class="ls-mini-tabs" id="ls-display-tabs">
                       <button class="ls-mini-tab active" data-ls-display="preview">プレビュー</button>
                       <button class="ls-mini-tab" data-ls-display="script">原稿</button>
+                      <button class="ls-mini-tab" data-ls-display="formulas">数式一覧</button>
                     </div>
                   </div>
                   <div class="ls-pane-body">
                     <div id="ls-display-preview" class="ls-display-preview"></div>
                     <textarea id="ls-display-text" class="ls-script-textarea" placeholder="表示テキスト" hidden></textarea>
                     <textarea id="ls-spoken-text" class="ls-script-textarea" placeholder="読み上げテキスト" hidden></textarea>
+                    <div id="ls-formulas" class="ls-formulas-panel" hidden></div>
                   </div>
                 </section>
               </div>
@@ -328,20 +346,20 @@
               </label>
             </template>
           </div>
+        </div>
+        </div>
+        </div>
 
-          <!-- Right: AI assistant + actions -->
-          <div class="ls-action-panel">
-            <div class="ls-action-header">AI アシスタント</div>
-            <div class="ls-action-body">
-              <div style="margin-bottom:12px">
-                <label id="ls-assistant-label" style="font-size:12px;color:var(--color-text-secondary);display:block;margin-bottom:4px">書き換え指示:</label>
-                <textarea id="ls-rewrite-prompt" class="ls-rewrite-textarea" placeholder="例: 前提知識の説明を1文追加して" disabled></textarea>
-              </div>
-              <button id="ls-rewrite-btn" class="admin-action-btn" disabled style="width:100%;margin-bottom:12px">AIで提案</button>
-              <hr style="border:none;border-top:1px solid var(--color-border);margin:12px 0">
-              <button id="ls-save-btn" class="admin-action-btn" disabled style="width:100%;background:var(--color-text-success);color:#fff">原稿を保存</button>
-              <div id="ls-action-status" class="upload-status" style="display:none;margin-top:8px"></div>
-              <div id="ls-formulas" style="margin-top:16px"></div>
+        <div id="ls-assistant-modal" class="ls-assistant-modal" hidden>
+          <div class="ls-assistant-dialog">
+            <div class="ls-assistant-head">
+              <h3>AI アシスタント</h3>
+              <button id="ls-assistant-close" class="lecture-chat-close" type="button">&times;</button>
+            </div>
+            <div class="ls-assistant-body">
+              <label id="ls-assistant-label" class="ls-assistant-label">書き換え指示:</label>
+              <textarea id="ls-rewrite-prompt" class="ls-rewrite-textarea" placeholder="例: 前提知識の説明を1文追加して" disabled></textarea>
+              <button id="ls-rewrite-btn" class="admin-action-btn" disabled>AIで提案</button>
             </div>
           </div>
         </div>
@@ -520,6 +538,6 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
-  <script src="/js/admin.js?v=lecture-studio-tabs-20260509-1"></script>
+  <script src="/js/admin.js?v=lecture-studio-wire-20260521-1"></script>
 </body>
 </html>

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -2234,7 +2234,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 10px;
   background: var(--color-background-primary);
-  padding: 14px;
+  padding: 14px 14px 0;
 }
 
 .ls-topbar {
@@ -2242,8 +2242,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 0 0 10px;
-  border-bottom: 1px solid var(--color-border);
+  padding: 0;
   margin-bottom: 10px;
   flex-wrap: wrap;
 }
@@ -2287,7 +2286,7 @@ body {
   justify-content: center;
   border: 1px dashed var(--color-border-secondary);
   border-radius: 8px;
-  background: var(--color-background-primary);
+  background: var(--color-background-secondary);
 }
 
 .ls-studio-workarea {
@@ -2295,9 +2294,10 @@ body {
   flex-direction: column;
   min-height: 0;
   flex: 1;
-  padding: 12px;
+  gap: 4px;
   border-radius: 8px;
   background: var(--color-background-secondary);
+  border: 1px dashed var(--color-border-secondary);
 }
 
 .ls-studio-workarea[hidden],
@@ -2310,7 +2310,8 @@ body {
   align-items: center;
   gap: 8px;
   min-height: 38px;
-  margin-bottom: 8px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-background-primary);
   flex-wrap: wrap;
 }
 
@@ -2339,8 +2340,8 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  min-height: 30px;
-  margin-bottom: 8px;
+  min-height: 28px;
+  padding: 0 8px;
 }
 
 .ls-work-meta-row .upload-status {
@@ -2382,11 +2383,9 @@ body {
 /* Issue #232: 左ペインタブ */
 .ls-nav-tabs {
   display: flex;
-  background: var(--color-background-primary);
   flex-shrink: 0;
   gap: 4px;
   padding: 3px;
-  border: 1px solid var(--color-border-tertiary);
   border-radius: 8px;
 }
 
@@ -2395,7 +2394,7 @@ body {
   font-size: 12px;
   font-weight: 600;
   color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
+  background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: 6px;
   cursor: pointer;
@@ -2418,7 +2417,6 @@ body {
 /* コースタブ */
 .ls-course-header {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--color-border);
   background: var(--color-background-primary);
   display: grid;
   gap: 2px;
@@ -2426,7 +2424,6 @@ body {
 
 .ls-course-chapter {
   padding: 7px 12px 5px;
-  border-bottom: 1px solid var(--color-border);
   background: var(--color-background-primary);
   font-size: 12px;
   font-weight: 700;
@@ -2435,7 +2432,6 @@ body {
 
 .ls-course-topic {
   padding: 6px 12px 6px 24px;
-  border-bottom: 1px solid var(--color-border);
   font-size: 12px;
   cursor: pointer;
   display: flex;
@@ -2548,7 +2544,6 @@ body {
   padding: 8px 12px;
   font-size: 12px;
   cursor: pointer;
-  border-bottom: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -2567,7 +2562,6 @@ body {
 .ls-doc-node,
 .ls-section-node {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--color-border);
   cursor: pointer;
   display: grid;
   gap: 2px;
@@ -2688,9 +2682,7 @@ body {
 .ls-work-tabs {
   position: relative;
   padding: 3px;
-  border: 1px solid var(--color-border-tertiary);
   border-radius: 8px;
-  background: var(--color-background-primary);
   flex-shrink: 0;
 }
 
@@ -2793,20 +2785,20 @@ body {
 }
 
 .ls-pane-head {
-  min-height: 38px;
-  padding: 6px 8px 6px 12px;
+  min-height: 22px;
+  padding: 0px 12px;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  background: var(--color-bg-secondary);
+  background: var(--color-bg-primary);
   border-bottom: 1px solid var(--color-border);
 }
 
 .ls-pane-title {
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 700;
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
 }
 
 .ls-pane-body {
@@ -2851,7 +2843,6 @@ body {
 }
 
 .ls-source-text {
-  padding: 12px;
   font-size: 13px;
   line-height: 1.6;
   height: 100%;
@@ -2864,10 +2855,10 @@ body {
 .ls-spoken-textarea,
 .ls-script-textarea {
   flex: 1;
+  padding: 12px;
   width: 100%;
   height: 100%;
   min-height: 360px;
-  padding: 12px;
   font-size: 13px;
   line-height: 1.6;
   border: none;
@@ -2889,8 +2880,8 @@ body {
 
 .ls-display-preview {
   height: 100%;
+  padding: 12px;
   min-height: 360px;
-  padding: 14px 16px;
   overflow-y: auto;
   color: var(--color-text-primary);
   font-size: 14px;
@@ -2984,13 +2975,17 @@ body {
   width: 100%;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-bg-primary);
   color: var(--color-text-primary);
   font-family: inherit;
   font-size: 13px;
   line-height: 1.55;
   padding: 8px;
   resize: vertical;
+
+  /* 一部のブラウザでは `field-sizing` はまだ非対応 */
+  field-sizing: content;
+  min-height: min-content !important;
 }
 
 .ls-course-small-textarea {

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -10,8 +10,6 @@
   --color-background-tertiary: #eeeef0;
   --color-background-info: #eef4fb;
   --color-background-success: rgba(93, 202, 165, 0.12);
-  --color-bg-secondary: var(--color-background-secondary);
-  --color-bg-tertiary: var(--color-background-tertiary);
   --color-text-primary: #1d1d1f;
   --color-text-secondary: #6e6e73;
   --color-text-tertiary: #aeaeb2;
@@ -1456,7 +1454,7 @@ body {
   font-size: 13px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
 }
 
@@ -1465,7 +1463,7 @@ body {
   font-size: 13px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
 }
 
@@ -1624,7 +1622,7 @@ body {
 .cb-material-select {
   border-bottom: 0.5px solid var(--color-border-tertiary);
   padding: 8px 12px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
 }
 
 .cb-material-select-header {
@@ -1652,7 +1650,7 @@ body {
   padding: 3px 8px;
   border-radius: 4px;
   border: 1px solid var(--color-border);
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
   transition: border-color 0.1s;
 }
 
@@ -2377,7 +2375,7 @@ body {
   font-weight: 600;
   color: var(--color-text-secondary);
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
 }
 
 /* Issue #232: 左ペインタブ */
@@ -2405,7 +2403,7 @@ body {
 }
 
 .ls-nav-tab:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
   color: var(--color-text-primary);
 }
 
@@ -2442,7 +2440,7 @@ body {
 
 .ls-course-topic:hover,
 .ls-course-topic.active {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
 }
 
 .ls-course-topic.active {
@@ -2484,7 +2482,7 @@ body {
 
 .ls-component-item:hover,
 .ls-component-item.active {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
 }
 
 .ls-component-item.active {
@@ -2551,11 +2549,11 @@ body {
 }
 
 .ls-chunk-item:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
 }
 
 .ls-chunk-item.active {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
   border-left: 3px solid var(--color-text-info);
 }
 
@@ -2579,7 +2577,7 @@ body {
 .ls-section-node:hover,
 .ls-doc-node.active,
 .ls-section-node.active {
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
 }
 
 .ls-doc-title {
@@ -2704,7 +2702,7 @@ body {
 .ls-work-tab,
 .ls-mini-tab {
   border: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-secondary);
   cursor: pointer;
   font-size: 12px;
@@ -2838,7 +2836,7 @@ body {
   font-size: 11px;
   font-weight: 600;
   color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -2875,7 +2873,7 @@ body {
 
 .ls-script-textarea:disabled {
   color: var(--color-text-secondary);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
 }
 
 .ls-display-preview {
@@ -3070,7 +3068,7 @@ body {
 .ls-evidence-chip {
   border: 1px solid var(--color-border);
   border-radius: 999px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   padding: 4px 8px;
   font-size: 12px;
@@ -3140,7 +3138,7 @@ body {
 .ls-evidence-kind {
   border-radius: 999px;
   padding: 2px 7px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-secondary);
   font-size: 11px;
   font-weight: 700;
@@ -3179,7 +3177,7 @@ body {
   padding: 10px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   text-align: left;
   cursor: pointer;
@@ -3280,7 +3278,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 12px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
 }
 
 .ls-theory-card-head {
@@ -3362,7 +3360,7 @@ body {
   padding: 1px 8px;
   margin: 0 2px;
   font-size: 0.9em;
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
 }
 
 .ls-graph-flow {
@@ -3375,7 +3373,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 10px 12px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   font-size: 13px;
 }
@@ -3384,7 +3382,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 10px 12px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
 }
 
 .ls-graph-edge summary {
@@ -3662,7 +3660,7 @@ body {
 
 .ss-analysis-step > div {
   height: 5px;
-  background: var(--color-bg-tertiary);
+  background: var(--color-background-tertiary);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -3717,7 +3715,7 @@ body {
   padding: 8px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 12px;
@@ -3765,7 +3763,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   color: var(--color-text-info);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   white-space: normal;
 }
 
@@ -3807,7 +3805,7 @@ body {
   margin-bottom: 6px;
   border: 1px solid var(--color-border);
   border-radius: 6px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   font-size: 12px;
 }
 
@@ -3945,7 +3943,7 @@ body {
   padding: 8px 10px;
   border: 1px solid var(--color-border);
   border-radius: 4px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   font-family: inherit;
   font-size: 13px;
@@ -3967,7 +3965,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   resize: vertical;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   color: var(--color-text-primary);
   font-family: inherit;
 }
@@ -3981,7 +3979,7 @@ body {
   padding: 6px 8px;
   margin-bottom: 4px;
   font-size: 11px;
-  background: var(--color-bg-secondary);
+  background: var(--color-background-secondary);
   border-radius: 4px;
   border: 1px solid var(--color-border);
 }

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -9,6 +9,9 @@
   --color-background-secondary: #f5f5f7;
   --color-background-tertiary: #eeeef0;
   --color-background-info: #eef4fb;
+  --color-background-success: rgba(93, 202, 165, 0.12);
+  --color-bg-secondary: var(--color-background-secondary);
+  --color-bg-tertiary: var(--color-background-tertiary);
   --color-text-primary: #1d1d1f;
   --color-text-secondary: #6e6e73;
   --color-text-tertiary: #aeaeb2;
@@ -16,9 +19,12 @@
   --color-text-success: #5dcaa5;
   --color-text-warning: #ef9f27;
   --color-text-danger: #e24b4a;
+  --color-border-primary: #c6c6cc;
   --color-border-secondary: #d2d2d7;
   --color-border-tertiary: #e5e5ea;
   --color-border-info: #378add;
+  --color-border-success: #8ed8be;
+  --color-border: var(--color-border-tertiary);
 }
 
 * {
@@ -1122,8 +1128,9 @@ body {
   max-width: none;
   width: 100%;
   margin: 0;
-  padding: 20px 24px;
-  overflow-x: auto;
+  padding: 20px 24px 0px;
+  overflow-x: hidden;
+  background: #f3f4f6;
 }
 
 .admin-section {
@@ -2216,7 +2223,18 @@ body {
 .ls-container {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 140px);
+  height: calc(100vh - 100px);
+}
+
+.ls-studio-frame {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  background: var(--color-background-primary);
+  padding: 14px;
 }
 
 .ls-topbar {
@@ -2224,9 +2242,9 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 0 0 12px;
+  padding: 0 0 10px;
   border-bottom: 1px solid var(--color-border);
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   flex-wrap: wrap;
 }
 
@@ -2242,13 +2260,102 @@ body {
   gap: 8px;
 }
 
+.ls-course-reset-btn {
+  border: none;
+  background: transparent;
+  color: var(--color-text-info);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+}
+
+.ls-course-reset-btn:hover {
+  text-decoration: underline;
+}
+
+.ls-course-current {
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.ls-empty-course {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--color-border-secondary);
+  border-radius: 8px;
+  background: var(--color-background-primary);
+}
+
+.ls-studio-workarea {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--color-background-secondary);
+}
+
+.ls-studio-workarea[hidden],
+.ls-empty-course[hidden] {
+  display: none !important;
+}
+
+.ls-studio-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.ls-toolbar-divider {
+  width: 1px;
+  height: 26px;
+  background: var(--color-border-tertiary);
+}
+
+.ls-toolbar-spacer {
+  flex: 1;
+  min-width: 12px;
+}
+
+.ls-toolbar-btn {
+  white-space: nowrap;
+}
+
+.ls-save-toolbar-btn {
+  background: var(--color-text-success);
+  color: #fff;
+}
+
+.ls-work-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 30px;
+  margin-bottom: 8px;
+}
+
+.ls-work-meta-row .upload-status {
+  margin: 0;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
 .ls-panels {
   display: flex;
   gap: 12px;
   flex: 1;
   min-height: 0;
-  overflow-x: auto;
-  padding-bottom: 4px;
+  overflow: hidden;
+  padding-bottom: 0;
 }
 
 .ls-nav-panel {
@@ -2260,6 +2367,7 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  background: var(--color-background-primary);
 }
 
 .ls-nav-header {
@@ -2274,29 +2382,27 @@ body {
 /* Issue #232: 左ペインタブ */
 .ls-nav-tabs {
   display: flex;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-primary);
   flex-shrink: 0;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: 8px;
 }
 
 .ls-nav-tab {
-  flex: 1;
-  padding: 7px 4px;
-  font-size: 11px;
+  padding: 8px 10px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--color-text-secondary);
-  background: transparent;
-  border: none;
-  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
   cursor: pointer;
   transition: background 0.12s, color 0.12s;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.ls-nav-tab:last-child {
-  border-right: none;
 }
 
 .ls-nav-tab:hover {
@@ -2313,7 +2419,7 @@ body {
 .ls-course-header {
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-primary);
   display: grid;
   gap: 2px;
 }
@@ -2321,7 +2427,7 @@ body {
 .ls-course-chapter {
   padding: 7px 12px 5px;
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
+  background: var(--color-background-primary);
   font-size: 12px;
   font-weight: 700;
   color: var(--color-text-primary);
@@ -2435,6 +2541,7 @@ body {
 .ls-chunk-list {
   overflow-y: auto;
   flex: 1;
+  background: var(--color-background-primary);
 }
 
 .ls-chunk-item {
@@ -2467,7 +2574,7 @@ body {
 }
 
 .ls-doc-node {
-  background: var(--color-bg-secondary);
+  background: var(--color-background-primary);
 }
 
 .ls-section-node {
@@ -2556,11 +2663,11 @@ body {
 }
 
 .ls-editor-panel {
-  flex: 1 0 1460px;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  min-width: 1460px;
+  min-width: 0;
 }
 
 .ls-workbar {
@@ -2576,6 +2683,30 @@ body {
   display: flex;
   align-items: center;
   gap: 4px;
+}
+
+.ls-work-tabs {
+  position: relative;
+  padding: 3px;
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: 8px;
+  background: var(--color-background-primary);
+  flex-shrink: 0;
+}
+
+.ls-work-tabs + .ls-work-tabs {
+  margin-left: 4px;
+  padding-left: 14px;
+}
+
+.ls-work-tabs + .ls-work-tabs::before {
+  content: "";
+  position: absolute;
+  left: 6px;
+  top: 6px;
+  bottom: 6px;
+  width: 1px;
+  background: var(--color-border-tertiary);
 }
 
 .ls-work-tab,
@@ -2635,7 +2766,7 @@ body {
   min-height: 0;
   display: flex;
   gap: 10px;
-  min-width: 1450px;
+  min-width: 0;
 }
 
 .ls-split[hidden] {
@@ -2643,13 +2774,22 @@ body {
 }
 
 .ls-pane {
-  flex: 1 0 720px;
-  min-width: 720px;
+  flex: 1 1 0;
+  min-width: 0;
   border: 1px solid var(--color-border);
   border-radius: 8px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  background: var(--color-background-primary);
+}
+
+.ls-split.ls-right-pane-collapsed #ls-left-pane {
+  flex-basis: 100%;
+}
+
+.ls-split.ls-right-pane-collapsed #ls-right-pane {
+  display: none;
 }
 
 .ls-pane-head {
@@ -2758,6 +2898,18 @@ body {
   white-space: pre-wrap;
   word-break: normal;
   overflow-wrap: break-word;
+}
+
+.ls-formulas-panel {
+  height: 100%;
+  min-height: 360px;
+  padding: 12px;
+  overflow-y: auto;
+  background: var(--color-background-primary);
+}
+
+.ls-formulas-panel[hidden] {
+  display: none !important;
 }
 
 .ls-display-preview p {
@@ -3696,30 +3848,56 @@ body {
   color: var(--color-text-secondary);
 }
 
-.ls-action-panel {
-  width: 280px;
-  min-width: 240px;
-  flex: 0 0 280px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+.ls-assistant-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+.ls-assistant-modal[hidden] {
+  display: none !important;
+}
+
+.ls-assistant-dialog {
+  width: min(560px, calc(100vw - 32px));
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 8px;
+  background: var(--color-background-primary);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.22);
   overflow: hidden;
 }
 
-.ls-action-header {
-  padding: 8px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
+.ls-assistant-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-bg-secondary);
 }
 
-.ls-action-body {
-  padding: 12px;
-  overflow-y: auto;
-  flex: 1;
+.ls-assistant-head h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.ls-assistant-body {
+  padding: 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.ls-assistant-label {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.ls-assistant-body #ls-rewrite-btn {
+  width: 100%;
 }
 
 .ls-settings-modal {

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -2823,6 +2823,7 @@
     graphLoading: false,
     // Issue #232: 左ペインタブ
     leftTab: "course",
+    rightPaneVisible: true,
     courseStructure: null,
     courseComponents: null,
   };
@@ -2855,6 +2856,73 @@
     document.querySelectorAll(".ls-menu").forEach(function (menu) {
       menu.hidden = true;
     });
+  }
+
+  function lsSelectedCourseTitle() {
+    var select = document.getElementById("ls-course-select");
+    if (!select || !lsState.courseId) return "";
+    var opt = select.options[select.selectedIndex];
+    return opt ? opt.textContent : "";
+  }
+
+  function lsUpdateCourseShell() {
+    var selected = Boolean(lsState.courseId);
+    var select = document.getElementById("ls-course-select");
+    var label = document.getElementById("ls-course-select-label");
+    var current = document.getElementById("ls-course-current");
+    var resetBtn = document.getElementById("ls-course-reset-btn");
+    var empty = document.getElementById("ls-empty-course");
+    var workarea = document.getElementById("ls-studio-workarea");
+    if (select) select.hidden = selected;
+    if (label) label.hidden = selected;
+    if (resetBtn) resetBtn.hidden = !selected;
+    if (current) {
+      current.hidden = !selected;
+      current.textContent = selected ? "コース: " + (lsSelectedCourseTitle() || lsState.courseId) : "コース: -";
+    }
+    if (empty) empty.hidden = selected;
+    if (workarea) workarea.hidden = !selected;
+    lsUpdateRightPaneToggle();
+    lsUpdateAssistantOpenButton();
+  }
+
+  function lsUpdateAssistantOpenButton() {
+    var btn = document.getElementById("ls-ai-assistant-btn");
+    var promptEl = document.getElementById("ls-rewrite-prompt");
+    if (!btn) return;
+    btn.disabled = !lsState.courseId || !promptEl || promptEl.disabled;
+  }
+
+  function lsOpenAssistantModal() {
+    var modal = document.getElementById("ls-assistant-modal");
+    var promptEl = document.getElementById("ls-rewrite-prompt");
+    if (!modal || !promptEl || promptEl.disabled) return;
+    lsUpdateAssistantContext();
+    modal.hidden = false;
+    setTimeout(function () { promptEl.focus(); }, 0);
+  }
+
+  function lsCloseAssistantModal() {
+    var modal = document.getElementById("ls-assistant-modal");
+    if (modal) modal.hidden = true;
+  }
+
+  function lsUpdateRightPaneToggle() {
+    var btn = document.getElementById("ls-right-pane-toggle");
+    if (!btn) return;
+    btn.disabled = !lsState.courseId || !document.getElementById("ls-right-pane");
+    btn.textContent = lsState.rightPaneVisible ? "右ペインを隠す" : "右ペインを表示";
+  }
+
+  function lsApplyRightPaneVisibility() {
+    var splitEl = document.querySelector("#ls-workspace .ls-split");
+    if (splitEl) splitEl.classList.toggle("ls-right-pane-collapsed", !lsState.rightPaneVisible);
+    lsUpdateRightPaneToggle();
+  }
+
+  function lsSetRightPaneVisible(visible) {
+    lsState.rightPaneVisible = visible !== false;
+    lsApplyRightPaneVisibility();
   }
 
   function lsIsTheoryGraphView(view) {
@@ -2911,6 +2979,11 @@
     var moreMenuBtn = document.getElementById("ls-more-menu-btn");
     var saveBtn = document.getElementById("ls-save-btn");
     var rewriteBtn = document.getElementById("ls-rewrite-btn");
+    var resetCourseBtn = document.getElementById("ls-course-reset-btn");
+    var assistantBtn = document.getElementById("ls-ai-assistant-btn");
+    var assistantCloseBtn = document.getElementById("ls-assistant-close");
+    var assistantModal = document.getElementById("ls-assistant-modal");
+    var rightPaneToggle = document.getElementById("ls-right-pane-toggle");
 
     lsBindMenu("ls-more-menu-btn", "ls-more-menu");
 
@@ -2924,6 +2997,8 @@
         settingsBtn.disabled = false;
         if (courseContentBtn) courseContentBtn.disabled = false;
         moreMenuBtn.disabled = false;
+        lsState.rightPaneVisible = true;
+        lsUpdateCourseShell();
         lsLoadSettings(courseId);
         lsLoadScripts(courseId);
       } else {
@@ -2949,7 +3024,30 @@
         lsRenderChunkList();
         lsRenderLeftPanel();
         lsClearEditor();
+        lsCloseAssistantModal();
+        lsUpdateCourseShell();
       }
+    });
+
+    if (resetCourseBtn) resetCourseBtn.addEventListener("click", function () {
+      courseSelect.value = "";
+      courseSelect.dispatchEvent(new Event("change"));
+    });
+
+    if (assistantBtn) assistantBtn.addEventListener("click", function () {
+      lsOpenAssistantModal();
+    });
+
+    if (assistantCloseBtn) assistantCloseBtn.addEventListener("click", function () {
+      lsCloseAssistantModal();
+    });
+
+    if (assistantModal) assistantModal.addEventListener("click", function (e) {
+      if (e.target === assistantModal) lsCloseAssistantModal();
+    });
+
+    if (rightPaneToggle) rightPaneToggle.addEventListener("click", function () {
+      lsSetRightPaneVisible(!lsState.rightPaneVisible);
     });
 
     if (audioAllBtn) audioAllBtn.addEventListener("click", function () {
@@ -3021,6 +3119,7 @@
     });
 
     lsUpdateWorkTabActive();
+    lsUpdateCourseShell();
     lsLoadCourses();
   }
 
@@ -3230,6 +3329,7 @@
           select.appendChild(opt);
         });
         if (currentVal) select.value = currentVal;
+        lsUpdateCourseShell();
       })
       .catch(function () {});
   }
@@ -3886,6 +3986,7 @@
         lsLoadComponentGraph(docId, true);
       });
     }
+    lsApplyRightPaneVisibility();
     return workspace;
   }
 
@@ -3913,6 +4014,7 @@
     var sourceEl = document.getElementById("ls-source-text");
     var displayEl = document.getElementById("ls-display-text");
     var spokenEl = document.getElementById("ls-spoken-text");
+    var formulasEl = document.getElementById("ls-formulas");
     if (sourceEl) sourceEl.textContent = "";
     if (displayEl) {
       displayEl.value = "";
@@ -3938,6 +4040,7 @@
     document.getElementById("ls-sync-row").hidden = true;
     document.getElementById("ls-display-preview").hidden = true;
     document.getElementById("ls-pdf-view").hidden = true;
+    if (formulasEl) formulasEl.hidden = true;
 
     var extractBtn = document.getElementById("ls-extract-theory-btn");
     if (extractBtn) {
@@ -4008,6 +4111,7 @@
     if (saveBtn) saveBtn.disabled = false;
     var rewriteBtn = document.getElementById("ls-rewrite-btn");
     if (rewriteBtn) rewriteBtn.disabled = true;
+    lsApplyRightPaneVisibility();
     lsUpdateAssistantContext();
   }
 
@@ -4518,6 +4622,7 @@
     var sourceEl = document.getElementById("ls-source-text");
     var displayEl = document.getElementById("ls-display-text");
     var spokenEl = document.getElementById("ls-spoken-text");
+    var formulasEl = document.getElementById("ls-formulas");
     sourceEl.textContent = chunk.raw_text || chunk.text || "(抽出テキストなし)";
     if (displayEl.value !== (chunk.display_text || chunk.text || "")) displayEl.value = chunk.display_text || chunk.text || "";
     if (spokenEl.value !== (chunk.spoken_text || displayEl.value || "")) spokenEl.value = chunk.spoken_text || displayEl.value || "";
@@ -4553,18 +4658,21 @@
       document.getElementById("ls-display-tabs").hidden = true;
       spokenEl.hidden = true;
       displayEl.hidden = true;
+      if (formulasEl) formulasEl.hidden = true;
       document.getElementById("ls-display-preview").hidden = true;
       lsRenderTheoryPanel(chunk);
     } else if (isClaims) {
       document.getElementById("ls-display-tabs").hidden = true;
       spokenEl.hidden = true;
       displayEl.hidden = true;
+      if (formulasEl) formulasEl.hidden = true;
       document.getElementById("ls-display-preview").hidden = true;
       lsRenderClaimsPanel(chunk);
     } else if (isGraph) {
       document.getElementById("ls-display-tabs").hidden = true;
       spokenEl.hidden = true;
       displayEl.hidden = true;
+      if (formulasEl) formulasEl.hidden = true;
       document.getElementById("ls-display-preview").hidden = true;
       var graphDocumentId = lsCurrentDocumentId();
       if (graphDocumentId && !lsState.graphByDocument[graphDocumentId] && !lsState.graphLoading) {
@@ -4576,14 +4684,19 @@
       document.getElementById("ls-display-tabs").hidden = true;
       document.getElementById("ls-display-preview").hidden = true;
       displayEl.hidden = true;
+      if (formulasEl) formulasEl.hidden = true;
       spokenEl.hidden = false;
       spokenEl.disabled = lsState.syncSpoken;
     } else {
-      document.getElementById("ls-right-title").textContent = "表示テキスト";
+      document.getElementById("ls-right-title").textContent = lsState.displayView === "formulas" ? "数式一覧" : "表示テキスト";
       document.getElementById("ls-display-tabs").hidden = false;
       spokenEl.hidden = true;
       displayEl.hidden = lsState.displayView !== "script";
       document.getElementById("ls-display-preview").hidden = lsState.displayView !== "preview";
+      if (formulasEl) {
+        formulasEl.hidden = lsState.displayView !== "formulas";
+        if (lsState.displayView === "formulas") lsRenderFormulas(chunk.formulas || []);
+      }
       lsRenderDisplayPreview();
     }
 
@@ -4597,8 +4710,10 @@
       });
       displayEl.hidden = true;
       document.getElementById("ls-display-preview").hidden = false;
+      if (formulasEl) formulasEl.hidden = true;
     }
     if (isStructure) lsRenderStructure(chunk);
+    lsApplyRightPaneVisibility();
     lsUpdateAssistantContext();
   }
 
@@ -4613,6 +4728,7 @@
       promptEl.disabled = false;
       btn.textContent = "AIで提案";
       btn.disabled = false;
+      lsUpdateAssistantOpenButton();
       return;
     }
     var view = lsState.view || "edit";
@@ -4660,6 +4776,9 @@
     label.textContent = config.label;
     promptEl.placeholder = config.placeholder;
     btn.textContent = config.button;
+    btn.disabled = !lsState.courseId || !lsState.selectedChunkId;
+    promptEl.disabled = btn.disabled;
+    lsUpdateAssistantOpenButton();
   }
 
   function lsChunkTheoryState(chunkId) {
@@ -5991,15 +6110,19 @@
     document.getElementById("ls-rewrite-prompt").disabled = true;
     document.getElementById("ls-rewrite-btn").disabled = true;
     document.getElementById("ls-save-btn").disabled = true;
-    document.getElementById("ls-formulas").innerHTML = "";
+    var formulasEl = document.getElementById("ls-formulas");
+    if (formulasEl) formulasEl.innerHTML = "";
     lsUpdateWorkTabActive();
     lsHideActionStatus();
+    lsUpdateAssistantOpenButton();
+    lsUpdateRightPaneToggle();
   }
 
   function lsRenderFormulas(formulas) {
     var el = document.getElementById("ls-formulas");
+    if (!el) return;
     if (!formulas || formulas.length === 0) {
-      el.innerHTML = "";
+      el.innerHTML = '<div class="ls-empty-state">この表示対象の数式一覧はありません。</div>';
       return;
     }
     var html = '<div style="font-size:11px;font-weight:600;color:var(--color-text-secondary);margin-bottom:6px">数式一覧</div>';


### PR DESCRIPTION
## Summary

- 原稿スタジオのコース選択後レイアウトを整理
- 原稿/構造/理論グラフ操作を上部ツールバーへ移動
- AIアシスタントを右ペインからモーダル表示に変更
- 右ペインの表示/非表示切り替えを追加
- 数式一覧タブを追加
