### PR TITLE
Add confirmation dialog and auto-close for material pipeline execution

### DIFF
--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -460,9 +460,10 @@
       btn.addEventListener("click", function () {
         var menu = this.closest(".material-pipeline-menu");
         if (!menu) return;
-        runMaterialPipeline(menu.getAttribute("data-material-id"), this.getAttribute("data-stage") || "");
         var panel = menu.querySelector(".material-pipeline-panel");
         if (panel) panel.hidden = true;
+        if (!confirm("既存の実行結果を上書きします。本当に実行しますか？")) return;
+        runMaterialPipeline(menu.getAttribute("data-material-id"), this.getAttribute("data-stage") || "");
       });
     });
     root.querySelectorAll(".material-export-item").forEach(function (btn) {
@@ -8132,6 +8133,12 @@
   function initApp() {
     // Role-based access control
     if (!setupRoleBasedUI()) return;
+
+    document.addEventListener("click", function () {
+      document.querySelectorAll(".material-pipeline-panel").forEach(function (panel) {
+        panel.hidden = true;
+      });
+    });
 
     var usernameEl = document.getElementById("admin-username");
     if (usernameEl) usernameEl.textContent = state.username || "";


### PR DESCRIPTION
## Summary
Adds user confirmation and improved UX for material pipeline execution in the admin panel. Users must now confirm before overwriting existing execution results, and pipeline panels auto-close when clicking outside them.

## Key Changes
- **Confirmation Dialog**: Added `confirm()` prompt before executing material pipeline to prevent accidental overwrites of existing results
  - Dialog message: "既存の実行結果を上書きします。本当に実行しますか？" (Existing execution results will be overwritten. Are you sure?)
  - Execution is cancelled if user declines
  
- **Auto-close Pipeline Panels**: Added global click listener that automatically hides all `.material-pipeline-panel` elements when clicking anywhere on the document
  - Improves UX by allowing users to dismiss panels without explicit close button
  - Panels are hidden before pipeline execution begins

- **Execution Order Fix**: Reordered operations so panel is hidden and confirmation is checked before `runMaterialPipeline()` is called

## Implementation Details
- Confirmation check is placed after panel hiding but before pipeline execution to ensure proper flow
- Global click listener is attached during document initialization (after role-based access control setup)
- Uses native `confirm()` dialog for simplicity and consistency with browser conventions

https://claude.ai/code/session_0162SVr6yqvXWCYRjxitKCFh