### PR TITLE
Build domain-independent theory-operation graph from derivations (#302)

### DIFF
--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Episteme Graphのナレッジグラフ、PDF教材処理パイプライン、DSL定義、パターンマッチング、
   およびPDF解析Agentパイプライン（DocumentStructureAgent / PaperSkeletonAgent /
   RhetoricalRoleAgent / ClaimQualificationAgent / EquationSemanticsAgent /
-  ThesisReconstructionAgent / DSLLinkingAgent / ComponentAssemblyAgent）に
+  ThesisReconstructionAgent / DSLLinkingAgent / ComponentAssemblyAgent /
+  ComponentAssemblyAgentが生成する理論操作グラフ TheoryOperationGraph (ComponentGraphAgent)）に
   関する実装や修正を行う際に使用します。ユーザーから「抽出ロジックを変更して」
   「ナレッジグラフの構造を修正して」「パイプラインを改善して」「DSLを拡張して」
   「パターンマッチングを調整して」「Agentを実装して」「カートリッジを更新して」

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ src/episteme_graph/agents/
   thesis_reconstruction/ → ThesisReconstructionAgent (#221)
   dsl_linking/          → DSLLinkingAgent (#222)
   component_assembly/   → ComponentAssemblyAgent (#223)
+  component_graph/      → ComponentGraphAgent (#266) — TheoryOperationGraph 構築
 ```
 
 各Agentディレクトリは最低限以下のファイルを持つ:
@@ -171,6 +172,31 @@ examples/          → サンプル入出力JSON
 3. **evidence-based**: 各出力フィールドに `reason` と `confidence` (0.0〜1.0) を付与
 4. **情報を落とさない**: 不明は `unknown` / `deferred` で保持し、削除しない
 5. **maturity・review情報の最終確定禁止**: LLMが提案しても provisional に留める
+
+#### TheoryOperationGraph (ComponentGraphAgent #266 / #302)
+
+`component_graph/normalizer.py` が DerivationChain から **理論操作グラフ (TheoryOperationGraph)** を
+決定論的に構築する。**特定分野・特定論文の用語をハードコードしない**（domain-independent）。
+
+- **node / edge の語彙は `operation` から導出する**: `schema.classify_operation()` が
+  `define_* → defines` / `linearize_* → linearizes` / `solve_* → solves` /
+  `eliminate_* → eliminates` / `derive_* → derives` / `constrain_* → constrains` /
+  `diagnose_* → diagnoses` / `compare_* → compares` のように prefix で edge_type を決める。
+  `transform` / `relate` / `connect` / `support` / `associate` など抽象的な operation は
+  generic 扱いとし、`inferred` / `requires_review` にして warning を出す。
+- **source-backing を必ず明示する**: 各 node は
+  `linked_equation_ids` / `linked_derivation_ids` / `linked_claim_ids` / `linked_evidence_ids` と
+  `source_backing_status`（`source_backed` / `partially_source_backed` / `inferred` / `review_required`）を持つ。
+  各 edge は `evidence_equation_ids` / `evidence_derivation_ids` / `evidence_claim_ids` /
+  `source_evidence_ids` と `review_status`（`source_backed` / `review_required`）を持つ。
+- **review の理由を必ず付与する**: `review_required` の node / edge は `review_reasons` を空にしない
+  （`missing_atomic_claim` / `missing_evidence_link` / `missing_equation_link` /
+  `missing_derivation_link` / `equation_needs_math_review` / `edge_not_source_backed` /
+  `fallback_or_inferred_node` / `source_span_missing` から選ぶ）。
+- **fallback / inferred node を main graph で確定扱いしない**: `deterministic_fallback` や
+  `inferred` の node は `graph_layer = "debug"` に分離し、`source_backed` にしてはならない（hard error）。
+- **UI (`admin.js`)** は `source_backing_status` で表示を区別する
+  （source_backed=通常 / partially=細線 / review_required=点線枠 / inferred・fallback=薄色+⚠）。
 
 #### カートリッジシステム
 

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -189,14 +189,25 @@ _GRAPH_RELATIONS = {
     "CHECKED_BY",
     "CONFLICTS_WITH",
     "RELATED_TO",
+    # Domain-neutral operation-derived relations (issue #302).
     "defines",
-    "feeds_equation_system",
+    "constructs",
     "linearizes",
-    "eliminates_bias",
+    "solves",
+    "substitutes",
+    "eliminates",
     "derives",
     "constrains",
     "diagnoses",
+    "compares",
+    "normalizes",
+    "approximates",
+    "transforms",
+    "feeds",
     "requires_review",
+    # Retained for backward compatibility with previously stored graphs.
+    "feeds_equation_system",
+    "eliminates_bias",
 }
 _MAX_COMPONENT_ASSEMBLY_CLAIMS = 40
 _MAX_COMPONENTS_PER_SECTION = 3
@@ -1952,6 +1963,12 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "eliminated_symbols": node.get("eliminated_symbols") if isinstance(node.get("eliminated_symbols"), list) else [],
             "retained_symbols": node.get("retained_symbols") if isinstance(node.get("retained_symbols"), list) else [],
             "derivation_operations": node.get("derivation_operations") if isinstance(node.get("derivation_operations"), list) else [],
+            "linked_equation_ids": node.get("linked_equation_ids") if isinstance(node.get("linked_equation_ids"), list) else [],
+            "linked_derivation_ids": node.get("linked_derivation_ids") if isinstance(node.get("linked_derivation_ids"), list) else [],
+            "linked_claim_ids": node.get("linked_claim_ids") if isinstance(node.get("linked_claim_ids"), list) else [],
+            "linked_evidence_ids": node.get("linked_evidence_ids") if isinstance(node.get("linked_evidence_ids"), list) else [],
+            "source_backing_status": str(node.get("source_backing_status") or ""),
+            "review_reasons": node.get("review_reasons") if isinstance(node.get("review_reasons"), list) else [],
         })
         seen_nodes.add(component_id)
     normalized_edges = []
@@ -1964,13 +1981,22 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
         "related_to": "RELATED_TO",
         "conflicts_with": "CONFLICTS_WITH",
         "defines": "defines",
-        "feeds_equation_system": "feeds_equation_system",
+        "constructs": "constructs",
         "linearizes": "linearizes",
-        "eliminates_bias": "eliminates_bias",
+        "solves": "solves",
+        "substitutes": "substitutes",
+        "eliminates": "eliminates",
         "derives": "derives",
         "constrains": "constrains",
         "diagnoses": "diagnoses",
+        "compares": "compares",
+        "normalizes": "normalizes",
+        "approximates": "approximates",
+        "transforms": "transforms",
+        "feeds": "feeds",
         "requires_review": "requires_review",
+        "feeds_equation_system": "feeds_equation_system",
+        "eliminates_bias": "eliminates_bias",
     }
     for edge in graph.get("edges") if isinstance(graph.get("edges"), list) else []:
         if not isinstance(edge, dict):
@@ -1990,7 +2016,8 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "edge_type": str(edge.get("edge_type") or raw_relation or "stored_pipeline_edge"),
             "confidence": float(edge.get("confidence") or 0.8),
             "support_status": str(edge.get("support_status") or "source_inferred"),
-            "review_status": str(edge.get("review_status") or "teacher_review_required"),
+            "review_status": str(edge.get("review_status") or "review_required"),
+            "review_reasons": edge.get("review_reasons") if isinstance(edge.get("review_reasons"), list) else [],
             "evidence": edge.get("evidence") if isinstance(edge.get("evidence"), dict) else {"reason": edge.get("reason") or ""},
         })
     if not normalized_nodes and not normalized_edges:

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -854,6 +854,13 @@ class ComponentGraphNode(BaseModel):
     eliminated_symbols: list[str] = Field(default_factory=list)
     retained_symbols: list[str] = Field(default_factory=list)
     derivation_operations: list[str] = Field(default_factory=list)
+    # Source-backing links and status (issue #302).
+    linked_equation_ids: list[str] = Field(default_factory=list)
+    linked_derivation_ids: list[str] = Field(default_factory=list)
+    linked_claim_ids: list[str] = Field(default_factory=list)
+    linked_evidence_ids: list[str] = Field(default_factory=list)
+    source_backing_status: str = ""
+    review_reasons: list[str] = Field(default_factory=list)
 
 
 class ComponentGraphEdge(BaseModel):
@@ -863,7 +870,8 @@ class ComponentGraphEdge(BaseModel):
     edge_type: str = "explicit_connector"
     confidence: float = 0.5
     support_status: str = "design_inferred"
-    review_status: str = "teacher_review_required"
+    review_status: str = "review_required"
+    review_reasons: list[str] = Field(default_factory=list)
     evidence: dict = Field(default_factory=dict)
 
 

--- a/backend/tests/test_theory_graph_source_backing.py
+++ b/backend/tests/test_theory_graph_source_backing.py
@@ -1,0 +1,77 @@
+"""Issue #302: TheoryOperationGraph の source-backed / review_required 対応の回帰チェック。
+
+backend route / Pydantic schema / frontend が、node・edge の source-backing リンクと
+review 理由を伝搬・表示することを構造的に検証する。重い依存 (fastapi 等) を import せず、
+ソーステキストに対するアサーションで確認する (既存 graph テストの方針に合わせる)。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ROUTES = ROOT / "backend" / "api" / "routes" / "theory_components.py"
+SCHEMAS = ROOT / "backend" / "api" / "schemas.py"
+ADMIN_JS = ROOT / "frontend" / "public" / "js" / "admin.js"
+STYLES = ROOT / "frontend" / "public" / "css" / "styles.css"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class TestGraphSchemaExposesSourceBacking:
+    def test_node_schema_has_source_links(self):
+        source = _read(SCHEMAS)
+        for field in (
+            "linked_equation_ids",
+            "linked_derivation_ids",
+            "linked_claim_ids",
+            "linked_evidence_ids",
+            "source_backing_status",
+            "review_reasons",
+        ):
+            assert field in source, f"ComponentGraphNode schema missing {field}"
+
+    def test_edge_schema_has_review_reasons(self):
+        source = _read(SCHEMAS)
+        assert "review_reasons: list[str]" in source
+
+
+class TestRoutePropagatesSourceBacking:
+    def test_normalize_passes_through_node_source_links(self):
+        source = _read(ROUTES)
+        for field in (
+            '"linked_equation_ids"',
+            '"linked_derivation_ids"',
+            '"linked_claim_ids"',
+            '"linked_evidence_ids"',
+            '"source_backing_status"',
+            '"review_reasons"',
+        ):
+            assert field in source, f"route does not propagate node field {field}"
+
+    def test_graph_relations_include_operation_edge_types(self):
+        source = _read(ROUTES)
+        for relation in ("solves", "substitutes", "eliminates", "compares", "constructs"):
+            assert f'"{relation}"' in source, f"_GRAPH_RELATIONS missing {relation}"
+
+
+class TestFrontendDistinguishesSourceBacking:
+    def test_admin_js_renders_source_backing(self):
+        source = _read(ADMIN_JS)
+        assert "source_backing_status" in source
+        assert "lsGraphSourceBackingLabel" in source
+        assert "lsGraphReviewReasonLabel" in source
+        # review_required nodes are drawn with a dashed border.
+        assert "review_required" in source
+
+    def test_styles_define_backing_states(self):
+        source = _read(STYLES)
+        for cls in (
+            ".ls-graph-backing-source_backed",
+            ".ls-graph-backing-partially_source_backed",
+            ".ls-graph-backing-inferred",
+            ".ls-graph-backing-review_required",
+        ):
+            assert cls in source, f"styles.css missing {cls}"

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -3619,6 +3619,53 @@ body {
   font-weight: 700;
 }
 
+/* Source-backing status & review reasons (issue #302) */
+.ls-graph-backing {
+  display: inline-block;
+  margin: 6px 0 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+}
+.ls-graph-backing-source_backed {
+  background: #dcfce7;
+  color: #166534;
+}
+.ls-graph-backing-partially_source_backed {
+  background: #fef9c3;
+  color: #854d0e;
+}
+.ls-graph-backing-inferred {
+  background: #f1f5f9;
+  color: #64748b;
+}
+.ls-graph-backing-review_required {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.ls-graph-detail-reasons {
+  display: grid;
+  gap: 4px;
+  margin: 6px 0 0;
+  padding-left: 16px;
+  font-size: 11px;
+  color: #b91c1c;
+}
+
+.ls-graph-detail-link {
+  font-size: 11px;
+  line-height: 1.5;
+  word-break: break-word;
+  margin-top: 4px;
+}
+.ls-graph-detail-link span {
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-right: 4px;
+}
+
 .ls-graph-validation {
   margin-top: 12px;
   padding: 12px;

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5269,16 +5269,23 @@
       var id = lsGraphNodeId(node) || ("node-" + index);
       var group = lsGraphNodeGroup(node);
       var pos = layoutPositions[id] || { x: 0, y: index * 160 };
+      var backing = String((node && node.source_backing_status) || "").toLowerCase();
       var visNode = {
         id: id,
-        label: lsWrapGraphLabel(node.label || node.name || id),
+        label: lsGraphNodeDisplayLabel(node, id),
         x: pos.x,
         y: pos.y,
         group: group,
-        title: node.component_type_text || node.component_type || node.review_status || "",
+        title: lsGraphNodeTooltip(node),
       };
-      if (lsGraphNodeDashed(node, group)) {
+      if (lsGraphNodeDashed(node, group) || backing === "review_required") {
         visNode.shapeProperties = { borderDashes: [6, 5] };
+      }
+      if (backing === "partially_source_backed") {
+        visNode.borderWidth = 1;
+      }
+      if (lsGraphNodeFaded(node, backing)) {
+        visNode.opacity = 0.55;
       }
       return visNode;
     }));
@@ -5357,10 +5364,27 @@
       var target = edge.target_component_id || edge.target || edge.to;
       return source === nodeId || target === nodeId;
     });
+    var backing = String(node.source_backing_status || "").toLowerCase();
     var html =
       '<div class="ls-graph-detail-badge ' + escHtml(lsGraphNodeGroup(node)) + '">' + escHtml(node.component_type_text || node.component_type || node.typeName || "component") + '</div>' +
       '<h4>' + escHtml(node.label || node.name || nodeId || "無題") + '</h4>' +
       '<p class="ls-graph-detail-meta">' + escHtml(node.review_status || node.origin || "paper") + '</p>';
+    if (backing) {
+      html += '<div class="ls-graph-detail-section"><b>出典の裏付け</b>' +
+        '<p class="ls-graph-backing ls-graph-backing-' + escHtml(backing) + '">' +
+        escHtml(lsGraphSourceBackingLabel(backing)) + '</p></div>';
+    }
+    if ((node.review_reasons || []).length) {
+      html += '<div class="ls-graph-detail-section"><b>要確認の理由</b><ul class="ls-graph-detail-reasons">';
+      node.review_reasons.forEach(function (reason) {
+        html += '<li>' + escHtml(lsGraphReviewReasonLabel(reason)) + '</li>';
+      });
+      html += '</ul></div>';
+    }
+    var links = lsGraphSourceLinksHtml(node);
+    if (links) {
+      html += '<div class="ls-graph-detail-section"><b>出典リンク</b>' + links + '</div>';
+    }
     if (node.summary) {
       html += '<div class="ls-graph-detail-section"><b>Summary</b><p>' + escHtml(node.summary) + '</p></div>';
     }
@@ -5405,6 +5429,23 @@
 
   function lsGraphNodeId(node) {
     return node && (node.component_id || node.id || node.node_id);
+  }
+
+  function lsGraphSourceLinksHtml(node) {
+    var rows = [
+      ["equation", node.linked_equation_ids],
+      ["derivation", node.linked_derivation_ids],
+      ["claim", node.linked_claim_ids],
+      ["evidence", node.linked_evidence_ids],
+    ];
+    var html = "";
+    rows.forEach(function (row) {
+      var ids = row[1] || [];
+      if (!ids.length) return;
+      html += '<div class="ls-graph-detail-link"><span>' + escHtml(row[0]) + '</span> ' +
+        escHtml(ids.join(", ")) + '</div>';
+    });
+    return html;
   }
 
   function lsWrapGraphLabel(label) {
@@ -5462,6 +5503,60 @@
     var maturity = String((node && node.maturity_source) || "").toLowerCase();
     return layer === "debug" || maturity === "deterministic_fallback" ||
       /uniform-coordinate|単一粒子/.test(label) || (group === "method" && /unpredictability/.test(label));
+  }
+
+  function lsGraphNodeFaded(node, backing) {
+    var layer = String((node && node.graph_layer) || "").toLowerCase();
+    var maturity = String((node && node.maturity_source) || "").toLowerCase();
+    return backing === "inferred" || layer === "debug" || maturity === "deterministic_fallback";
+  }
+
+  function lsGraphNodeIsFallback(node) {
+    var maturity = String((node && node.maturity_source) || "").toLowerCase();
+    var backing = String((node && node.source_backing_status) || "").toLowerCase();
+    return maturity === "deterministic_fallback" || backing === "inferred";
+  }
+
+  // Prefix a warning icon for fallback / inferred nodes so they are not mistaken
+  // for confirmed, source-backed theory operations (issue #302).
+  function lsGraphNodeDisplayLabel(node, id) {
+    var label = lsWrapGraphLabel((node && (node.label || node.name)) || id);
+    return lsGraphNodeIsFallback(node) ? "⚠ " + label : label;
+  }
+
+  function lsGraphSourceBackingLabel(status) {
+    var labels = {
+      source_backed: "出典あり",
+      partially_source_backed: "部分的に出典あり",
+      inferred: "推論",
+      review_required: "要確認",
+    };
+    return labels[String(status || "").toLowerCase()] || status || "";
+  }
+
+  function lsGraphReviewReasonLabel(reason) {
+    var labels = {
+      missing_atomic_claim: "atomicなclaim未紐付け",
+      missing_evidence_link: "evidence未紐付け",
+      missing_equation_link: "equation未紐付け",
+      missing_derivation_link: "derivation未紐付け",
+      equation_needs_math_review: "数式の確認が必要",
+      edge_not_source_backed: "edgeに出典がない",
+      fallback_or_inferred_node: "fallback / 推論ノード",
+      source_span_missing: "原文spanがない",
+    };
+    return labels[String(reason || "")] || reason || "";
+  }
+
+  function lsGraphNodeTooltip(node) {
+    var parts = [];
+    var type = node.component_type_text || node.component_type || node.review_status || "";
+    if (type) parts.push(type);
+    var backing = lsGraphSourceBackingLabel(node.source_backing_status);
+    if (backing) parts.push(backing);
+    var reasons = (node.review_reasons || []).map(lsGraphReviewReasonLabel);
+    if (reasons.length) parts.push(reasons.join(" / "));
+    return parts.join("\n");
   }
 
   function lsGraphDisplayEdges(edges) {
@@ -5593,6 +5688,8 @@
   function lsGraphEdgeDashed(edge) {
     var status = String((edge && edge.support_status) || "").toLowerCase();
     var relation = String((edge && (edge.relation || edge.edge_type || edge.type)) || "").toLowerCase();
+    var review = String((edge && edge.review_status) || "").toLowerCase();
+    if (review === "review_required") return true;
     return /llm|related|qualifies|conflicts|inhibits|uncertain/.test(status + " " + relation);
   }
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -1,10 +1,16 @@
-"""Normalize ComponentGraph into theory-structure graph nodes and edges.
+"""Normalize ComponentGraph into a source-backed theory-operation graph.
 
-The LLM edge pass connects assembled components. That is useful for debugging,
-but the published graph should show the paper's theoretical operations:
-definitions, equation-system construction, bias eliminations, consistency
-relations, and diagnostics. This module builds that graph deterministically from
-component equation roles plus derivation-chain operations.
+The LLM edge pass connects assembled components, which is useful for debugging.
+The published graph, however, should show the paper's *theory operations*
+(definitions, linearizations, eliminations, derivations, diagnostics, …) and
+make explicit, for every node and edge:
+
+  * which artifacts (equations / derivations / claims / evidence) back it, and
+  * whether it is ``source_backed`` or ``review_required`` (with reasons).
+
+This module builds that graph deterministically from the DerivationChain. It is
+domain-independent: node labels and edge types are derived from each step's
+``operation`` via :func:`classify_operation`, never from hard-coded paper terms.
 """
 from __future__ import annotations
 
@@ -13,9 +19,18 @@ from dataclasses import replace
 from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
 from episteme_graph.agents.derivation_chain.schema import DerivationChainResult
 
-from .schema import ComponentGraphEdge, ComponentGraphNode, ComponentGraphResult
+from .schema import (
+    ComponentGraphEdge,
+    ComponentGraphNode,
+    ComponentGraphResult,
+    classify_operation,
+)
 
 _GENERIC_LABELS = {"define", "transform", "relate", "result"}
+# Minimum number of theory-operation nodes required before we publish the
+# derivation-derived graph as the main graph (smaller chains fall back to the
+# component view).
+_MIN_THEORY_NODES = 3
 
 
 class ComponentGraphNormalizer:
@@ -25,18 +40,19 @@ class ComponentGraphNormalizer:
         components: ComponentAssemblyResult,
         derivations: DerivationChainResult | None = None,
     ) -> ComponentGraphResult:
-        theory_nodes, theory_edges = self._build_derivation_theory_graph(
+        theory_nodes, theory_edges = self._build_theory_graph(
             result.document_id,
             derivations,
         )
-        if len(theory_nodes) >= 5:
+        if len(theory_nodes) >= _MIN_THEORY_NODES:
             return replace(
                 result,
                 nodes=theory_nodes + self._debug_nodes(result.nodes),
                 edges=theory_edges,
                 confidence=max(result.confidence, 0.85),
                 review_notes=list(result.review_notes or []) + [
-                    "GraphNormalizer built the main graph from derivation operations and equation roles."
+                    "GraphNormalizer built the main graph from derivation operations "
+                    "and equation roles."
                 ],
             )
 
@@ -44,224 +60,196 @@ class ComponentGraphNormalizer:
             self._normalize_component_node(node, comp)
             for node, comp in _join_nodes_to_components(result.nodes, components)
         ]
-        return replace(result, nodes=normalized_nodes, edges=self._normalize_edges(result.edges, normalized_nodes))
+        return replace(
+            result,
+            nodes=normalized_nodes,
+            edges=self._normalize_edges(result.edges, normalized_nodes),
+        )
 
-    # ------------------------------------------------------------------
+    # ------------------------------------------------------------------ #
+    # Derivation → theory-operation graph (domain-independent)
+    # ------------------------------------------------------------------ #
 
-    def _build_derivation_theory_graph(
+    def _build_theory_graph(
         self,
         document_id: str,
         derivations: DerivationChainResult | None,
     ) -> tuple[list[ComponentGraphNode], list[ComponentGraphEdge]]:
-        steps = [
-            step
-            for chain in (getattr(derivations, "chains", []) or [])
-            for step in (getattr(chain, "steps", []) or [])
-        ]
-        if not steps:
+        records = self._collect_step_records(derivations)
+        if not records:
             return [], []
 
-        index = _DerivationIndex(steps)
-        nodes: list[ComponentGraphNode] = []
-
-        def add(
-            component_id: str,
-            label: str,
-            operation: str,
-            theory_object: str,
-            eqs: list[str],
-            *,
-            inputs: list[str] | None = None,
-            outputs: list[str] | None = None,
-            constraints: list[str] | None = None,
-            definitions: list[str] | None = None,
-            eliminated: list[str] | None = None,
-            retained: list[str] | None = None,
-            ops: list[str] | None = None,
-        ) -> None:
-            nodes.append(ComponentGraphNode(
-                component_id=component_id,
-                label=label,
-                component_type="TheoryOperationNode",
-                review_status="teacher_review_required",
-                display_order=len(nodes),
-                origin="derivation_chain",
-                operation=operation,
-                theory_object=theory_object,
-                graph_layer="main",
-                maturity_source="derivation_normalized",
-                publish_ready=False,
-                input_equation_ids=_ordered_unique(inputs if inputs is not None else eqs[:1]),
-                intermediate_equation_ids=[],
-                output_equation_ids=_ordered_unique(outputs if outputs is not None else eqs[-1:]),
-                definition_equation_ids=_ordered_unique(definitions or []),
-                constraint_equation_ids=_ordered_unique(constraints or []),
-                review_required_equation_ids=_ordered_unique(eqs),
-                eliminated_symbols=_ordered_unique(eliminated or []),
-                retained_symbols=_ordered_unique(retained or []),
-                derivation_operations=_ordered_unique(ops or []),
-            ))
-
-        add(
-            "theory_matter_perturbation_kernels",
-            "Define matter perturbation kernels",
-            "define",
-            "matter perturbation kernels",
-            index.equations_matching("eq_2_5", "eq_2_7", "eq_2_10", "eq_2_11"),
-            definitions=index.equations_matching("eq_2_5", "eq_2_7"),
-            ops=index.operations_matching("define", "derive_result"),
-        )
-        add(
-            "theory_galaxy_bias_model",
-            "Define galaxy bias model",
-            "define",
-            "galaxy bias model",
-            index.equations_matching("eq_2_12", "eq_2_13", "eq_2_14"),
-            definitions=index.equations_matching("eq_2_12", "eq_2_14"),
-            ops=index.operations_matching("define", "transform"),
-        )
-        add(
-            "theory_smoothed_observables",
-            "Define smoothed skewness/kurtosis observables",
-            "define",
-            "smoothed skewness/kurtosis observables",
-            index.equations_matching("eq_2_16", "eq_2_17", "eq_2_18", "eq_2_19", "eq_2_21"),
-            definitions=index.equations_matching("eq_2_17", "eq_2_18", "eq_2_19", "eq_2_21"),
-            ops=index.operations_matching("introduce_observable", "define"),
-        )
-        add(
-            "theory_skewness_bias_linear_equations",
-            "Build skewness bias-linear equations",
-            "linearize",
-            "skewness bias-linear moment equations",
-            index.equations_matching("eq_3_32", "eq_3_33", "eq_3_34"),
-            inputs=index.equations_matching("eq_3_32", "eq_3_33"),
-            outputs=index.equations_matching("eq_3_34"),
-            ops=index.operations_matching("linearize_skewness_bias_dependence"),
-        )
-        add(
-            "theory_kurtosis_bias_linear_equations",
-            "Build kurtosis bias-linear equations",
-            "linearize",
-            "kurtosis bias-linear moment equations",
-            index.equations_matching("eq_3_33", "eq_3_35"),
-            inputs=index.equations_matching("eq_3_33"),
-            outputs=index.equations_matching("eq_3_35"),
-            ops=index.operations_matching("linearize_kurtosis_bias_dependence", "linearize_skewness_bias_dependence"),
-        )
-        add(
-            "theory_second_order_bias_elimination",
-            "Eliminate second-order bias",
-            "eliminate",
-            "second-order galaxy bias",
-            index.equations_matching("eq_3_32", "eq_3_35", "eq_3_36"),
-            inputs=index.equations_matching("eq_3_32", "eq_3_35"),
-            outputs=index.equations_matching("eq_3_36"),
-            eliminated=["b2", "beta2", "second-order bias"],
-            retained=["b1", "kappa", "lambda", "skewness observables"],
-            ops=index.operations_matching("solve_second_order_bias", "substitute_second_order_bias"),
-        )
-        add(
-            "theory_third_order_bias_elimination",
-            "Eliminate third-order bias",
-            "eliminate",
-            "third-order galaxy bias",
-            index.equations_matching("eq_3_35", "eq_3_36"),
-            inputs=index.equations_matching("eq_3_35", "eq_3_36"),
-            outputs=index.equations_matching("eq_3_35", "eq_3_36"),
-            eliminated=["b3", "gamma2", "third-order bias"],
-            retained=["b1", "kurtosis observables", "gravity parameters"],
-            ops=index.operations_matching("solve_third_order_bias", "substitute_third_order_bias"),
-        )
-        add(
-            "theory_skewness_consistency_relation",
-            "Derive skewness consistency relation",
-            "derive",
-            "skewness consistency relation",
-            index.equations_matching("eq_3_34"),
-            inputs=index.equations_matching("eq_3_32"),
-            outputs=index.equations_matching("eq_3_34"),
-            constraints=index.equations_matching("eq_3_34"),
-            ops=index.operations_matching("derive_skewness_consistency_relation"),
-        )
-        add(
-            "theory_first_kurtosis_consistency_relation",
-            "Derive first kurtosis consistency relation",
-            "derive",
-            "first kurtosis consistency relation",
-            index.equations_matching("eq_3_35"),
-            inputs=index.equations_matching("eq_3_33"),
-            outputs=index.equations_matching("eq_3_35"),
-            constraints=index.equations_matching("eq_3_35"),
-            ops=index.operations_matching("derive_first_kurtosis_consistency_relation", "linearize_skewness_bias_dependence"),
-        )
-        add(
-            "theory_second_kurtosis_consistency_relation",
-            "Derive second kurtosis consistency relation",
-            "derive",
-            "second kurtosis consistency relation",
-            index.equations_matching("eq_3_36"),
-            inputs=index.equations_matching("eq_3_35"),
-            outputs=index.equations_matching("eq_3_36"),
-            constraints=index.equations_matching("eq_3_36"),
-            ops=index.operations_matching("derive_second_kurtosis_consistency_relation", "solve_second_order_bias"),
-        )
-        add(
-            "theory_horndeski_dhost_diagnostic",
-            "Diagnose Horndeski / DHOST gravity",
-            "diagnose",
-            "Horndeski / DHOST gravity",
-            index.equations_matching("eq_2_10", "eq_3_34", "eq_3_35", "eq_3_36"),
-            inputs=index.equations_matching("eq_3_34", "eq_3_35", "eq_3_36"),
-            outputs=index.equations_matching("eq_2_10"),
-            constraints=index.equations_matching("eq_2_10"),
-            ops=index.operations_matching("derive_result", "apply_criterion"),
-        )
-
-        nodes = [node for node in nodes if _node_has_evidence(node)]
-        node_ids = {n.component_id for n in nodes}
-        edge_specs = [
-            ("theory_matter_perturbation_kernels", "theory_galaxy_bias_model", "defines"),
-            ("theory_galaxy_bias_model", "theory_smoothed_observables", "defines"),
-            ("theory_smoothed_observables", "theory_skewness_bias_linear_equations", "feeds_equation_system"),
-            ("theory_smoothed_observables", "theory_kurtosis_bias_linear_equations", "feeds_equation_system"),
-            ("theory_skewness_bias_linear_equations", "theory_second_order_bias_elimination", "linearizes"),
-            ("theory_kurtosis_bias_linear_equations", "theory_third_order_bias_elimination", "linearizes"),
-            ("theory_second_order_bias_elimination", "theory_skewness_consistency_relation", "eliminates_bias"),
-            ("theory_third_order_bias_elimination", "theory_first_kurtosis_consistency_relation", "eliminates_bias"),
-            ("theory_third_order_bias_elimination", "theory_second_kurtosis_consistency_relation", "eliminates_bias"),
-            ("theory_skewness_consistency_relation", "theory_horndeski_dhost_diagnostic", "diagnoses"),
-            ("theory_first_kurtosis_consistency_relation", "theory_horndeski_dhost_diagnostic", "diagnoses"),
-            ("theory_second_kurtosis_consistency_relation", "theory_horndeski_dhost_diagnostic", "diagnoses"),
-        ]
-        edges = [
-            ComponentGraphEdge(
-                edge_id=f"theory_edge_{idx:04d}",
-                source=source,
-                target=target,
-                edge_type=edge_type,
-                support_status="derivation_linked",
-                evidence_claims=[],
-                evidence_equation_ids=_edge_equations(nodes, source, target),
-                reasoning=f"GraphNormalizer relation: {source} {edge_type} {target}.",
-                confidence=0.9,
-                review_status="teacher_review_required",
-            )
-            for idx, (source, target, edge_type) in enumerate(edge_specs, start=1)
-            if source in node_ids and target in node_ids
-        ]
+        nodes = [self._node_from_record(rec) for rec in records]
+        edges = self._edges_from_records(records)
         return nodes, edges
+
+    @staticmethod
+    def _collect_step_records(derivations: DerivationChainResult | None) -> list[dict]:
+        records: list[dict] = []
+        counter = 0
+        for chain in getattr(derivations, "chains", []) or []:
+            derivation_id = str(getattr(chain, "derivation_id", "") or "")
+            for step in getattr(chain, "steps", []) or []:
+                counter += 1
+                operation = str(getattr(step, "operation", "") or "")
+                verb, edge_type, is_generic = classify_operation(operation)
+                step_id = str(getattr(step, "step_id", "") or f"step_{counter}")
+                records.append({
+                    "node_id": f"theory_op_{counter:04d}",
+                    "step": step,
+                    "step_id": step_id,
+                    "derivation_id": derivation_id,
+                    "operation": operation,
+                    "verb": verb,
+                    "edge_type": edge_type,
+                    "is_generic": is_generic,
+                    "inputs": _ordered_unique(getattr(step, "input_equation_ids", []) or []),
+                    "outputs": _ordered_unique(getattr(step, "output_equation_ids", []) or []),
+                })
+        return records
+
+    @staticmethod
+    def _node_from_record(rec: dict) -> ComponentGraphNode:
+        step = rec["step"]
+        inputs = rec["inputs"]
+        outputs = rec["outputs"]
+        edge_type = rec["edge_type"]
+
+        linked_equation_ids = _ordered_unique(inputs + outputs)
+        linked_derivation_ids = _ordered_unique([rec["derivation_id"], rec["step_id"]])
+        linked_claim_ids = _ordered_unique(
+            list(getattr(step, "required_claim_ids", []) or [])
+            + list(getattr(step, "input_claim_ids", []) or [])
+            + list(getattr(step, "output_claim_ids", []) or [])
+        )
+        linked_evidence_ids = _ordered_unique(getattr(step, "source_evidence_ids", []) or [])
+
+        status, reasons = _node_backing(
+            linked_equation_ids=linked_equation_ids,
+            linked_derivation_ids=linked_derivation_ids,
+            linked_claim_ids=linked_claim_ids,
+            linked_evidence_ids=linked_evidence_ids,
+            is_generic=rec["is_generic"],
+        )
+
+        definitions = outputs if edge_type == "defines" else []
+        constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
+
+        return ComponentGraphNode(
+            component_id=rec["node_id"],
+            label=_build_label(rec["verb"], step, inputs, outputs),
+            component_type="TheoryOperationNode",
+            review_status="teacher_review_required",
+            display_order=int(rec["node_id"].rsplit("_", 1)[-1]),
+            origin="derivation_chain",
+            operation=rec["operation"],
+            theory_object=str(getattr(step, "reason", "") or "").strip()[:120] or rec["verb"],
+            graph_layer="main",
+            maturity_source="derivation_normalized",
+            publish_ready=False,
+            input_equation_ids=inputs,
+            intermediate_equation_ids=[],
+            output_equation_ids=outputs,
+            definition_equation_ids=_ordered_unique(definitions),
+            constraint_equation_ids=_ordered_unique(constraints),
+            review_required_equation_ids=[],
+            eliminated_symbols=_ordered_unique(getattr(step, "eliminated_symbols", []) or []),
+            retained_symbols=_ordered_unique(getattr(step, "retained_symbols", []) or []),
+            derivation_operations=[rec["operation"]] if rec["operation"] else [],
+            linked_equation_ids=linked_equation_ids,
+            linked_derivation_ids=linked_derivation_ids,
+            linked_claim_ids=linked_claim_ids,
+            linked_evidence_ids=linked_evidence_ids,
+            source_backing_status=status,
+            review_reasons=reasons,
+        )
+
+    @staticmethod
+    def _edges_from_records(records: list[dict]) -> list[ComponentGraphEdge]:
+        edges: list[ComponentGraphEdge] = []
+        seen: set[tuple[str, str, str]] = set()
+        for j, target in enumerate(records):
+            target_inputs = set(target["inputs"])
+            if not target_inputs:
+                continue
+            for source in records[:j]:
+                overlap = [eq for eq in source["outputs"] if eq in target_inputs]
+                if not overlap:
+                    continue
+                edge_type = target["edge_type"]
+                key = (source["node_id"], target["node_id"], edge_type)
+                if key in seen or source["node_id"] == target["node_id"]:
+                    continue
+                seen.add(key)
+                step = target["step"]
+                review_status, review_reasons = _edge_backing(
+                    evidence_equation_ids=overlap,
+                    is_generic=target["is_generic"],
+                )
+                edges.append(ComponentGraphEdge(
+                    edge_id=f"theory_edge_{len(edges) + 1:04d}",
+                    source=source["node_id"],
+                    target=target["node_id"],
+                    edge_type=edge_type,
+                    support_status="derivation_linked",
+                    evidence_claims=[],
+                    reasoning=(
+                        f"Derivation data flow: {source['operation'] or 'step'} output "
+                        f"feeds {target['operation'] or 'step'} ({', '.join(overlap)})."
+                    ),
+                    confidence=0.9,
+                    evidence_equation_ids=_ordered_unique(overlap),
+                    review_status=review_status,
+                    evidence_derivation_ids=_ordered_unique([
+                        source["step_id"], target["step_id"]
+                    ]),
+                    evidence_claim_ids=_ordered_unique(
+                        getattr(step, "required_claim_ids", []) or []
+                    ),
+                    source_evidence_ids=_ordered_unique(
+                        getattr(step, "source_evidence_ids", []) or []
+                    ),
+                    review_reasons=review_reasons,
+                ))
+        return edges
+
+    # ------------------------------------------------------------------ #
+    # Component-graph fallback path
+    # ------------------------------------------------------------------ #
 
     def _normalize_component_node(self, node: ComponentGraphNode, comp) -> ComponentGraphNode:
         label = str(node.label or "").strip()
         if label.lower() in _GENERIC_LABELS:
             label = _label_for_component(comp) or label
+        linked_equation_ids = _ordered_unique(
+            list(node.input_equation_ids)
+            + list(node.intermediate_equation_ids)
+            + list(node.output_equation_ids)
+            + list(node.definition_equation_ids)
+            + list(node.constraint_equation_ids)
+        )
+        linked_claim_ids = _ordered_unique(getattr(comp, "linked_claim_ids", []) or [])
+        linked_evidence_ids = _ordered_unique(getattr(comp, "linked_evidence_ids", []) or [])
+        is_fallback = node.maturity_source == "deterministic_fallback"
+        status, reasons = _node_backing(
+            linked_equation_ids=linked_equation_ids,
+            linked_derivation_ids=node.derivation_operations,
+            linked_claim_ids=linked_claim_ids,
+            linked_evidence_ids=linked_evidence_ids,
+            is_generic=is_fallback,
+        )
         return replace(
             node,
             label=label,
             operation=node.operation or str(getattr(comp, "operation", "") or ""),
-            theory_object=node.theory_object or _theory_object_for_component(comp),
-            graph_layer="debug" if node.maturity_source == "deterministic_fallback" else node.graph_layer,
+            theory_object=node.theory_object or str(getattr(comp, "summary", "") or "")[:120],
+            graph_layer="debug" if is_fallback else node.graph_layer,
+            linked_equation_ids=linked_equation_ids,
+            linked_claim_ids=linked_claim_ids,
+            linked_evidence_ids=linked_evidence_ids,
+            linked_derivation_ids=node.linked_derivation_ids,
+            source_backing_status=status,
+            review_reasons=reasons,
         )
 
     def _normalize_edges(
@@ -280,41 +268,110 @@ class ComponentGraphNormalizer:
             if key in seen:
                 continue
             seen.add(key)
-            result.append(replace(edge, edge_type=edge_type))
+            review_status, review_reasons = _edge_backing(
+                evidence_equation_ids=edge.evidence_equation_ids,
+                is_generic=edge_type.lower() in ("requires_review", "transforms", "related_to"),
+                evidence_claims=edge.evidence_claims,
+            )
+            result.append(replace(
+                edge,
+                edge_type=edge_type,
+                review_status=review_status,
+                review_reasons=review_reasons,
+            ))
         return result
 
     @staticmethod
     def _debug_nodes(nodes: list[ComponentGraphNode]) -> list[ComponentGraphNode]:
         return [
-            replace(node, graph_layer="debug", display_order=1000 + idx)
+            replace(
+                node,
+                graph_layer="debug",
+                display_order=1000 + idx,
+                source_backing_status="inferred",
+                review_reasons=_ordered_unique(
+                    list(node.review_reasons) + ["fallback_or_inferred_node"]
+                ),
+            )
             for idx, node in enumerate(nodes)
             if node.maturity_source == "deterministic_fallback"
         ]
 
 
-class _DerivationIndex:
-    def __init__(self, steps) -> None:
-        self.steps = list(steps or [])
+# ---------------------------------------------------------------------- #
+# Backing computation
+# ---------------------------------------------------------------------- #
 
-    def equations_matching(self, *eq_ids: str) -> list[str]:
-        wanted = set(eq_ids)
-        result: list[str] = []
-        for step in self.steps:
-            for eq_id in list(getattr(step, "input_equation_ids", []) or []) + list(getattr(step, "output_equation_ids", []) or []):
-                if eq_id in wanted:
-                    result.append(eq_id)
-        return _ordered_unique(result)
+def _node_backing(
+    *,
+    linked_equation_ids: list[str],
+    linked_derivation_ids: list[str],
+    linked_claim_ids: list[str],
+    linked_evidence_ids: list[str],
+    is_generic: bool,
+) -> tuple[str, list[str]]:
+    reasons: list[str] = []
+    if not linked_equation_ids:
+        reasons.append("missing_equation_link")
+    if not linked_claim_ids:
+        reasons.append("missing_atomic_claim")
+    if not linked_evidence_ids:
+        reasons.append("missing_evidence_link")
+    if not linked_derivation_ids:
+        reasons.append("missing_derivation_link")
+    if is_generic:
+        reasons.append("fallback_or_inferred_node")
 
-    def operations_matching(self, *operations: str) -> list[str]:
-        wanted = set(operations)
-        return _ordered_unique(
-            str(getattr(step, "operation", "") or "")
-            for step in self.steps
-            if str(getattr(step, "operation", "") or "") in wanted
-        )
+    has_equation = bool(linked_equation_ids)
+    has_strong = bool(linked_claim_ids or linked_evidence_ids)
+
+    if is_generic:
+        status = "inferred"
+    elif has_equation and has_strong:
+        status = "source_backed"
+    elif has_equation or linked_derivation_ids:
+        status = "partially_source_backed"
+    else:
+        status = "review_required"
+
+    if status == "source_backed":
+        # Confirmed structure: do not surface informational gaps as reasons.
+        reasons = []
+    return status, reasons
 
 
-def _join_nodes_to_components(nodes: list[ComponentGraphNode], components: ComponentAssemblyResult) -> list[tuple[ComponentGraphNode, object]]:
+def _edge_backing(
+    *,
+    evidence_equation_ids: list[str],
+    is_generic: bool,
+    evidence_claims: list[str] | None = None,
+) -> tuple[str, list[str]]:
+    has_evidence = bool(evidence_equation_ids) or bool(evidence_claims)
+    if is_generic:
+        return "review_required", ["edge_not_source_backed", "fallback_or_inferred_node"]
+    if has_evidence:
+        return "source_backed", []
+    return "review_required", ["edge_not_source_backed"]
+
+
+# ---------------------------------------------------------------------- #
+# Label / component helpers
+# ---------------------------------------------------------------------- #
+
+def _build_label(verb: str, step, inputs: list[str], outputs: list[str]) -> str:
+    obj = (outputs[:1] or inputs[:1] or [""])[0]
+    if obj:
+        return f"{verb} {obj}".strip()
+    reason = str(getattr(step, "reason", "") or "").strip()
+    if reason and reason.lower() not in _GENERIC_LABELS:
+        return reason[:80]
+    return verb
+
+
+def _join_nodes_to_components(
+    nodes: list[ComponentGraphNode],
+    components: ComponentAssemblyResult,
+) -> list[tuple[ComponentGraphNode, object]]:
     comp_by_id = {c.component_id: c for c in components.components}
     return [(node, comp_by_id.get(node.component_id)) for node in nodes]
 
@@ -322,93 +379,29 @@ def _join_nodes_to_components(nodes: list[ComponentGraphNode], components: Compo
 def _label_for_component(comp) -> str:
     if comp is None:
         return ""
-    op = str(getattr(comp, "operation", "") or "").lower()
-    theory_object = _theory_object_for_component(comp)
-    if op and theory_object:
-        return f"{_verb_for_operation(op)} {theory_object}"
-    if theory_object:
-        return theory_object[:1].upper() + theory_object[1:]
+    op = str(getattr(comp, "operation", "") or "")
+    if op:
+        verb, _edge_type, _generic = classify_operation(op)
+        outputs = list(getattr(comp, "output_equation_ids", []) or [])
+        if outputs:
+            return f"{verb} {outputs[0]}".strip()
+        return verb
+    summary = str(getattr(comp, "summary", "") or "").strip()
+    if summary:
+        return summary[:80]
     return ""
 
 
-def _theory_object_for_component(comp) -> str:
-    text = " ".join([
-        str(getattr(comp, "label", "") or ""),
-        str(getattr(comp, "summary", "") or ""),
-        str(getattr(comp, "reason", "") or ""),
-        " ".join(getattr(comp, "linked_equation_ids", []) or []),
-        " ".join(getattr(comp, "output_equation_ids", []) or []),
-    ]).lower()
-    if "horndeski" in text or "dhost" in text or "eq_2_10" in text:
-        return "Horndeski / DHOST gravity"
-    if "eq_3_34" in text or "skewness" in text:
-        return "skewness consistency relation"
-    if "eq_3_35" in text or "eq_3_36" in text or "kurtosis" in text:
-        return "kurtosis consistency relation"
-    if "bias" in text or "eq_2_12" in text or "eq_2_13" in text:
-        return "galaxy bias model"
-    if "observable" in text or "eq_2_17" in text or "eq_2_18" in text:
-        return "smoothed skewness/kurtosis observables"
-    if "kernel" in text or "eq_2_5" in text:
-        return "matter perturbation kernels"
-    return ""
-
-
-def _verb_for_operation(operation: str) -> str:
-    if operation in ("define", "observable_definition"):
-        return "Define"
-    if operation == "linearize":
-        return "Build"
-    if operation == "eliminate":
-        return "Eliminate"
-    if operation == "derive":
-        return "Derive"
-    if operation == "diagnose":
-        return "Diagnose"
-    if operation == "constrain":
-        return "Constrain"
-    return operation.replace("_", " ").capitalize()
-
-
-def _semantic_edge_type(edge: ComponentGraphEdge, source: ComponentGraphNode, target: ComponentGraphNode) -> str:
-    src_op = str(source.operation or "").lower()
-    tgt_op = str(target.operation or "").lower()
-    target_label = str(target.label or "").lower()
-    if tgt_op == "diagnose" or "diagnos" in target_label or "horndeski" in target_label or "dhost" in target_label:
-        return "diagnoses"
-    if tgt_op == "derive" or "consistency relation" in target_label:
-        return "derives"
-    if tgt_op == "eliminate" or "bias elimination" in target_label:
-        return "eliminates_bias"
-    if tgt_op == "linearize" or "equation system" in target_label:
-        return "feeds_equation_system"
-    if src_op == "define":
-        return "defines"
+def _semantic_edge_type(
+    edge: ComponentGraphEdge,
+    source: ComponentGraphNode,
+    target: ComponentGraphNode,
+) -> str:
+    tgt_op = str(target.operation or "")
+    if tgt_op:
+        _verb, edge_type, _generic = classify_operation(tgt_op)
+        return edge_type
     return edge.edge_type
-
-
-def _node_has_evidence(node: ComponentGraphNode) -> bool:
-    return any([
-        node.input_equation_ids,
-        node.output_equation_ids,
-        node.definition_equation_ids,
-        node.constraint_equation_ids,
-        node.derivation_operations,
-    ])
-
-
-def _edge_equations(nodes: list[ComponentGraphNode], source: str, target: str) -> list[str]:
-    by_id = {node.component_id: node for node in nodes}
-    values: list[str] = []
-    for node_id in (source, target):
-        node = by_id.get(node_id)
-        if not node:
-            continue
-        values.extend(node.input_equation_ids)
-        values.extend(node.output_equation_ids)
-        values.extend(node.constraint_equation_ids)
-        values.extend(node.definition_equation_ids)
-    return _ordered_unique(values)
 
 
 def _ordered_unique(values) -> list[str]:

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -26,15 +26,121 @@ VALID_EDGE_TYPES = [
     "INHIBITS",
     "DERIVES_FROM",
     # Theory-structure graph relations used by GraphNormalizer.
+    # Domain-neutral operation-derived edge types (issue #302).
     "defines",
-    "feeds_equation_system",
+    "constructs",
     "linearizes",
-    "eliminates_bias",
+    "solves",
+    "substitutes",
+    "eliminates",
     "derives",
     "constrains",
     "diagnoses",
+    "compares",
+    "normalizes",
+    "approximates",
+    "transforms",
+    "feeds",
     "requires_review",
+    # Retained for backward compatibility with previously stored graphs.
+    "feeds_equation_system",
+    "eliminates_bias",
 ]
+
+# Source-backing classification for theory-operation nodes (issue #302).
+SOURCE_BACKING_STATUSES = [
+    "source_backed",
+    "partially_source_backed",
+    "inferred",
+    "review_required",
+]
+
+# Structured review-reason vocabulary (issue #302). review_required nodes/edges
+# must always carry at least one of these so the UI can explain *why*.
+REVIEW_REASONS = [
+    "missing_atomic_claim",
+    "missing_evidence_link",
+    "missing_equation_link",
+    "missing_derivation_link",
+    "equation_needs_math_review",
+    "edge_not_source_backed",
+    "fallback_or_inferred_node",
+    "source_span_missing",
+]
+
+# Edge types that are too generic to publish as confirmed theory structure.
+GENERIC_EDGE_TYPES = {"related_to", "correlates", "supports", "transforms", "relate"}
+
+# Operations that do not name a concrete theory operation. When a derivation
+# step carries one of these, the resulting node/edge is treated as inferred and
+# flagged for review instead of being published as confirmed structure.
+GENERIC_OPERATIONS = {"transform", "relate", "connect", "support", "associate", ""}
+
+# Full operation name → (verb, edge_type) for ontology operations that do not
+# follow the simple ``<prefix>_<object>`` shape.
+_OPERATION_FULL_MAP = {
+    "apply_definition": ("Apply definition", "defines"),
+    "apply_criterion": ("Apply criterion", "diagnoses"),
+    "apply_constraint": ("Apply constraint", "constrains"),
+    "apply_equation": ("Apply equation", "transforms"),
+    "apply_measurement_or_update": ("Apply measurement", "transforms"),
+    "apply_non_disturbance_or_independence": ("Apply independence", "constrains"),
+    "introduce_observable": ("Introduce observable", "defines"),
+    "solve_linear_system": ("Solve linear system", "solves"),
+    "eliminate_parameter": ("Eliminate parameter", "eliminates"),
+    "derive_result": ("Derive result", "derives"),
+    "infer_conclusion": ("Infer conclusion", "derives"),
+    "infer_intermediate_claim": ("Infer intermediate claim", "derives"),
+    "state_assumption": ("State assumption", "defines"),
+    "branch_on_condition": ("Branch on condition", "constrains"),
+    "flag_limitation": ("Flag limitation", "constrains"),
+}
+
+# First token of an operation → (verb, edge_type). Domain-neutral; the object
+# part of the operation name is appended to keep the label specific.
+_OPERATION_PREFIX_MAP = {
+    "define": ("Define", "defines"),
+    "construct": ("Construct", "constructs"),
+    "linearize": ("Linearize", "linearizes"),
+    "solve": ("Solve", "solves"),
+    "substitute": ("Substitute", "substitutes"),
+    "eliminate": ("Eliminate", "eliminates"),
+    "derive": ("Derive", "derives"),
+    "constrain": ("Constrain", "constrains"),
+    "diagnose": ("Diagnose", "diagnoses"),
+    "compare": ("Compare", "compares"),
+    "normalize": ("Normalize", "normalizes"),
+    "approximate": ("Approximate", "approximates"),
+    "introduce": ("Introduce", "defines"),
+    "state": ("State", "defines"),
+    "infer": ("Infer", "derives"),
+    "flag": ("Flag", "constrains"),
+}
+
+
+def classify_operation(operation: str) -> tuple[str, str, bool]:
+    """Map a derivation operation to a (verb, edge_type, is_generic) triple.
+
+    Domain-neutral: no paper- or field-specific terms. ``is_generic`` is True
+    when the operation does not name a concrete theory operation, in which case
+    the resulting node/edge should be flagged for review rather than published.
+    """
+    op = str(operation or "").strip().lower()
+    if op in GENERIC_OPERATIONS:
+        verb = op.replace("_", " ").capitalize() if op else "Operation"
+        return verb, "requires_review", True
+    if op in _OPERATION_FULL_MAP:
+        verb, edge_type = _OPERATION_FULL_MAP[op]
+        return verb, edge_type, False
+    prefix = op.split("_", 1)[0]
+    if prefix in _OPERATION_PREFIX_MAP:
+        verb, edge_type = _OPERATION_PREFIX_MAP[prefix]
+        rest = op.split("_")[1:]
+        label = (verb + " " + " ".join(rest)).strip() if rest else verb
+        return label, edge_type, False
+    # Unknown operation: keep it but treat as a generic transform pending review.
+    return op.replace("_", " ").capitalize(), "transforms", True
+
 
 SUPPORT_STATUSES = [
     "llm_inferred",
@@ -77,6 +183,14 @@ class ComponentGraphNode:
     eliminated_symbols: list[str] = field(default_factory=list)
     retained_symbols: list[str] = field(default_factory=list)
     derivation_operations: list[str] = field(default_factory=list)
+    # Source-backing links and status (issue #302).
+    linked_equation_ids: list[str] = field(default_factory=list)
+    linked_derivation_ids: list[str] = field(default_factory=list)
+    linked_claim_ids: list[str] = field(default_factory=list)
+    linked_evidence_ids: list[str] = field(default_factory=list)
+    # Set explicitly by the normalizer; "" means not yet classified.
+    source_backing_status: str = ""
+    review_reasons: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -90,7 +204,14 @@ class ComponentGraphEdge:
     reasoning: str
     confidence: float = 0.75
     evidence_equation_ids: list[str] = field(default_factory=list)
-    review_status: str = "teacher_review_required"
+    # review_status here records evidence backing (issue #302):
+    # "source_backed" | "review_required". "" means not yet classified.
+    review_status: str = ""
+    # Source-backing links (issue #302).
+    evidence_derivation_ids: list[str] = field(default_factory=list)
+    evidence_claim_ids: list[str] = field(default_factory=list)
+    source_evidence_ids: list[str] = field(default_factory=list)
+    review_reasons: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -164,6 +285,12 @@ class ComponentGraphResult:
                     "eliminated_symbols": n.eliminated_symbols,
                     "retained_symbols": n.retained_symbols,
                     "derivation_operations": n.derivation_operations,
+                    "linked_equation_ids": n.linked_equation_ids,
+                    "linked_derivation_ids": n.linked_derivation_ids,
+                    "linked_claim_ids": n.linked_claim_ids,
+                    "linked_evidence_ids": n.linked_evidence_ids,
+                    "source_backing_status": n.source_backing_status,
+                    "review_reasons": n.review_reasons,
                 }
                 for n in self.nodes
             ],
@@ -176,10 +303,14 @@ class ComponentGraphResult:
                     "edge_type": e.edge_type,
                     "support_status": e.support_status,
                     "confidence": e.confidence,
-                    "review_status": "teacher_review_required",
+                    "review_status": e.review_status,
+                    "review_reasons": e.review_reasons,
                     "evidence": {
                         "evidence_claims": e.evidence_claims,
                         "evidence_equation_ids": e.evidence_equation_ids,
+                        "evidence_derivation_ids": e.evidence_derivation_ids,
+                        "evidence_claim_ids": e.evidence_claim_ids,
+                        "source_evidence_ids": e.source_evidence_ids,
                         "reason": e.reasoning,
                     },
                 }

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -2,17 +2,23 @@
 from __future__ import annotations
 
 from .schema import (
+    GENERIC_EDGE_TYPES,
+    GENERIC_OPERATIONS,
     VALID_EDGE_TYPES,
     CartridgeContext,
     ComponentGraphEdge,
     ComponentGraphLLMInput,
+    ComponentGraphNode,
     ComponentGraphResult,
     ValidationIssue,
+    classify_operation,
 )
 
 _GENERIC_LABELS = {"define", "transform", "relate", "result"}
-_GENERIC_EDGE_TYPES = {"RELATED_TO", "CORRELATES", "supports"}
+_GENERIC_EDGE_TYPES = {"RELATED_TO", "CORRELATES", "supports", "related_to", "correlates"}
 _BIAS_ELIMINATION_NEEDLES = ("bias elimination", "eliminate second", "eliminate third", "second-order bias", "third-order bias")
+# Operation edge types whose nodes must expose their output/constraint equations.
+_OUTPUT_BEARING_EDGE_TYPES = {"constrains", "derives", "diagnoses"}
 
 
 class ComponentGraphValidator:
@@ -36,10 +42,11 @@ class ComponentGraphValidator:
                     f"node {node.component_id!r} has empty label",
                     f"nodes[{node.component_id}].label",
                 ))
+            is_main = str(getattr(node, "graph_layer", "main") or "main") == "main"
             if not node.component_type:
                 issues.append(ValidationIssue(
                     "component_graph_node_missing_component_type",
-                    "warning",
+                    "error" if is_main else "warning",
                     f"node {node.component_id!r} has empty component_type",
                     f"nodes[{node.component_id}].component_type",
                 ))
@@ -91,16 +98,7 @@ class ComponentGraphValidator:
                     f"bias elimination node {node.component_id!r} has no eliminated_symbols",
                     f"nodes[{node.component_id}].eliminated_symbols",
                 ))
-            if (
-                str(getattr(node, "review_status", "") or "") == "teacher_review_required"
-                and str(getattr(node, "graph_layer", "main") or "main") == "main"
-            ):
-                issues.append(ValidationIssue(
-                    "review_required_component_in_main_graph",
-                    "warning",
-                    f"review-required component {node.component_id!r} appears in main graph",
-                    f"nodes[{node.component_id}]",
-                ))
+            issues += self._check_node_source_backing(node, is_main)
 
         valid_types = set(VALID_EDGE_TYPES)
         if cartridge:
@@ -122,6 +120,93 @@ class ComponentGraphValidator:
                 "error",
                 "result confidence out of [0, 1]",
                 "confidence",
+            ))
+
+        return issues
+
+    @staticmethod
+    def _check_node_source_backing(node: ComponentGraphNode, is_main: bool) -> list[ValidationIssue]:
+        issues: list[ValidationIssue] = []
+        cid = node.component_id
+        backing = str(getattr(node, "source_backing_status", "") or "")
+        reasons = list(getattr(node, "review_reasons", []) or [])
+        maturity = str(getattr(node, "maturity_source", "") or "")
+        operation = str(getattr(node, "operation", "") or "")
+        _verb, edge_type, is_generic_op = classify_operation(operation) if operation else ("", "", False)
+
+        linked = _collect_source_links(node)
+        is_theory_op = str(getattr(node, "component_type", "") or "") == "TheoryOperationNode"
+
+        # Hard error: every theory-operation node must carry a source link
+        # (acceptance criterion #1).
+        if is_main and is_theory_op and not linked:
+            issues.append(ValidationIssue(
+                "theory_node_missing_source_link",
+                "error",
+                f"node {cid!r} has no equation/derivation/claim/evidence link",
+                f"nodes[{cid}]",
+            ))
+
+        # Hard error: review_required node must explain why.
+        if backing == "review_required" and not reasons:
+            issues.append(ValidationIssue(
+                "review_required_node_missing_reasons",
+                "error",
+                f"node {cid!r} is review_required but has empty review_reasons",
+                f"nodes[{cid}].review_reasons",
+            ))
+
+        # Hard error: fallback/inferred nodes must not be marked source_backed.
+        if backing == "source_backed" and maturity == "deterministic_fallback":
+            issues.append(ValidationIssue(
+                "fallback_node_marked_source_backed",
+                "error",
+                f"fallback node {cid!r} is marked source_backed",
+                f"nodes[{cid}].source_backing_status",
+            ))
+
+        # Hard error: result/constraint/derive nodes must expose equation links.
+        if operation and edge_type in _OUTPUT_BEARING_EDGE_TYPES and is_main:
+            if not getattr(node, "linked_equation_ids", []):
+                issues.append(ValidationIssue(
+                    "output_node_missing_linked_equations",
+                    "error",
+                    f"{edge_type} node {cid!r} has no linked_equation_ids",
+                    f"nodes[{cid}].linked_equation_ids",
+                ))
+            if edge_type == "derives" and not getattr(node, "linked_derivation_ids", []):
+                issues.append(ValidationIssue(
+                    "derive_node_missing_derivation_link",
+                    "error",
+                    f"derive node {cid!r} has no linked_derivation_ids",
+                    f"nodes[{cid}].linked_derivation_ids",
+                ))
+
+        # Warning: review_required node visible in the main graph.
+        if is_main and backing == "review_required":
+            issues.append(ValidationIssue(
+                "review_required_node_in_main_graph",
+                "warning",
+                f"review_required node {cid!r} appears in main graph ({', '.join(reasons)})",
+                f"nodes[{cid}]",
+            ))
+
+        # Warning: node has no claim backing.
+        if not getattr(node, "linked_claim_ids", []):
+            issues.append(ValidationIssue(
+                "theory_node_missing_claim_link",
+                "warning",
+                f"node {cid!r} has no linked_claim_ids (prefer atomic claims)",
+                f"nodes[{cid}].linked_claim_ids",
+            ))
+
+        # Warning: generic operation cannot be published as a concrete operation.
+        if operation and (operation.strip().lower() in GENERIC_OPERATIONS or is_generic_op):
+            issues.append(ValidationIssue(
+                "theory_node_generic_operation",
+                "warning",
+                f"node {cid!r} operation {operation!r} is too generic for the main graph",
+                f"nodes[{cid}].operation",
             ))
 
         return issues
@@ -228,12 +313,27 @@ class ComponentGraphValidator:
                 f"{eid}: evidence_equation_ids must be a list",
                 f"edges[{eid}].evidence_equation_ids",
             ))
-        elif len(edge.evidence_claims or []) == 0 and len(edge.evidence_equation_ids or []) == 0:
+        elif (
+            len(edge.evidence_claims or []) == 0
+            and len(edge.evidence_equation_ids or []) == 0
+            and len(getattr(edge, "evidence_derivation_ids", []) or []) == 0
+        ):
             issues.append(ValidationIssue(
                 "component_graph_edge_no_evidence",
                 "warning",
-                f"{eid}: edge has no claim or equation evidence",
-                f"edges[{eid}].evidence_claims",
+                f"{eid}: edge has no equation or derivation evidence",
+                f"edges[{eid}].evidence_equation_ids",
+            ))
+
+        if (
+            str(getattr(edge, "review_status", "") or "") == "review_required"
+            and not list(getattr(edge, "review_reasons", []) or [])
+        ):
+            issues.append(ValidationIssue(
+                "review_required_edge_missing_reasons",
+                "warning",
+                f"{eid}: review_required edge has empty review_reasons",
+                f"edges[{eid}].review_reasons",
             ))
 
         if edge.confidence < 0.0 or edge.confidence > 1.0:
@@ -245,6 +345,18 @@ class ComponentGraphValidator:
             ))
 
         return issues
+
+
+def _collect_source_links(node: ComponentGraphNode) -> list[str]:
+    links: list[str] = []
+    for field_name in (
+        "linked_equation_ids",
+        "linked_derivation_ids",
+        "linked_claim_ids",
+        "linked_evidence_ids",
+    ):
+        links.extend(getattr(node, field_name, []) or [])
+    return links
 
 
 def _has_equation_roles(node: ComponentGraphNode) -> bool:

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -8,29 +8,34 @@ from episteme_graph.agents.derivation_chain.schema import (
 )
 
 
-def _step(operation, inputs, outputs):
+def _step(operation, inputs, outputs, **kwargs):
     return DerivationStep(
         step_id=f"step_{operation}",
         input_equation_ids=inputs,
         operation=operation,
         output_equation_ids=outputs,
         review_status="teacher_review_required",
+        **kwargs,
     )
 
 
 def _derivations():
+    # Domain-neutral chain: a definition feeds a linearization, which feeds an
+    # elimination, a derivation, then a diagnostic, ending in a generic step.
     steps = [
-        _step("define", ["eq_2_5"], ["eq_2_7"]),
-        _step("define", ["eq_2_12"], ["eq_2_14"]),
-        _step("define", ["eq_2_16"], ["eq_2_17"]),
-        _step("linearize_skewness_bias_dependence", ["eq_3_32"], ["eq_3_34"]),
-        _step("linearize_kurtosis_bias_dependence", ["eq_3_33"], ["eq_3_35"]),
-        _step("solve_second_order_bias", ["eq_3_35"], ["eq_3_36"]),
-        _step("solve_third_order_bias", ["eq_3_35"], ["eq_3_36"]),
-        _step("derive_skewness_consistency_relation", ["eq_3_32"], ["eq_3_34"]),
-        _step("derive_first_kurtosis_consistency_relation", ["eq_3_33"], ["eq_3_35"]),
-        _step("derive_second_kurtosis_consistency_relation", ["eq_3_35"], ["eq_3_36"]),
-        _step("apply_criterion", ["eq_3_34", "eq_3_35", "eq_3_36"], ["eq_2_10"]),
+        _step("define", ["eq_a"], ["eq_b"]),
+        _step("linearize_moment_equations", ["eq_b"], ["eq_c"]),
+        _step(
+            "eliminate_second_order_parameter",
+            ["eq_c"],
+            ["eq_d"],
+            required_claim_ids=["claim_1"],
+            source_evidence_ids=["ev_1"],
+            eliminated_symbols=["b2"],
+        ),
+        _step("derive_consistency_relation", ["eq_d"], ["eq_e"]),
+        _step("apply_criterion", ["eq_e"], ["eq_f"]),
+        _step("transform", ["eq_f"], ["eq_g"]),
     ]
     return DerivationChainResult(
         document_id="doc",
@@ -70,30 +75,84 @@ def _empty_graph():
     )
 
 
-def test_normalizer_builds_theory_structure_graph_from_derivations():
-    result = ComponentGraphNormalizer().normalize(_empty_graph(), _empty_components(), _derivations())
+def _normalized():
+    return ComponentGraphNormalizer().normalize(_empty_graph(), _empty_components(), _derivations())
 
-    labels = {node.label for node in result.nodes if node.graph_layer == "main"}
-    assert "Eliminate second-order bias" in labels
-    assert "Eliminate third-order bias" in labels
-    assert "Derive skewness consistency relation" in labels
-    assert "Derive first kurtosis consistency relation" in labels
-    assert "Derive second kurtosis consistency relation" in labels
-    assert "Diagnose Horndeski / DHOST gravity" in labels
+
+def test_normalizer_builds_domain_independent_theory_graph():
+    result = _normalized()
+    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
+
+    # One theory-operation node per derivation step, all typed and source-linked.
+    assert len(main_nodes) == 6
+    assert all(n.component_type == "TheoryOperationNode" for n in main_nodes)
+    assert all(n.operation for n in main_nodes)
+
+    # No bare generic labels in the main graph (acceptance #9).
+    labels = {n.label for n in main_nodes}
     assert "Define" not in labels
     assert "Transform" not in labels
+    assert "Relate" not in labels
+    assert "Result" not in labels
 
+    # Labels are derived deterministically from operation + equations.
+    assert "Define eq_b" in labels
+    assert any(l.startswith("Eliminate second order parameter") for l in labels)
+
+
+def test_normalizer_maps_operations_to_edge_types():
+    result = _normalized()
     edge_types = {edge.edge_type for edge in result.edges}
-    assert {"defines", "feeds_equation_system", "linearizes", "eliminates_bias", "diagnoses"} <= edge_types
+    # define -> defines isn't produced as an edge unless its output is consumed;
+    # the consuming operations drive the edge type (acceptance #5).
+    assert "solves" not in edge_types  # no solve_* step in this chain
+    assert {"linearizes", "eliminates", "derives", "diagnoses"} <= edge_types
 
-    diagnostic_sources = {
-        edge.source for edge in result.edges
-        if edge.target == "theory_horndeski_dhost_diagnostic"
-    }
-    assert "theory_skewness_consistency_relation" in diagnostic_sources
-    assert "theory_first_kurtosis_consistency_relation" in diagnostic_sources
-    assert "theory_second_kurtosis_consistency_relation" in diagnostic_sources
+    # Every backed edge carries derivation + equation evidence (acceptance #2).
+    backed = [e for e in result.edges if e.review_status == "source_backed"]
+    assert backed
+    for edge in backed:
+        assert edge.evidence_equation_ids
+        assert edge.evidence_derivation_ids
 
-    second_order = next(node for node in result.nodes if node.component_id == "theory_second_order_bias_elimination")
-    assert second_order.eliminated_symbols
-    assert second_order.output_equation_ids
+
+def test_normalizer_flags_generic_operations_for_review():
+    result = _normalized()
+    generic = next(n for n in result.nodes if n.operation == "transform")
+    assert generic.source_backing_status == "inferred"
+    assert "fallback_or_inferred_node" in generic.review_reasons
+
+    # The edge into the generic node is review_required with explicit reasons.
+    generic_edges = [e for e in result.edges if e.target == generic.component_id]
+    assert generic_edges
+    assert all(e.review_status == "review_required" for e in generic_edges)
+    assert all(e.review_reasons for e in generic_edges)
+
+
+def test_normalizer_promotes_fully_backed_nodes():
+    result = _normalized()
+    # The eliminate step carries a claim + evidence link → source_backed.
+    backed = next(n for n in result.nodes if n.operation == "eliminate_second_order_parameter")
+    assert backed.source_backing_status == "source_backed"
+    assert backed.review_reasons == []
+    assert backed.linked_claim_ids == ["claim_1"]
+    assert backed.linked_evidence_ids == ["ev_1"]
+    assert backed.linked_equation_ids
+    assert backed.linked_derivation_ids
+    assert backed.eliminated_symbols == ["b2"]
+
+
+def test_normalizer_review_required_nodes_have_reasons():
+    result = _normalized()
+    for node in result.nodes:
+        if node.source_backing_status == "review_required":
+            assert node.review_reasons, f"{node.component_id} missing review_reasons"
+
+
+def test_normalizer_diagnostic_backed_by_upstream_results():
+    result = _normalized()
+    diagnostic = next(n for n in result.nodes if n.operation == "apply_criterion")
+    incoming = {e.source for e in result.edges if e.target == diagnostic.component_id}
+    # The diagnostic node is fed by the upstream derivation node (acceptance #7).
+    derive_node = next(n for n in result.nodes if n.operation == "derive_consistency_relation")
+    assert derive_node.component_id in incoming

--- a/src/tests/agents/component_graph/test_schema.py
+++ b/src/tests/agents/component_graph/test_schema.py
@@ -162,3 +162,80 @@ class TestComponentGraphResult:
         )
         assert edge["support_status"] == "llm_inferred"
         assert edge["relation"] == "TRANSFORMS"
+
+
+class TestClassifyOperation:
+    """Domain-independent operation → (verb, edge_type, is_generic) mapping (#302)."""
+
+    @pytest.mark.parametrize("operation,edge_type", [
+        ("define_kernel", "defines"),
+        ("construct_system", "constructs"),
+        ("linearize_moment_equations", "linearizes"),
+        ("solve_second_order_bias", "solves"),
+        ("substitute_parameter", "substitutes"),
+        ("eliminate_bias", "eliminates"),
+        ("derive_consistency_relation", "derives"),
+        ("constrain_gravity", "constrains"),
+        ("diagnose_modified_gravity", "diagnoses"),
+        ("compare_models", "compares"),
+        ("apply_criterion", "diagnoses"),
+        ("introduce_observable", "defines"),
+    ])
+    def test_concrete_operations_map_to_edge_types(self, operation, edge_type):
+        from episteme_graph.agents.component_graph.schema import classify_operation
+        verb, mapped, is_generic = classify_operation(operation)
+        assert mapped == edge_type
+        assert is_generic is False
+        assert verb and verb.lower() not in {"define", "transform", "relate", "result"}
+
+    @pytest.mark.parametrize("operation", ["transform", "relate", "connect", "support", "associate", ""])
+    def test_generic_operations_flagged(self, operation):
+        from episteme_graph.agents.component_graph.schema import classify_operation
+        _verb, edge_type, is_generic = classify_operation(operation)
+        assert is_generic is True
+        assert edge_type == "requires_review"
+
+
+class TestSourceBackingSerialization:
+    """New source-backing fields round-trip through (de)serialization (#302)."""
+
+    def test_node_source_links_in_payload(self):
+        node = _make_node("comp_001")
+        node.linked_equation_ids = ["eq_1"]
+        node.linked_derivation_ids = ["step_1"]
+        node.linked_claim_ids = ["claim_1"]
+        node.linked_evidence_ids = ["ev_1"]
+        node.source_backing_status = "source_backed"
+        node.component_type = "TheoryOperationNode"
+        payload = _make_result(nodes=[node]).to_graph_payload()
+        n = payload["nodes"][0]
+        assert n["linked_equation_ids"] == ["eq_1"]
+        assert n["linked_derivation_ids"] == ["step_1"]
+        assert n["linked_claim_ids"] == ["claim_1"]
+        assert n["linked_evidence_ids"] == ["ev_1"]
+        assert n["source_backing_status"] == "source_backed"
+
+    def test_edge_evidence_links_in_payload(self):
+        edge = ComponentGraphEdge(
+            edge_id="e1", source="comp_001", target="comp_002", edge_type="derives",
+            support_status="derivation_linked", evidence_claims=[], reasoning="",
+            confidence=0.9, evidence_equation_ids=["eq_1"], review_status="source_backed",
+            evidence_derivation_ids=["step_1"], evidence_claim_ids=["claim_1"],
+            source_evidence_ids=["ev_1"], review_reasons=[],
+        )
+        payload = _make_result(edges=[edge]).to_graph_payload()
+        e = payload["edges"][0]
+        assert e["review_status"] == "source_backed"
+        assert e["evidence"]["evidence_derivation_ids"] == ["step_1"]
+        assert e["evidence"]["evidence_claim_ids"] == ["claim_1"]
+        assert e["evidence"]["source_evidence_ids"] == ["ev_1"]
+
+    def test_from_dict_restores_source_backing(self):
+        node = _make_node("comp_001")
+        node.source_backing_status = "partially_source_backed"
+        node.review_reasons = ["missing_evidence_link"]
+        node.linked_equation_ids = ["eq_1"]
+        restored = ComponentGraphResult.from_dict(_make_result(nodes=[node]).to_dict())
+        assert restored.nodes[0].source_backing_status == "partially_source_backed"
+        assert restored.nodes[0].review_reasons == ["missing_evidence_link"]
+        assert restored.nodes[0].linked_equation_ids == ["eq_1"]

--- a/src/tests/agents/component_graph/test_validator.py
+++ b/src/tests/agents/component_graph/test_validator.py
@@ -199,3 +199,79 @@ class TestComponentGraphValidator:
         nodes = [_node("c1"), _node("c2")]
         issues = self.validator.validate(_result(nodes, [_edge("c1", "c2", edge_type="RELATED_TO")]))
         assert any(i.rule_id == "component_graph_related_to_edge" for i in issues)
+
+
+def _theory_node(cid, **kw):
+    defaults = dict(
+        component_id=cid,
+        label=f"Define {cid}",
+        component_type="TheoryOperationNode",
+        operation="define",
+        graph_layer="main",
+        linked_equation_ids=["eq_1"],
+        linked_derivation_ids=["step_1"],
+        linked_claim_ids=["claim_1"],
+        linked_evidence_ids=["ev_1"],
+        source_backing_status="source_backed",
+    )
+    defaults.update(kw)
+    return ComponentGraphNode(**defaults)
+
+
+class TestSourceBackingRules:
+    def setup_method(self):
+        self.validator = ComponentGraphValidator()
+
+    def test_theory_node_without_source_link_is_error(self):
+        node = _theory_node(
+            "c1",
+            linked_equation_ids=[],
+            linked_derivation_ids=[],
+            linked_claim_ids=[],
+            linked_evidence_ids=[],
+            source_backing_status="review_required",
+            review_reasons=["missing_equation_link"],
+        )
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "theory_node_missing_source_link" for i in issues)
+
+    def test_review_required_node_without_reasons_is_error(self):
+        node = _theory_node("c1", source_backing_status="review_required", review_reasons=[])
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "review_required_node_missing_reasons" for i in issues)
+
+    def test_fallback_node_marked_source_backed_is_error(self):
+        node = _theory_node("c1", maturity_source="deterministic_fallback", source_backing_status="source_backed")
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "fallback_node_marked_source_backed" for i in issues)
+
+    def test_derive_node_without_derivation_link_is_error(self):
+        node = _theory_node("c1", operation="derive_relation", linked_derivation_ids=[])
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "derive_node_missing_derivation_link" for i in issues)
+
+    def test_generic_operation_warns(self):
+        node = _theory_node("c1", operation="transform", label="Transform eq_1")
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "theory_node_generic_operation" for i in issues)
+
+    def test_edge_without_evidence_warns(self):
+        nodes = [_theory_node("c1"), _theory_node("c2")]
+        edge = ComponentGraphEdge(
+            edge_id="e1", source="c1", target="c2", edge_type="defines",
+            support_status="derivation_linked", evidence_claims=[], reasoning="",
+            confidence=0.8, evidence_equation_ids=[], evidence_derivation_ids=[],
+        )
+        issues = self.validator.validate(_result(nodes, [edge]))
+        assert any(i.rule_id == "component_graph_edge_no_evidence" for i in issues)
+
+    def test_fully_backed_theory_node_has_no_errors(self):
+        nodes = [_theory_node("c1"), _theory_node("c2")]
+        edge = ComponentGraphEdge(
+            edge_id="e1", source="c1", target="c2", edge_type="defines",
+            support_status="derivation_linked", evidence_claims=[],
+            reasoning="flow", confidence=0.9, evidence_equation_ids=["eq_1"],
+            evidence_derivation_ids=["step_1"], review_status="source_backed",
+        )
+        issues = self.validator.validate(_result(nodes, [edge]))
+        assert [i for i in issues if i.severity == "error"] == []


### PR DESCRIPTION
## Summary

Refactor `ComponentGraphNormalizer` to build a **source-backed theory-operation graph** deterministically from `DerivationChain`, eliminating hard-coded paper-specific terms. Introduce domain-neutral operation classification, explicit source-backing status tracking, and structured review-reason vocabulary for every node and edge.

## Key Changes

### Core Graph Construction (`normalizer.py`)
- **Replace hard-coded theory nodes** with `_collect_step_records()` + `_node_from_record()` pipeline that derives node labels and edge types from each derivation step's `operation` field via `classify_operation()`
- **Automatic edge inference** via `_edges_from_records()`: edges are created when a source node's outputs feed a target node's inputs, eliminating manual edge specification
- **Source-backing metadata**: every node/edge now carries:
  - `linked_equation_ids`, `linked_derivation_ids`, `linked_claim_ids`, `linked_evidence_ids`
  - `source_backing_status` (one of: `source_backed`, `partially_source_backed`, `inferred`, `review_required`)
  - `review_reasons` (structured vocabulary: `missing_atomic_claim`, `missing_evidence_link`, etc.)
- **Configurable threshold**: `_MIN_THEORY_NODES = 3` replaces hard-coded `>= 5` check

### Operation Classification (`schema.py`)
- **New `classify_operation(operation: str) → (verb, edge_type, is_generic)` function**:
  - Maps concrete operations (`define_*`, `linearize_*`, `solve_*`, etc.) to domain-neutral edge types (`defines`, `linearizes`, `solves`, `eliminates`, `derives`, `constrains`, `diagnoses`, etc.)
  - Flags generic operations (`transform`, `relate`, `connect`, `support`, `associate`, `""`) as `is_generic=True` → `edge_type="requires_review"`
  - Uses two-tier lookup: full operation name map (`_OPERATION_FULL_MAP`) then prefix-based fallback (`_OPERATION_PREFIX_MAP`)
- **New vocabulary constants**:
  - `SOURCE_BACKING_STATUSES`, `REVIEW_REASONS`, `GENERIC_EDGE_TYPES`, `GENERIC_OPERATIONS`
  - Expanded `VALID_EDGE_TYPES` with new operation-derived relations

### Validation (`validator.py`)
- **New `_check_node_source_backing()` method** enforcing:
  - Hard error: theory-operation nodes in main graph must have ≥1 source link (acceptance #1)
  - Hard error: `review_required` nodes must explain why (non-empty `review_reasons`)
  - Hard error: fallback nodes cannot be marked `source_backed`
  - Hard error: `constrains`/`derives`/`diagnoses` nodes must expose equation links
  - Hard error: `derive_*` operations must link to derivation steps
  - Warning: generic operations flagged for review
- Updated `component_type` validation to error on main-graph nodes without type

### Frontend & API
- **Admin UI** (`admin.js`):
  - Display source-backing status badge with color-coded styling
  - Render review reasons as structured list
  - Show source links (equations, derivations, claims, evidence) in node detail panel
  - Dashed border for `review_required` nodes; faded opacity for inferred nodes
- **Styles** (`styles.css`): new `.ls-graph-backing-*` and `.ls-graph-detail-reasons` classes
- **Backend route** (`theory_components.py`): propagate new fields through normalization pipeline; expand `_GRAPH_RELATIONS` with new operation-derived types
- **Pydantic schema** (`schemas.py`): add `linked_*_ids`, `source_backing_status`, `review_reasons` fields to `ComponentGraphNode` and `ComponentGraphEdge`

### Tests
- **`test_normalizer.py`**: replace hard-coded node/edge assertions with domain-independent checks (operation mapping, edge inference, source-link validation)

https://claude.ai/code/session_013kRDtdgXTPx9Wbh5G5Gifx