### PR TITLE
Support TeX archive sources in document pipeline

### DIFF
--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -1631,6 +1631,35 @@ def _load_pipeline_pdf(material_id: str, filename: str) -> bytes:
     raise FileNotFoundError(f"PDF object not found for material {material_id}")
 
 
+def _load_pipeline_source(material_id: str, filename: str) -> tuple[bytes, str]:
+    """教材ファイルをストレージからロードし、(bytes, source_kind) を返す。
+
+    filename 拡張子から source_kind を判定し、対応するオブジェクト名を試みる。
+    """
+    lower = (filename or "").lower()
+    if lower.endswith(".tar.gz") or lower.endswith(".tgz"):
+        source_kind = "tex_archive"
+        candidates = (
+            f"uploads/{material_id}.tar.gz",
+            f"uploads/{material_id}.tgz",
+            filename,
+            material_id,
+        )
+    else:
+        source_kind = "pdf"
+        candidates = (f"uploads/{material_id}.pdf", filename, material_id)
+
+    storage = get_storage_client()
+    for object_name in candidates:
+        if not object_name:
+            continue
+        try:
+            return storage.get_object("raw-papers", object_name), source_kind
+        except Exception:
+            continue
+    raise FileNotFoundError(f"Source object not found for material {material_id} (source_kind={source_kind})")
+
+
 def _set_document_pipeline_status(document_id: str, status: str) -> None:
     session = _pg_session()
     try:
@@ -1809,7 +1838,7 @@ def _material_document_pipeline_worker(
 
     publish("processing", 0)
     try:
-        pdf_bytes = _load_pipeline_pdf(material_id, document["filename"])
+        source_bytes, source_kind = _load_pipeline_source(material_id, document["filename"])
         if target_stage is None:
             _set_document_pipeline_status(document_id, "processing")
 
@@ -1819,10 +1848,11 @@ def _material_document_pipeline_worker(
             publish("processing", int((info or {}).get("progress") or 0))
 
         run_document_pipeline(
-            pdf_bytes=pdf_bytes,
+            pdf_bytes=source_bytes,
             document_id=document_id,
             material_id=material_id,
             filename=document["filename"],
+            source_kind=source_kind,
             course_id=None,
             progress_callback=on_stage,
             target_stage=target_stage,
@@ -1885,7 +1915,7 @@ def _course_document_pipeline_worker(
             current_document = doc["document_id"]
             current_stage = target_stage or "document_pipeline"
             publish("processing")
-            pdf_bytes = _load_pipeline_pdf(doc["material_id"], doc["filename"])
+            source_bytes, source_kind = _load_pipeline_source(doc["material_id"], doc["filename"])
             if target_stage is None:
                 _set_document_pipeline_status(doc["document_id"], "processing")
 
@@ -1913,10 +1943,11 @@ def _course_document_pipeline_worker(
                 )
 
             run_document_pipeline(
-                pdf_bytes=pdf_bytes,
+                pdf_bytes=source_bytes,
                 document_id=doc["document_id"],
                 material_id=doc["material_id"],
                 filename=doc["filename"],
+                source_kind=source_kind,
                 course_id=course_id,
                 progress_callback=on_stage,
                 target_stage=target_stage,

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -1340,15 +1340,30 @@
         btn.textContent = "登録完了!";
         btn.style.background = "var(--color-text-success)";
 
-        // Show success message in chat
-        state.chatMessages.push({
+        var newCourseId = data.id;
+        var successMsg = {
           role: "assistant",
-          content: "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + data.id + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。",
-        });
+          content: "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + newCourseId + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。\n\nコース内容を自動生成中...",
+        };
+        state.chatMessages.push(successMsg);
         renderCourseChat();
 
-        // コース本文はバックエンド側で、既存のAgent成果物とアウトラインを対応付けて作成する。
-        // 教材解析のAgentパイプラインは教材アップロード後または原稿スタジオから明示実行する。
+        apiFetch("/admin/courses/" + newCourseId + "/course-content/generate", {
+          method: "POST",
+          body: "{}",
+        })
+          .then(function (genRes) {
+            if (genRes.ok) {
+              successMsg.content = "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + newCourseId + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。\n\nコース内容の自動生成を開始しました。完了後は原稿スタジオで確認できます。";
+            } else {
+              successMsg.content = "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + newCourseId + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。\n\n（コース内容の自動生成を開始できませんでした。原稿スタジオから手動で実行してください。）";
+            }
+            renderCourseChat();
+          })
+          .catch(function () {
+            successMsg.content = "コース「" + (data.title || draft.title) + "」が正常に登録されました。（ID: " + newCourseId + "）\n\n「コース管理」タブからグループ単位で受講可／編集可の権限を設定できます。\n\n（コース内容の自動生成を開始できませんでした。原稿スタジオから手動で実行してください。）";
+            renderCourseChat();
+          });
       })
       .catch(function () {
         btn.disabled = false;


### PR DESCRIPTION
## Summary
Extends the document pipeline to support both PDF and TeX archive (`.tar.gz`, `.tgz`) source materials, enabling processing of LaTeX-based documents in addition to PDFs. Also adds automatic course content generation when a course is created.

## Key Changes

### Backend (`backend/api/routes/lecture_studio.py`)
- **New function `_load_pipeline_source()`**: Replaces `_load_pipeline_pdf()` with a more flexible loader that:
  - Detects source type from filename extension (`.tar.gz`/`.tgz` → `tex_archive`, otherwise → `pdf`)
  - Returns tuple of `(bytes, source_kind)` to track the source material type
  - Tries multiple candidate object names in MinIO storage for robustness
  
- **Updated pipeline calls**: Modified two document pipeline execution points to:
  - Use `_load_pipeline_source()` instead of `_load_pipeline_pdf()`
  - Pass `source_kind` parameter to `run_document_pipeline()` alongside the source bytes
  - Maintains backward compatibility with existing PDF processing

### Frontend (`frontend/public/js/admin.js`)
- **Automatic course content generation**: When a course is successfully created:
  - Immediately triggers `/admin/courses/{courseId}/course-content/generate` POST request
  - Updates success message to indicate auto-generation is in progress
  - Gracefully handles generation failures with fallback messages directing users to manual execution in the manuscript studio
  - Provides real-time feedback to users about the generation status

## Implementation Details
- The `source_kind` parameter allows downstream pipeline stages to apply source-specific processing logic
- Storage lookup uses a candidate list pattern for flexibility (standard paths, custom filenames, material IDs)
- Course content generation is non-blocking and provides user feedback via chat message updates
- Error handling ensures course creation succeeds even if auto-generation fails

https://claude.ai/code/session_015mBBDZAdvQdPQPgmMD3PwE