### PR TITLE
Fix issue #304: Preserve edge review_reasons in component graph persistence

### DIFF
--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -706,6 +706,9 @@ def persist_component_graph(
                 "support_status": e.get("support_status", "llm_inferred"),
                 "confidence": e.get("confidence", 0.0),
                 "review_status": e.get("review_status", "teacher_review_required"),
+                # review_required edge の理由 (issue #302/#304) を保存する。
+                # 落とすと API/UI 側で review 理由を表示・検証できなくなる。
+                "review_reasons": list(e.get("review_reasons") or []),
                 "evidence": evidence,
                 "edge_id": e.get("edge_id", ""),
             })

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -883,6 +883,99 @@ def test_issue_266_persist_component_graph_new_schema():
         assert e["target_component_id"] == "db-uuid-B"
 
 
+def test_issue_304_persist_component_graph_keeps_edge_review_reasons():
+    """persist_component_graph must keep edge review_reasons (issue #304)."""
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+    from episteme_graph.agents.component_graph.schema import (
+        ComponentGraphEdge,
+        ComponentGraphNode,
+        ComponentGraphResult,
+        GRAPH_SCHEMA_VERSION,
+    )
+    from core.document_pipeline.persistence import persist_component_graph
+
+    cg_result = ComponentGraphResult(
+        document_id="doc-304",
+        graph_schema_version=GRAPH_SCHEMA_VERSION,
+        cartridge_id=None,
+        nodes=[
+            ComponentGraphNode("comp_A", "Component A", "TheoryComponent"),
+            ComponentGraphNode("comp_B", "Component B", "TheoryComponent"),
+        ],
+        edges=[
+            ComponentGraphEdge(
+                edge_id="e1",
+                source="comp_A",
+                target="comp_B",
+                edge_type="requires_review",
+                support_status="llm_inferred",
+                evidence_claims=[],
+                reasoning="no backing",
+                confidence=0.5,
+                review_status="review_required",
+                review_reasons=["edge_not_source_backed", "fallback_or_inferred_node"],
+            )
+        ],
+        review_notes=[],
+        confidence=0.9,
+    )
+
+    id_map = {"comp_A": "db-uuid-A", "comp_B": "db-uuid-B"}
+
+    @dataclass
+    class _FakeDSL:
+        nodes: list = field(default_factory=list)
+        edges: list = field(default_factory=list)
+
+    saved_graph = {}
+
+    def fake_session():
+        class _Row:
+            def __getitem__(self, idx):
+                return "graph-id-304"
+
+        class _Exec:
+            def fetchone(self):
+                return _Row()
+
+        class _Session:
+            def execute(self, *a, **kw):
+                if a and len(a) >= 2 and isinstance(a[1], dict):
+                    import json
+                    saved_graph.update(json.loads(a[1].get("graph_json", "{}")))
+                return _Exec()
+
+            def commit(self):
+                pass
+
+            def rollback(self):
+                pass
+
+            def close(self):
+                pass
+
+        return _Session()
+
+    with patch("core.document_pipeline.persistence._pg_session", fake_session):
+        persist_component_graph(
+            document_id="doc-304",
+            component_id_map=id_map,
+            component_result=None,
+            dsl_result=_FakeDSL(),
+            component_graph_result=cg_result,
+        )
+
+    assert saved_graph.get("edges"), "graph_json must contain edges"
+    e = saved_graph["edges"][0]
+    assert e.get("review_status") == "review_required"
+    assert e.get("review_reasons") == [
+        "edge_not_source_backed",
+        "fallback_or_inferred_node",
+    ], "edge review_reasons must survive persistence (issue #304)"
+
+
 # --- regression-style structural assertions (issue #226) ----------------
 
 def test_issue_226_pipeline_files_exist():

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -28,9 +28,11 @@ from .schema import (
 
 _GENERIC_LABELS = {"define", "transform", "relate", "result"}
 # Minimum number of theory-operation nodes required before we publish the
-# derivation-derived graph as the main graph (smaller chains fall back to the
-# component view).
-_MIN_THEORY_NODES = 3
+# derivation-derived graph as the main graph. Whenever a DerivationChain yields
+# at least one theory-operation node we adopt it (issue #304): even a 1–2 step
+# chain carries operation-derived node/edge types that must reach the graph.
+# Only an empty derivation set falls back to the component view.
+_MIN_THEORY_NODES = 1
 
 
 class ComponentGraphNormalizer:
@@ -185,6 +187,7 @@ class ComponentGraphNormalizer:
                 review_status, review_reasons = _edge_backing(
                     evidence_equation_ids=overlap,
                     is_generic=target["is_generic"],
+                    evidence_derivation_ids=[source["step_id"], target["step_id"]],
                 )
                 edges.append(ComponentGraphEdge(
                     edge_id=f"theory_edge_{len(edges) + 1:04d}",
@@ -272,6 +275,7 @@ class ComponentGraphNormalizer:
                 evidence_equation_ids=edge.evidence_equation_ids,
                 is_generic=edge_type.lower() in ("requires_review", "transforms", "related_to"),
                 evidence_claims=edge.evidence_claims,
+                evidence_derivation_ids=edge.evidence_derivation_ids,
             )
             result.append(replace(
                 edge,
@@ -345,8 +349,16 @@ def _edge_backing(
     evidence_equation_ids: list[str],
     is_generic: bool,
     evidence_claims: list[str] | None = None,
+    evidence_derivation_ids: list[str] | None = None,
 ) -> tuple[str, list[str]]:
-    has_evidence = bool(evidence_equation_ids) or bool(evidence_claims)
+    # A derivation-backed edge is just as source-backed as an equation- or
+    # claim-backed one (issue #304): equation OR claim OR derivation evidence
+    # all count as backing.
+    has_evidence = (
+        bool(evidence_equation_ids)
+        or bool(evidence_claims)
+        or bool(evidence_derivation_ids)
+    )
     if is_generic:
         return "review_required", ["edge_not_source_backed", "fallback_or_inferred_node"]
     if has_evidence:

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -1,5 +1,8 @@
 from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
-from episteme_graph.agents.component_graph.normalizer import ComponentGraphNormalizer
+from episteme_graph.agents.component_graph.normalizer import (
+    ComponentGraphNormalizer,
+    _edge_backing,
+)
 from episteme_graph.agents.component_graph.schema import GRAPH_SCHEMA_VERSION, ComponentGraphResult
 from episteme_graph.agents.derivation_chain.schema import (
     DerivationChainRecord,
@@ -156,3 +159,75 @@ def test_normalizer_diagnostic_backed_by_upstream_results():
     # The diagnostic node is fed by the upstream derivation node (acceptance #7).
     derive_node = next(n for n in result.nodes if n.operation == "derive_consistency_relation")
     assert derive_node.component_id in incoming
+
+
+# --- issue #304 regression tests --------------------------------------------
+
+
+def test_edge_backing_treats_derivation_evidence_as_source_backed():
+    """An edge with only evidence_derivation_ids is source-backed (issue #304)."""
+    status, reasons = _edge_backing(
+        evidence_equation_ids=[],
+        is_generic=False,
+        evidence_claims=[],
+        evidence_derivation_ids=["step_1", "step_2"],
+    )
+    assert status == "source_backed"
+    assert reasons == []
+
+    # No backing at all is still review_required with a reason.
+    status, reasons = _edge_backing(
+        evidence_equation_ids=[],
+        is_generic=False,
+        evidence_claims=[],
+        evidence_derivation_ids=[],
+    )
+    assert status == "review_required"
+    assert reasons
+
+
+def _short_derivations(steps):
+    return DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[
+            DerivationChainRecord(
+                derivation_id="deriv",
+                document_id="doc",
+                source_section_ids=[],
+                steps=steps,
+            )
+        ],
+    )
+
+
+def test_normalizer_reflects_two_step_derivation_chain():
+    """A 1–2 step chain still produces operation-derived nodes/edges (issue #304)."""
+    derivations = _short_derivations([
+        _step("define", ["eq_a"], ["eq_b"]),
+        _step("linearize_moment_equations", ["eq_b"], ["eq_c"]),
+    ])
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
+    # Both derivation steps surface as main theory-operation nodes.
+    assert len(main_nodes) == 2
+    assert all(n.component_type == "TheoryOperationNode" for n in main_nodes)
+
+    # The operation-derived edge type reaches the graph instead of being
+    # dropped back to the component fallback view.
+    edge_types = {edge.edge_type for edge in result.edges}
+    assert "linearizes" in edge_types
+
+
+def test_normalizer_reflects_single_step_derivation_chain():
+    derivations = _short_derivations([
+        _step("derive_consistency_relation", ["eq_a"], ["eq_b"]),
+    ])
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
+    assert len(main_nodes) == 1
+    assert main_nodes[0].operation == "derive_consistency_relation"


### PR DESCRIPTION
## Summary

Fixes issue #304 by ensuring that edge `review_reasons` are preserved when persisting component graphs to the database. Additionally, improves the derivation chain handling in the component graph normalizer to recognize derivation-backed edges as source-backed and to surface even short (1–2 step) derivation chains in the main graph.

## Key Changes

### 1. **Persistence Layer** (`backend/core/document_pipeline/persistence.py`)
- Added `review_reasons` field to the edge JSON serialization in `persist_component_graph()`
- Previously, review reasons were being dropped during persistence, preventing the API/UI from displaying or validating edge review status
- Now explicitly preserves the list of review reason strings for each edge

### 2. **Edge Backing Logic** (`src/episteme_graph/agents/component_graph/normalizer.py`)
- Updated `_edge_backing()` function to treat derivation-backed edges as source-backed
- Added `evidence_derivation_ids` parameter to the backing evaluation logic
- An edge with derivation evidence (equation OR claim OR derivation) now correctly returns `"source_backed"` status
- Ensures that derivation chains contribute to edge credibility assessment

### 3. **Derivation Chain Threshold** (`src/episteme_graph/agents/component_graph/normalizer.py`)
- Lowered `_MIN_THEORY_NODES` from 3 to 1
- Previously, only derivation chains with 3+ theory-operation nodes would surface in the main graph; shorter chains fell back to the component view
- Now even 1–2 step derivation chains are adopted, preserving operation-derived node/edge types that carry semantic value
- Only completely empty derivation sets fall back to the component view

### 4. **Test Coverage** (`backend/tests/test_document_pipeline.py` and `src/tests/agents/component_graph/test_normalizer.py`)
- Added regression test `test_issue_304_persist_component_graph_keeps_edge_review_reasons()` to verify review_reasons survive persistence
- Added `test_edge_backing_treats_derivation_evidence_as_source_backed()` to validate derivation-backed edge logic
- Added `test_normalizer_reflects_two_step_derivation_chain()` and `test_normalizer_reflects_single_step_derivation_chain()` to ensure short chains surface correctly

## Implementation Details

- The fix is minimal and non-breaking: it only adds missing data to the persistence layer and corrects the backing evaluation logic
- Derivation evidence is now treated symmetrically with equation and claim evidence in the backing assessment
- The lowered threshold allows operation-derived semantics (e.g., "linearizes", "derives_consistency_relation") to reach the graph even in short chains, improving semantic fidelity

https://claude.ai/code/session_01Vbq87dkpeuZTRo9JGhKsvk