### PR TITLE
Implement layered theory graph with main/equation_detail separation (#306)

### DIFF
--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -268,6 +268,34 @@ src/tests/agents/<agent_name>/
 cd src && python -m pytest tests/ -v
 ```
 
+### TheoryOperationGraph の層構造 (ComponentGraphAgent / #266・#302・#306)
+
+`component_graph/normalizer.py` は DerivationChain から **domain-independent** な理論操作グラフを
+決定論的に構築する。node label / edge type は `schema.classify_operation()` が `operation` の
+prefix から導出し、特定分野・特定論文の用語をハードコードしない。
+
+グラフは 2 層に分離する (#306):
+
+- **main 層** (`graph_layer="main"`, `component_type="TheoryOperationNode"`): 上位理論構成。
+  式 step を `(derivation_id, operation family)` で集約した少数 node。generic operation
+  (`transform`/`relate`/`connect`/`support`/`associate`) は main にしない。
+- **equation_detail 層** (`graph_layer="equation_detail"`, `component_type="EquationOperationNode"`):
+  derivation step ごとの式単位 node。`parent_component_id` で main node を、main node は
+  `member_component_ids` で detail node を相互参照する。generic step は `debug` 層へ。
+
+その他の必須ルール:
+
+- **source-backing を明示**: 各 node は `linked_equation_ids` / `linked_derivation_ids` /
+  `linked_claim_ids` / `linked_evidence_ids` と `source_backing_status` を持つ。
+- **atomic claim を優先**: 主たる backing は atomic claim（短く evidence_text が非空、paper-level
+  でない）を優先。無ければ `review_reasons=["missing_atomic_claim"]`、equation ID だけの label は
+  `partially_source_backed`。空 evidence を強い backing にしない。
+- **review_status は backing から導出**: `schema.review_status_for_backing()` を使い、全 node を
+  一律 `teacher_review_required` にしない。`review_required` の node/edge は `review_reasons` を
+  空にしない。
+- **UI (`admin.js`)**: 層トグル（主グラフ / 式の詳細 / すべて）で `graph_layer` を切り替え、既定は
+  main を優先表示する。
+
 ## 開発ガイドライン
 
 1. **スキーマ変更**: `backend/core/schema.py` の Pydantic モデルを先に更新し、`backend/core/models.py` の ORM モデルも同期する

--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -289,7 +289,8 @@ prefix から導出し、特定分野・特定論文の用語をハードコー�
   `linked_claim_ids` / `linked_evidence_ids` と `source_backing_status` を持つ。
 - **atomic claim を優先**: 主たる backing は atomic claim（短く evidence_text が非空、paper-level
   でない）を優先。無ければ `review_reasons=["missing_atomic_claim"]`、equation ID だけの label は
-  `partially_source_backed`。空 evidence を強い backing にしない。
+  `partially_source_backed`。空 evidence を強い backing にしない。evidence link で `source_backed`
+  になった node でも atomic claim が無ければ `missing_atomic_claim` warning を残す。
 - **review_status は backing から導出**: `schema.review_status_for_backing()` を使い、全 node を
   一律 `teacher_review_required` にしない。`review_required` の node/edge は `review_reasons` を
   空にしない。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,8 +195,23 @@ examples/          → サンプル入出力JSON
   `fallback_or_inferred_node` / `source_span_missing` から選ぶ）。
 - **fallback / inferred node を main graph で確定扱いしない**: `deterministic_fallback` や
   `inferred` の node は `graph_layer = "debug"` に分離し、`source_backed` にしてはならない（hard error）。
+- **graph を 2 層に分離する (#306)**: main graph は上位理論構成を表す少数の集約 node
+  (`graph_layer = "main"`, `component_type = "TheoryOperationNode"`)、式単位の step は
+  (`graph_layer = "equation_detail"`, `component_type = "EquationOperationNode"`) に保持する。
+  式 step は `(derivation_id, operation family)` で集約して main node を作り、各 detail node は
+  `parent_component_id`、各 main node は `member_component_ids` で相互参照する。
+  generic operation は main node にしない（detail / debug に置き `inferred`）。
+- **review_status は source_backing_status から導出する (#306)**: `schema.review_status_for_backing()`
+  が `source_backed → source_backed` / `partially_source_backed → teacher_review_required` /
+  `inferred・review_required → review_required` にマップする。全 node を一律
+  `teacher_review_required` にしない。
+- **atomic claim を優先する (#306)**: node の主たる backing は atomic claim（短く、evidence_text が
+  非空、paper-level でない）を優先する。atomic claim が無ければ `review_reasons=["missing_atomic_claim"]`
+  を付け、equation ID だけの label は `partially_source_backed` に留める。空の evidence_text を
+  強い source backing として扱わない。
 - **UI (`admin.js`)** は `source_backing_status` で表示を区別する
   （source_backed=通常 / partially=細線 / review_required=点線枠 / inferred・fallback=薄色+⚠）。
+  グラフ層トグル（主グラフ / 式の詳細 / すべて）で `graph_layer` を切り替え、既定は main を優先表示する。
 
 #### カートリッジシステム
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,9 @@ examples/          → サンプル入出力JSON
 - **atomic claim を優先する (#306)**: node の主たる backing は atomic claim（短く、evidence_text が
   非空、paper-level でない）を優先する。atomic claim が無ければ `review_reasons=["missing_atomic_claim"]`
   を付け、equation ID だけの label は `partially_source_backed` に留める。空の evidence_text を
-  強い source backing として扱わない。
+  強い source backing として扱わない。evidence link により `source_backed` になった node でも
+  atomic claim が無ければ `missing_atomic_claim` を warning として残す（`review_status` は
+  `source_backed` のまま）。
 - **UI (`admin.js`)** は `source_backing_status` で表示を区別する
   （source_backed=通常 / partially=細線 / review_required=点線枠 / inferred・fallback=薄色+⚠）。
   グラフ層トグル（主グラフ / 式の詳細 / すべて）で `graph_layer` を切り替え、既定は main を優先表示する。

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -1969,6 +1969,8 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "linked_evidence_ids": node.get("linked_evidence_ids") if isinstance(node.get("linked_evidence_ids"), list) else [],
             "source_backing_status": str(node.get("source_backing_status") or ""),
             "review_reasons": node.get("review_reasons") if isinstance(node.get("review_reasons"), list) else [],
+            "parent_component_id": str(node.get("parent_component_id") or ""),
+            "member_component_ids": node.get("member_component_ids") if isinstance(node.get("member_component_ids"), list) else [],
         })
         seen_nodes.add(component_id)
     normalized_edges = []

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -861,6 +861,9 @@ class ComponentGraphNode(BaseModel):
     linked_evidence_ids: list[str] = Field(default_factory=list)
     source_backing_status: str = ""
     review_reasons: list[str] = Field(default_factory=list)
+    # Layer linkage between main TheoryOperationNode and equation_detail nodes (issue #306).
+    parent_component_id: str = ""
+    member_component_ids: list[str] = Field(default_factory=list)
 
 
 class ComponentGraphEdge(BaseModel):

--- a/backend/tests/test_theory_graph_source_backing.py
+++ b/backend/tests/test_theory_graph_source_backing.py
@@ -57,6 +57,29 @@ class TestRoutePropagatesSourceBacking:
             assert f'"{relation}"' in source, f"_GRAPH_RELATIONS missing {relation}"
 
 
+class TestGraphLayering:
+    """Issue #306: main / equation_detail layering plumbing."""
+
+    def test_node_schema_has_layer_linkage(self):
+        source = _read(SCHEMAS)
+        assert "parent_component_id" in source
+        assert "member_component_ids" in source
+
+    def test_route_passes_through_layer_linkage(self):
+        source = _read(ROUTES)
+        for field in ('"parent_component_id"', '"member_component_ids"'):
+            assert field in source, f"route does not propagate node field {field}"
+
+    def test_admin_js_supports_layer_toggle(self):
+        source = _read(ADMIN_JS)
+        assert "graphLayerFilter" in source
+        assert "lsGraphForCurrentLayer" in source
+        assert "lsGraphLayerToolbarHtml" in source
+        # Default view prioritizes the main graph.
+        assert 'graphLayerFilter: "main"' in source
+        assert "equation_detail" in source
+
+
 class TestFrontendDistinguishesSourceBacking:
     def test_admin_js_renders_source_backing(self):
         source = _read(ADMIN_JS)

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -3498,6 +3498,46 @@ body {
   background: var(--color-background-secondary);
 }
 
+/* Issue #306: グラフ層トグル (main / equation_detail / all) */
+.ls-graph-layer-toolbar {
+  position: absolute;
+  left: 14px;
+  top: 14px;
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  z-index: 5;
+}
+
+.ls-graph-layer-btn {
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 5px 10px;
+  line-height: 1;
+}
+
+.ls-graph-layer-btn:hover {
+  background: var(--color-background-secondary);
+}
+
+.ls-graph-layer-btn.is-active {
+  background: var(--color-accent, #2563eb);
+  border-color: var(--color-accent, #2563eb);
+  color: #ffffff;
+}
+
+.ls-graph-layer-count {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
 .ls-component-graph-detail {
   min-width: 0;
   padding: 18px;

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -2847,6 +2847,8 @@
     claimMetaByChunk: {},
     componentsBySection: {},
     graphByDocument: {},
+    // Issue #306: 表示するグラフ層 ("main" | "equation_detail" | "all")。
+    graphLayerFilter: "main",
     selectedScope: null,
     selectedTheoryComponentId: null,
     analysisStatus: null,
@@ -5196,9 +5198,11 @@
       return;
     }
 
+    var view = lsGraphForCurrentLayer(graph);
     var html =
       '<div class="ls-component-graph-shell">' +
         '<div class="ls-component-graph-main">' +
+          lsGraphLayerToolbarHtml(nodes) +
           '<div id="ls-component-network" class="ls-component-network" tabindex="0"></div>' +
           '<div class="ls-component-legend">' +
             '<div class="ls-component-legend-title">論理コンポーネント</div>' +
@@ -5212,18 +5216,94 @@
           '<button id="ls-component-graph-fit" class="ls-component-graph-fit" type="button" title="全体を表示">⤢</button>' +
         '</div>' +
         '<aside id="ls-component-graph-detail" class="ls-component-graph-detail">' +
-          lsGraphEmptyDetailHtml(nodes.length, edges.length) +
+          lsGraphEmptyDetailHtml(view.nodes.length, view.edges.length) +
         '</aside>' +
       '</div>' +
       lsGraphValidationHtml(validations);
     container.innerHTML = html;
 
+    lsBindGraphLayerToolbar(documentId);
+
     if (!window.vis || !window.vis.Network) {
-      lsRenderGraphFallback(container, graph);
+      lsRenderGraphFallback(container, view);
       return;
     }
 
-    lsInitComponentGraphNetwork(graph);
+    lsInitComponentGraphNetwork(view);
+  }
+
+  // Issue #306: グラフは main（上位理論構成）と equation_detail（式単位）の
+  // 2層を持つ。デフォルトは main を優先表示し、トグルで詳細層を展開できる。
+  function lsGraphLayerOptions(nodes) {
+    var counts = { main: 0, equation_detail: 0, debug: 0, other: 0 };
+    (nodes || []).forEach(function (node) {
+      var layer = String((node && node.graph_layer) || "main").toLowerCase();
+      if (counts[layer] === undefined) counts.other += 1;
+      else counts[layer] += 1;
+    });
+    // Only a layered graph (with equation_detail / debug nodes) needs a toggle.
+    if (!counts.equation_detail && !counts.debug && !counts.other) return [];
+    var options = [{ value: "main", label: "主グラフ", count: counts.main }];
+    if (counts.equation_detail) {
+      options.push({ value: "equation_detail", label: "式の詳細", count: counts.equation_detail });
+    }
+    options.push({
+      value: "all",
+      label: "すべて",
+      count: counts.main + counts.equation_detail + counts.debug + counts.other,
+    });
+    return options;
+  }
+
+  function lsGraphLayerToolbarHtml(nodes) {
+    var options = lsGraphLayerOptions(nodes);
+    if (options.length <= 1) return "";
+    var current = lsState.graphLayerFilter || "main";
+    var buttons = options.map(function (opt) {
+      var active = opt.value === current ? " is-active" : "";
+      return '<button type="button" class="ls-graph-layer-btn' + active + '" data-graph-layer="' +
+        escHtml(opt.value) + '">' + escHtml(opt.label) +
+        ' <span class="ls-graph-layer-count">' + escHtml(String(opt.count)) + '</span></button>';
+    }).join("");
+    return '<div class="ls-graph-layer-toolbar" role="group" aria-label="グラフ層の切り替え">' +
+      buttons + '</div>';
+  }
+
+  function lsBindGraphLayerToolbar(documentId) {
+    var buttons = document.querySelectorAll(".ls-graph-layer-btn");
+    Array.prototype.forEach.call(buttons, function (btn) {
+      btn.addEventListener("click", function () {
+        var layer = btn.getAttribute("data-graph-layer") || "main";
+        if (layer === lsState.graphLayerFilter) return;
+        lsState.graphLayerFilter = layer;
+        lsRenderGraphPanel(documentId);
+      });
+    });
+  }
+
+  // Return a graph filtered to the currently selected layer. Edges are kept
+  // only when both endpoints remain visible.
+  function lsGraphForCurrentLayer(graph) {
+    var filter = lsState.graphLayerFilter || "main";
+    var nodes = graph.nodes || [];
+    var edges = graph.edges || [];
+    if (filter === "all") return graph;
+    var visible = nodes.filter(function (node) {
+      var layer = String((node && node.graph_layer) || "main").toLowerCase();
+      if (filter === "main") return layer === "main";
+      // equation_detail view shows the detailed trace plus its debug steps.
+      return layer === "equation_detail" || layer === "debug";
+    });
+    // Never show an empty canvas: fall back to all nodes if the filter is empty.
+    if (!visible.length) visible = nodes;
+    var visibleIds = {};
+    visible.forEach(function (node) { visibleIds[lsGraphNodeId(node)] = true; });
+    var visibleEdges = edges.filter(function (edge) {
+      var source = edge.source_component_id || edge.source || edge.from;
+      var target = edge.target_component_id || edge.target || edge.to;
+      return visibleIds[source] && visibleIds[target];
+    });
+    return Object.assign({}, graph, { nodes: visible, edges: visibleEdges });
   }
 
   function lsGraphEmptyDetailHtml(nodeCount, edgeCount) {
@@ -5368,7 +5448,11 @@
     var html =
       '<div class="ls-graph-detail-badge ' + escHtml(lsGraphNodeGroup(node)) + '">' + escHtml(node.component_type_text || node.component_type || node.typeName || "component") + '</div>' +
       '<h4>' + escHtml(node.label || node.name || nodeId || "無題") + '</h4>' +
-      '<p class="ls-graph-detail-meta">' + escHtml(node.review_status || node.origin || "paper") + '</p>';
+      '<p class="ls-graph-detail-meta">' + escHtml(lsGraphLayerLabel(node.graph_layer)) + ' ・ ' + escHtml(node.review_status || node.origin || "paper") + '</p>';
+    var linkage = lsGraphLayerLinkageHtml(node);
+    if (linkage) {
+      html += '<div class="ls-graph-detail-section"><b>グラフ層</b>' + linkage + '</div>';
+    }
     if (backing) {
       html += '<div class="ls-graph-detail-section"><b>出典の裏付け</b>' +
         '<p class="ls-graph-backing ls-graph-backing-' + escHtml(backing) + '">' +
@@ -5522,6 +5606,29 @@
   function lsGraphNodeDisplayLabel(node, id) {
     var label = lsWrapGraphLabel((node && (node.label || node.name)) || id);
     return lsGraphNodeIsFallback(node) ? "⚠ " + label : label;
+  }
+
+  function lsGraphLayerLabel(layer) {
+    var labels = {
+      main: "主グラフ（上位理論構成）",
+      equation_detail: "式の詳細",
+      debug: "要確認 / 推論層",
+    };
+    return labels[String(layer || "main").toLowerCase()] || layer || "主グラフ";
+  }
+
+  function lsGraphLayerLinkageHtml(node) {
+    var html = "";
+    var members = node.member_component_ids || [];
+    if (members.length) {
+      html += '<div class="ls-graph-detail-link"><span>式ステップ</span> ' +
+        escHtml(String(members.length)) + ' 件を集約</div>';
+    }
+    if (node.parent_component_id) {
+      html += '<div class="ls-graph-detail-link"><span>所属</span> ' +
+        escHtml(node.parent_component_id) + '</div>';
+    }
+    return html;
   }
 
   function lsGraphSourceBackingLabel(status) {

--- a/src/episteme_graph/agents/component_graph/agent.py
+++ b/src/episteme_graph/agents/component_graph/agent.py
@@ -34,6 +34,43 @@ from .validator import ComponentGraphValidator
 logger = logging.getLogger(__name__)
 
 
+def _first_text(*values) -> str:
+    """Return the first value that is a non-empty string (ignore lists/dicts)."""
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _build_claim_index(claims: list[dict] | None) -> dict[str, dict]:
+    """Build ``claim_id -> metadata`` for atomic-claim preference (issue #306).
+
+    The normalizer uses ``text`` / ``evidence_text`` / ``is_atomic`` / level to
+    decide whether a claim is strong (atomic) backing for a theory operation.
+    """
+    index: dict[str, dict] = {}
+    for claim in claims or []:
+        if not isinstance(claim, dict):
+            continue
+        cid = str(claim.get("claim_id") or claim.get("id") or "").strip()
+        if not cid:
+            continue
+        index[cid] = {
+            "text": str(claim.get("text") or claim.get("claim_text") or ""),
+            "predicate": str(claim.get("predicate") or ""),
+            "evidence_text": _first_text(
+                claim.get("evidence_text"),
+                claim.get("source_span"),
+                claim.get("source_text"),
+            ),
+            "claim_level": str(
+                claim.get("claim_level") or claim.get("level") or claim.get("granularity") or ""
+            ),
+            "is_atomic": claim.get("is_atomic"),
+        }
+    return index
+
+
 class ComponentGraphAgent:
     """Build a component dependency graph with LLM-inferred edges."""
 
@@ -126,7 +163,9 @@ class ComponentGraphAgent:
         if existing_graph:
             result = self._merger.merge(existing_graph, result)
 
-        result = self._normalizer.normalize(result, components, derivations)
+        result = self._normalizer.normalize(
+            result, components, derivations, claim_index=_build_claim_index(claims)
+        )
         result.validation_issues = self._validator.validate(result, cartridge)
         return result
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -581,8 +581,11 @@ def _node_backing(
         status = "review_required"
 
     if status == "source_backed":
-        # Confirmed structure: do not surface informational gaps as reasons.
-        reasons = []
+        # Confirmed structure: drop informational gaps. Keep only the
+        # missing_atomic_claim warning (issue #306): equations / evidence back
+        # the node, but no minimal atomic claim directly supports its meaning,
+        # so reviewers should still be told the atomic backing is absent.
+        reasons = [] if atomic_claim_ids else ["missing_atomic_claim"]
     return status, _ordered_unique(reasons)
 
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -1,4 +1,4 @@
-"""Normalize ComponentGraph into a source-backed theory-operation graph.
+"""Normalize ComponentGraph into a layered, source-backed theory graph.
 
 The LLM edge pass connects assembled components, which is useful for debugging.
 The published graph, however, should show the paper's *theory operations*
@@ -11,6 +11,20 @@ make explicit, for every node and edge:
 This module builds that graph deterministically from the DerivationChain. It is
 domain-independent: node labels and edge types are derived from each step's
 ``operation`` via :func:`classify_operation`, never from hard-coded paper terms.
+
+Two layers are produced (issue #306):
+
+``main`` (TheoryOperationNode)
+    Aggregated, high-level theory operations. Equation-level steps that share a
+    derivation and an operation family collapse into a single node so the main
+    graph stays small and shows the theory backbone rather than one node per
+    equation. Generic operations (``transform`` / ``relate`` / …) never become
+    confirmed main nodes.
+
+``equation_detail`` (EquationOperationNode)
+    One node per derivation step, preserving the full equation-by-equation
+    trace. Each detail node points back at its main node via
+    ``parent_component_id``; generic steps land in the ``debug`` layer instead.
 """
 from __future__ import annotations
 
@@ -20,18 +34,23 @@ from episteme_graph.agents.component_assembly.schema import ComponentAssemblyRes
 from episteme_graph.agents.derivation_chain.schema import DerivationChainResult
 
 from .schema import (
+    EQUATION_OPERATION_NODE,
+    GRAPH_LAYER_DEBUG,
+    GRAPH_LAYER_EQUATION_DETAIL,
+    GRAPH_LAYER_MAIN,
+    THEORY_OPERATION_NODE,
     ComponentGraphEdge,
     ComponentGraphNode,
     ComponentGraphResult,
     classify_operation,
+    review_status_for_backing,
 )
 
-_GENERIC_LABELS = {"define", "transform", "relate", "result"}
-# Minimum number of theory-operation nodes required before we publish the
-# derivation-derived graph as the main graph. Whenever a DerivationChain yields
-# at least one theory-operation node we adopt it (issue #304): even a 1–2 step
-# chain carries operation-derived node/edge types that must reach the graph.
-# Only an empty derivation set falls back to the component view.
+_GENERIC_LABELS = {"define", "transform", "relate", "result", "operation"}
+# Minimum number of theory-operation nodes (across both layers) required before
+# we publish the derivation-derived graph. Whenever a DerivationChain yields at
+# least one operation node we adopt it (issue #304); only an empty derivation
+# set falls back to the component view.
 _MIN_THEORY_NODES = 1
 
 
@@ -41,20 +60,32 @@ class ComponentGraphNormalizer:
         result: ComponentGraphResult,
         components: ComponentAssemblyResult,
         derivations: DerivationChainResult | None = None,
+        claim_index: dict[str, dict] | None = None,
     ) -> ComponentGraphResult:
-        theory_nodes, theory_edges = self._build_theory_graph(
-            result.document_id,
-            derivations,
+        """Build the layered theory graph.
+
+        Args:
+            result: edge-pass output (LLM/component nodes used as a fallback).
+            components: assembled components (fallback node source).
+            derivations: derivation chains driving the main/detail layers.
+            claim_index: optional ``claim_id -> {text, evidence_text, is_atomic}``
+                metadata. When present, only atomic claims with non-empty
+                evidence count as strong backing (issue #306, acceptance #10/#11).
+        """
+        claim_index = claim_index or {}
+        main_nodes, detail_nodes, edges = self._build_theory_graph(
+            derivations, claim_index
         )
+        theory_nodes = main_nodes + detail_nodes
         if len(theory_nodes) >= _MIN_THEORY_NODES:
             return replace(
                 result,
                 nodes=theory_nodes + self._debug_nodes(result.nodes),
-                edges=theory_edges,
+                edges=edges,
                 confidence=max(result.confidence, 0.85),
                 review_notes=list(result.review_notes or []) + [
-                    "GraphNormalizer built the main graph from derivation operations "
-                    "and equation roles."
+                    "GraphNormalizer built a layered graph: aggregated theory "
+                    "operations (main) over equation-level steps (equation_detail)."
                 ],
             )
 
@@ -69,21 +100,34 @@ class ComponentGraphNormalizer:
         )
 
     # ------------------------------------------------------------------ #
-    # Derivation → theory-operation graph (domain-independent)
+    # Derivation → layered theory graph (domain-independent)
     # ------------------------------------------------------------------ #
 
     def _build_theory_graph(
         self,
-        document_id: str,
         derivations: DerivationChainResult | None,
-    ) -> tuple[list[ComponentGraphNode], list[ComponentGraphEdge]]:
+        claim_index: dict[str, dict],
+    ) -> tuple[list[ComponentGraphNode], list[ComponentGraphNode], list[ComponentGraphEdge]]:
         records = self._collect_step_records(derivations)
         if not records:
-            return [], []
+            return [], [], []
 
-        nodes = [self._node_from_record(rec) for rec in records]
-        edges = self._edges_from_records(records)
-        return nodes, edges
+        groups = _group_records(records)
+        main_nodes = [
+            _main_node_from_group(group, claim_index) for group in groups
+        ]
+        parent_by_record = {
+            rec["detail_id"]: group["node_id"]
+            for group in groups
+            for rec in group["records"]
+        }
+        detail_nodes = [
+            _detail_node_from_record(rec, parent_by_record.get(rec["detail_id"], ""), claim_index)
+            for rec in records
+        ]
+        main_edges = _main_edges_from_groups(groups)
+        detail_edges = _detail_edges_from_records(records, claim_index)
+        return main_nodes, detail_nodes, main_edges + detail_edges
 
     @staticmethod
     def _collect_step_records(derivations: DerivationChainResult | None) -> list[dict]:
@@ -97,7 +141,8 @@ class ComponentGraphNormalizer:
                 verb, edge_type, is_generic = classify_operation(operation)
                 step_id = str(getattr(step, "step_id", "") or f"step_{counter}")
                 records.append({
-                    "node_id": f"theory_op_{counter:04d}",
+                    "detail_id": f"eq_op_{counter:04d}",
+                    "order": counter,
                     "step": step,
                     "step_id": step_id,
                     "derivation_id": derivation_id,
@@ -109,112 +154,6 @@ class ComponentGraphNormalizer:
                     "outputs": _ordered_unique(getattr(step, "output_equation_ids", []) or []),
                 })
         return records
-
-    @staticmethod
-    def _node_from_record(rec: dict) -> ComponentGraphNode:
-        step = rec["step"]
-        inputs = rec["inputs"]
-        outputs = rec["outputs"]
-        edge_type = rec["edge_type"]
-
-        linked_equation_ids = _ordered_unique(inputs + outputs)
-        linked_derivation_ids = _ordered_unique([rec["derivation_id"], rec["step_id"]])
-        linked_claim_ids = _ordered_unique(
-            list(getattr(step, "required_claim_ids", []) or [])
-            + list(getattr(step, "input_claim_ids", []) or [])
-            + list(getattr(step, "output_claim_ids", []) or [])
-        )
-        linked_evidence_ids = _ordered_unique(getattr(step, "source_evidence_ids", []) or [])
-
-        status, reasons = _node_backing(
-            linked_equation_ids=linked_equation_ids,
-            linked_derivation_ids=linked_derivation_ids,
-            linked_claim_ids=linked_claim_ids,
-            linked_evidence_ids=linked_evidence_ids,
-            is_generic=rec["is_generic"],
-        )
-
-        definitions = outputs if edge_type == "defines" else []
-        constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
-
-        return ComponentGraphNode(
-            component_id=rec["node_id"],
-            label=_build_label(rec["verb"], step, inputs, outputs),
-            component_type="TheoryOperationNode",
-            review_status="teacher_review_required",
-            display_order=int(rec["node_id"].rsplit("_", 1)[-1]),
-            origin="derivation_chain",
-            operation=rec["operation"],
-            theory_object=str(getattr(step, "reason", "") or "").strip()[:120] or rec["verb"],
-            graph_layer="main",
-            maturity_source="derivation_normalized",
-            publish_ready=False,
-            input_equation_ids=inputs,
-            intermediate_equation_ids=[],
-            output_equation_ids=outputs,
-            definition_equation_ids=_ordered_unique(definitions),
-            constraint_equation_ids=_ordered_unique(constraints),
-            review_required_equation_ids=[],
-            eliminated_symbols=_ordered_unique(getattr(step, "eliminated_symbols", []) or []),
-            retained_symbols=_ordered_unique(getattr(step, "retained_symbols", []) or []),
-            derivation_operations=[rec["operation"]] if rec["operation"] else [],
-            linked_equation_ids=linked_equation_ids,
-            linked_derivation_ids=linked_derivation_ids,
-            linked_claim_ids=linked_claim_ids,
-            linked_evidence_ids=linked_evidence_ids,
-            source_backing_status=status,
-            review_reasons=reasons,
-        )
-
-    @staticmethod
-    def _edges_from_records(records: list[dict]) -> list[ComponentGraphEdge]:
-        edges: list[ComponentGraphEdge] = []
-        seen: set[tuple[str, str, str]] = set()
-        for j, target in enumerate(records):
-            target_inputs = set(target["inputs"])
-            if not target_inputs:
-                continue
-            for source in records[:j]:
-                overlap = [eq for eq in source["outputs"] if eq in target_inputs]
-                if not overlap:
-                    continue
-                edge_type = target["edge_type"]
-                key = (source["node_id"], target["node_id"], edge_type)
-                if key in seen or source["node_id"] == target["node_id"]:
-                    continue
-                seen.add(key)
-                step = target["step"]
-                review_status, review_reasons = _edge_backing(
-                    evidence_equation_ids=overlap,
-                    is_generic=target["is_generic"],
-                    evidence_derivation_ids=[source["step_id"], target["step_id"]],
-                )
-                edges.append(ComponentGraphEdge(
-                    edge_id=f"theory_edge_{len(edges) + 1:04d}",
-                    source=source["node_id"],
-                    target=target["node_id"],
-                    edge_type=edge_type,
-                    support_status="derivation_linked",
-                    evidence_claims=[],
-                    reasoning=(
-                        f"Derivation data flow: {source['operation'] or 'step'} output "
-                        f"feeds {target['operation'] or 'step'} ({', '.join(overlap)})."
-                    ),
-                    confidence=0.9,
-                    evidence_equation_ids=_ordered_unique(overlap),
-                    review_status=review_status,
-                    evidence_derivation_ids=_ordered_unique([
-                        source["step_id"], target["step_id"]
-                    ]),
-                    evidence_claim_ids=_ordered_unique(
-                        getattr(step, "required_claim_ids", []) or []
-                    ),
-                    source_evidence_ids=_ordered_unique(
-                        getattr(step, "source_evidence_ids", []) or []
-                    ),
-                    review_reasons=review_reasons,
-                ))
-        return edges
 
     # ------------------------------------------------------------------ #
     # Component-graph fallback path
@@ -237,6 +176,7 @@ class ComponentGraphNormalizer:
         status, reasons = _node_backing(
             linked_equation_ids=linked_equation_ids,
             linked_derivation_ids=node.derivation_operations,
+            atomic_claim_ids=linked_claim_ids,
             linked_claim_ids=linked_claim_ids,
             linked_evidence_ids=linked_evidence_ids,
             is_generic=is_fallback,
@@ -246,7 +186,8 @@ class ComponentGraphNormalizer:
             label=label,
             operation=node.operation or str(getattr(comp, "operation", "") or ""),
             theory_object=node.theory_object or str(getattr(comp, "summary", "") or "")[:120],
-            graph_layer="debug" if is_fallback else node.graph_layer,
+            graph_layer=GRAPH_LAYER_DEBUG if is_fallback else node.graph_layer,
+            review_status=review_status_for_backing(status),
             linked_equation_ids=linked_equation_ids,
             linked_claim_ids=linked_claim_ids,
             linked_evidence_ids=linked_evidence_ids,
@@ -290,8 +231,9 @@ class ComponentGraphNormalizer:
         return [
             replace(
                 node,
-                graph_layer="debug",
-                display_order=1000 + idx,
+                graph_layer=GRAPH_LAYER_DEBUG,
+                display_order=2000 + idx,
+                review_status=review_status_for_backing("inferred"),
                 source_backing_status="inferred",
                 review_reasons=_ordered_unique(
                     list(node.review_reasons) + ["fallback_or_inferred_node"]
@@ -303,6 +245,303 @@ class ComponentGraphNormalizer:
 
 
 # ---------------------------------------------------------------------- #
+# Grouping (equation steps → aggregated main operations)
+# ---------------------------------------------------------------------- #
+
+def _group_records(records: list[dict]) -> list[dict]:
+    """Aggregate non-generic step records into main theory-operation groups.
+
+    Grouping key: ``(derivation_id, operation family)``. Consecutive equation
+    steps that share a derivation and an operation family collapse into one
+    high-level node; generic operations never form a main node (issue #306).
+    """
+    groups: list[dict] = []
+    index: dict[tuple[str, str], dict] = {}
+    order = 0
+    for rec in records:
+        if rec["is_generic"]:
+            continue
+        key = (rec["derivation_id"], rec["edge_type"])
+        group = index.get(key)
+        if group is None:
+            order += 1
+            group = {
+                "node_id": f"theory_op_{order:04d}",
+                "order": order,
+                "derivation_id": rec["derivation_id"],
+                "edge_type": rec["edge_type"],
+                "records": [],
+            }
+            index[key] = group
+            groups.append(group)
+        group["records"].append(rec)
+    return groups
+
+
+def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> ComponentGraphNode:
+    records = group["records"]
+    edge_type = group["edge_type"]
+
+    inputs = _ordered_unique([eq for rec in records for eq in rec["inputs"]])
+    outputs = _ordered_unique([eq for rec in records for eq in rec["outputs"]])
+    linked_equation_ids = _ordered_unique(inputs + outputs)
+    linked_derivation_ids = _ordered_unique(
+        [group["derivation_id"]] + [rec["step_id"] for rec in records]
+    )
+    linked_claim_ids = _ordered_unique(
+        [cid for rec in records for cid in _step_claim_ids(rec["step"])]
+    )
+    linked_evidence_ids = _ordered_unique(
+        [eid for rec in records for eid in (getattr(rec["step"], "source_evidence_ids", []) or [])]
+    )
+    eliminated = _ordered_unique(
+        [s for rec in records for s in (getattr(rec["step"], "eliminated_symbols", []) or [])]
+    )
+    retained = _ordered_unique(
+        [s for rec in records for s in (getattr(rec["step"], "retained_symbols", []) or [])]
+    )
+    operations = _ordered_unique([rec["operation"] for rec in records if rec["operation"]])
+
+    atomic_claim_ids = _atomic_claim_ids(linked_claim_ids, claim_index)
+    status, reasons = _node_backing(
+        linked_equation_ids=linked_equation_ids,
+        linked_derivation_ids=linked_derivation_ids,
+        atomic_claim_ids=atomic_claim_ids,
+        linked_claim_ids=linked_claim_ids,
+        linked_evidence_ids=linked_evidence_ids,
+        is_generic=False,
+    )
+
+    rep = _representative_record(records)
+    label, label_from_eq_only = _build_main_label(
+        rep, records, inputs, outputs, eliminated, retained, atomic_claim_ids, claim_index
+    )
+    # A node whose label could only be built from an equation ID is, by
+    # definition, not backed by an atomic claim (acceptance #3 / #9). A
+    # source-backed node (it has evidence) keeps its status; only the
+    # remaining cases gain the missing_atomic_claim reason.
+    if label_from_eq_only and status != "source_backed":
+        reasons = _ordered_unique(reasons + ["missing_atomic_claim"])
+
+    definitions = outputs if edge_type == "defines" else []
+    constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
+
+    return ComponentGraphNode(
+        component_id=group["node_id"],
+        label=label,
+        component_type=THEORY_OPERATION_NODE,
+        review_status=review_status_for_backing(status),
+        display_order=group["order"],
+        origin="derivation_chain",
+        operation=rep["operation"],
+        theory_object=_theory_object(rep, atomic_claim_ids, claim_index),
+        graph_layer=GRAPH_LAYER_MAIN,
+        maturity_source="derivation_aggregated",
+        publish_ready=status == "source_backed",
+        input_equation_ids=inputs,
+        intermediate_equation_ids=[],
+        output_equation_ids=outputs,
+        definition_equation_ids=_ordered_unique(definitions),
+        constraint_equation_ids=_ordered_unique(constraints),
+        review_required_equation_ids=[],
+        eliminated_symbols=eliminated,
+        retained_symbols=retained,
+        derivation_operations=operations,
+        linked_equation_ids=linked_equation_ids,
+        linked_derivation_ids=linked_derivation_ids,
+        linked_claim_ids=linked_claim_ids,
+        linked_evidence_ids=linked_evidence_ids,
+        source_backing_status=status,
+        review_reasons=reasons,
+        member_component_ids=[rec["detail_id"] for rec in records],
+    )
+
+
+def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
+    """High-level theory flow: group output equation feeds another group's input."""
+    summaries = []
+    for group in groups:
+        outputs = {eq for rec in group["records"] for eq in rec["outputs"]}
+        inputs = {eq for rec in group["records"] for eq in rec["inputs"]}
+        step_ids = [rec["step_id"] for rec in group["records"]]
+        claim_ids = _ordered_unique(
+            [cid for rec in group["records"] for cid in _step_claim_ids(rec["step"])]
+        )
+        evidence_ids = _ordered_unique(
+            [eid for rec in group["records"]
+             for eid in (getattr(rec["step"], "source_evidence_ids", []) or [])]
+        )
+        summaries.append({
+            "group": group,
+            "outputs": outputs,
+            "inputs": inputs,
+            "step_ids": step_ids,
+            "claim_ids": claim_ids,
+            "evidence_ids": evidence_ids,
+        })
+
+    edges: list[ComponentGraphEdge] = []
+    seen: set[tuple[str, str, str]] = set()
+    for tgt in summaries:
+        if not tgt["inputs"]:
+            continue
+        for src in summaries:
+            if src["group"]["node_id"] == tgt["group"]["node_id"]:
+                continue
+            overlap = _ordered_unique([eq for eq in src["outputs"] if eq in tgt["inputs"]])
+            if not overlap:
+                continue
+            edge_type = tgt["group"]["edge_type"]
+            key = (src["group"]["node_id"], tgt["group"]["node_id"], edge_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            evidence_derivation_ids = _ordered_unique(src["step_ids"] + tgt["step_ids"])
+            review_status, review_reasons = _edge_backing(
+                evidence_equation_ids=overlap,
+                is_generic=False,
+                evidence_claims=tgt["claim_ids"],
+                evidence_derivation_ids=evidence_derivation_ids,
+            )
+            edges.append(ComponentGraphEdge(
+                edge_id=f"theory_edge_{len(edges) + 1:04d}",
+                source=src["group"]["node_id"],
+                target=tgt["group"]["node_id"],
+                edge_type=edge_type,
+                support_status="derivation_linked",
+                evidence_claims=[],
+                reasoning=(
+                    f"Theory flow: {src['group']['edge_type']} output feeds "
+                    f"{tgt['group']['edge_type']} ({', '.join(overlap)})."
+                ),
+                confidence=0.9,
+                evidence_equation_ids=overlap,
+                review_status=review_status,
+                evidence_derivation_ids=evidence_derivation_ids,
+                evidence_claim_ids=tgt["claim_ids"],
+                source_evidence_ids=tgt["evidence_ids"],
+                review_reasons=review_reasons,
+            ))
+    return edges
+
+
+# ---------------------------------------------------------------------- #
+# Equation-detail layer (one node / edge per derivation step)
+# ---------------------------------------------------------------------- #
+
+def _detail_node_from_record(
+    rec: dict,
+    parent_id: str,
+    claim_index: dict[str, dict],
+) -> ComponentGraphNode:
+    step = rec["step"]
+    inputs = rec["inputs"]
+    outputs = rec["outputs"]
+    edge_type = rec["edge_type"]
+
+    linked_equation_ids = _ordered_unique(inputs + outputs)
+    linked_derivation_ids = _ordered_unique([rec["derivation_id"], rec["step_id"]])
+    linked_claim_ids = _ordered_unique(_step_claim_ids(step))
+    linked_evidence_ids = _ordered_unique(getattr(step, "source_evidence_ids", []) or [])
+    atomic_claim_ids = _atomic_claim_ids(linked_claim_ids, claim_index)
+
+    status, reasons = _node_backing(
+        linked_equation_ids=linked_equation_ids,
+        linked_derivation_ids=linked_derivation_ids,
+        atomic_claim_ids=atomic_claim_ids,
+        linked_claim_ids=linked_claim_ids,
+        linked_evidence_ids=linked_evidence_ids,
+        is_generic=rec["is_generic"],
+    )
+
+    definitions = outputs if edge_type == "defines" else []
+    constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
+    # Generic / inferred steps are kept for traceability but never confirmed.
+    layer = GRAPH_LAYER_DEBUG if rec["is_generic"] else GRAPH_LAYER_EQUATION_DETAIL
+
+    return ComponentGraphNode(
+        component_id=rec["detail_id"],
+        label=_build_detail_label(rec["verb"], step, inputs, outputs),
+        component_type=EQUATION_OPERATION_NODE,
+        review_status=review_status_for_backing(status),
+        display_order=1000 + rec["order"],
+        origin="derivation_chain",
+        operation=rec["operation"],
+        theory_object=str(getattr(step, "reason", "") or "").strip()[:120] or rec["verb"],
+        graph_layer=layer,
+        maturity_source="derivation_step",
+        publish_ready=False,
+        input_equation_ids=inputs,
+        intermediate_equation_ids=[],
+        output_equation_ids=outputs,
+        definition_equation_ids=_ordered_unique(definitions),
+        constraint_equation_ids=_ordered_unique(constraints),
+        review_required_equation_ids=[],
+        eliminated_symbols=_ordered_unique(getattr(step, "eliminated_symbols", []) or []),
+        retained_symbols=_ordered_unique(getattr(step, "retained_symbols", []) or []),
+        derivation_operations=[rec["operation"]] if rec["operation"] else [],
+        linked_equation_ids=linked_equation_ids,
+        linked_derivation_ids=linked_derivation_ids,
+        linked_claim_ids=linked_claim_ids,
+        linked_evidence_ids=linked_evidence_ids,
+        source_backing_status=status,
+        review_reasons=reasons,
+        parent_component_id=parent_id,
+    )
+
+
+def _detail_edges_from_records(
+    records: list[dict],
+    claim_index: dict[str, dict],
+) -> list[ComponentGraphEdge]:
+    edges: list[ComponentGraphEdge] = []
+    seen: set[tuple[str, str, str]] = set()
+    for j, target in enumerate(records):
+        target_inputs = set(target["inputs"])
+        if not target_inputs:
+            continue
+        for source in records[:j]:
+            overlap = [eq for eq in source["outputs"] if eq in target_inputs]
+            if not overlap:
+                continue
+            edge_type = target["edge_type"]
+            key = (source["detail_id"], target["detail_id"], edge_type)
+            if key in seen or source["detail_id"] == target["detail_id"]:
+                continue
+            seen.add(key)
+            step = target["step"]
+            review_status, review_reasons = _edge_backing(
+                evidence_equation_ids=overlap,
+                is_generic=target["is_generic"],
+                evidence_derivation_ids=[source["step_id"], target["step_id"]],
+            )
+            edges.append(ComponentGraphEdge(
+                edge_id=f"eq_edge_{len(edges) + 1:04d}",
+                source=source["detail_id"],
+                target=target["detail_id"],
+                edge_type=edge_type,
+                support_status="derivation_linked",
+                evidence_claims=[],
+                reasoning=(
+                    f"Derivation data flow: {source['operation'] or 'step'} output "
+                    f"feeds {target['operation'] or 'step'} ({', '.join(overlap)})."
+                ),
+                confidence=0.9,
+                evidence_equation_ids=_ordered_unique(overlap),
+                review_status=review_status,
+                evidence_derivation_ids=_ordered_unique([
+                    source["step_id"], target["step_id"]
+                ]),
+                evidence_claim_ids=_ordered_unique(_step_claim_ids(step)),
+                source_evidence_ids=_ordered_unique(
+                    getattr(step, "source_evidence_ids", []) or []
+                ),
+                review_reasons=review_reasons,
+            ))
+    return edges
+
+
+# ---------------------------------------------------------------------- #
 # Backing computation
 # ---------------------------------------------------------------------- #
 
@@ -310,6 +549,7 @@ def _node_backing(
     *,
     linked_equation_ids: list[str],
     linked_derivation_ids: list[str],
+    atomic_claim_ids: list[str],
     linked_claim_ids: list[str],
     linked_evidence_ids: list[str],
     is_generic: bool,
@@ -317,7 +557,9 @@ def _node_backing(
     reasons: list[str] = []
     if not linked_equation_ids:
         reasons.append("missing_equation_link")
-    if not linked_claim_ids:
+    # Atomic claims are preferred backing; a non-atomic / empty-evidence claim
+    # does not remove the gap (issue #306, acceptance #10/#11).
+    if not atomic_claim_ids:
         reasons.append("missing_atomic_claim")
     if not linked_evidence_ids:
         reasons.append("missing_evidence_link")
@@ -327,7 +569,7 @@ def _node_backing(
         reasons.append("fallback_or_inferred_node")
 
     has_equation = bool(linked_equation_ids)
-    has_strong = bool(linked_claim_ids or linked_evidence_ids)
+    has_strong = bool(atomic_claim_ids or linked_evidence_ids)
 
     if is_generic:
         status = "inferred"
@@ -341,7 +583,7 @@ def _node_backing(
     if status == "source_backed":
         # Confirmed structure: do not surface informational gaps as reasons.
         reasons = []
-    return status, reasons
+    return status, _ordered_unique(reasons)
 
 
 def _edge_backing(
@@ -367,10 +609,55 @@ def _edge_backing(
 
 
 # ---------------------------------------------------------------------- #
+# Claim helpers (atomic-claim preference, issue #306)
+# ---------------------------------------------------------------------- #
+
+def _step_claim_ids(step) -> list[str]:
+    return (
+        list(getattr(step, "required_claim_ids", []) or [])
+        + list(getattr(step, "input_claim_ids", []) or [])
+        + list(getattr(step, "output_claim_ids", []) or [])
+    )
+
+
+def _atomic_claim_ids(claim_ids: list[str], claim_index: dict[str, dict]) -> list[str]:
+    """Return the subset of claim IDs that count as strong (atomic) backing.
+
+    When no metadata exists for a claim we keep it (unknown but usable, so
+    derivation-linked claims still back a node, issue #304). When metadata is
+    present, only atomic claims with non-empty evidence text qualify.
+    """
+    if not claim_ids:
+        return []
+    strong: list[str] = []
+    for cid in claim_ids:
+        meta = claim_index.get(cid)
+        if meta is None:
+            strong.append(cid)
+            continue
+        if _claim_is_atomic(meta) and str(meta.get("evidence_text") or "").strip():
+            strong.append(cid)
+    return _ordered_unique(strong)
+
+
+def _claim_is_atomic(meta: dict) -> bool:
+    level = str(meta.get("claim_level") or meta.get("level") or meta.get("granularity") or "").lower()
+    if level in ("paper", "paper_level", "document", "global"):
+        return False
+    if meta.get("is_atomic") is False:
+        return False
+    text = str(meta.get("text") or "").strip()
+    # Long, multi-sentence claims tend to mix background/method/result and are
+    # not atomic backing for a single theory operation.
+    return bool(text) and len(text) <= 240
+
+
+# ---------------------------------------------------------------------- #
 # Label / component helpers
 # ---------------------------------------------------------------------- #
 
-def _build_label(verb: str, step, inputs: list[str], outputs: list[str]) -> str:
+def _build_detail_label(verb: str, step, inputs: list[str], outputs: list[str]) -> str:
+    """Equation-level label: equation IDs are acceptable here (traceability)."""
     obj = (outputs[:1] or inputs[:1] or [""])[0]
     if obj:
         return f"{verb} {obj}".strip()
@@ -378,6 +665,83 @@ def _build_label(verb: str, step, inputs: list[str], outputs: list[str]) -> str:
     if reason and reason.lower() not in _GENERIC_LABELS:
         return reason[:80]
     return verb
+
+
+def _representative_record(records: list[dict]) -> dict:
+    """Pick the member whose operation carries the most specific object phrase."""
+    return max(records, key=lambda r: (len(str(r["operation"] or "")), -r["order"]))
+
+
+def _build_main_label(
+    rep: dict,
+    records: list[dict],
+    inputs: list[str],
+    outputs: list[str],
+    eliminated: list[str],
+    retained: list[str],
+    atomic_claim_ids: list[str],
+    claim_index: dict[str, dict],
+) -> tuple[str, bool]:
+    """Domain-neutral ``operation + theory object`` label for a main node.
+
+    Returns ``(label, from_equation_id_only)``. The object phrase is taken, in
+    order, from: atomic claim text → step reason → eliminated/retained symbols →
+    equation ID (last resort, which flags the node, acceptance #3).
+    """
+    verb = str(rep["verb"] or "").strip()
+    # 1. atomic claim text
+    claim_phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index)
+    if claim_phrase:
+        return _compose_label(verb, claim_phrase), False
+    # 2. step reason (skip bare generic words)
+    for rec in [rep] + records:
+        reason = str(getattr(rec["step"], "reason", "") or "").strip()
+        if reason and reason.lower() not in _GENERIC_LABELS:
+            return _compose_label(verb, reason[:80]), False
+    # 3. eliminated / retained symbols
+    symbols = eliminated or retained
+    if symbols:
+        return _compose_label(verb, ", ".join(symbols[:3])), False
+    # 4. the verb already names a specific operation (multi-word from operation)
+    if " " in verb:
+        return verb, False
+    # 5. equation ID fallback only — flags the node as not atomically backed
+    obj = (outputs[:1] or inputs[:1] or [""])[0]
+    if obj:
+        return f"{verb} {obj}".strip(), True
+    return verb, True
+
+
+def _compose_label(verb: str, phrase: str) -> str:
+    verb = verb.strip()
+    phrase = phrase.strip()
+    if not phrase:
+        return verb
+    if not verb:
+        return phrase
+    # Avoid duplicating the verb if the phrase already starts with it.
+    if phrase.lower().startswith(verb.lower()):
+        return phrase
+    return f"{verb} {phrase}"
+
+
+def _atomic_claim_phrase(atomic_claim_ids: list[str], claim_index: dict[str, dict]) -> str:
+    for cid in atomic_claim_ids:
+        meta = claim_index.get(cid)
+        if not meta:
+            continue
+        text = str(meta.get("text") or meta.get("predicate") or "").strip()
+        if text:
+            return text[:80]
+    return ""
+
+
+def _theory_object(rep: dict, atomic_claim_ids: list[str], claim_index: dict[str, dict]) -> str:
+    phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index)
+    if phrase:
+        return phrase[:120]
+    reason = str(getattr(rep["step"], "reason", "") or "").strip()
+    return reason[:120] or str(rep["verb"] or "")
 
 
 def _join_nodes_to_components(

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -76,6 +76,34 @@ GENERIC_EDGE_TYPES = {"related_to", "correlates", "supports", "transforms", "rel
 # flagged for review instead of being published as confirmed structure.
 GENERIC_OPERATIONS = {"transform", "relate", "connect", "support", "associate", ""}
 
+# Graph layers (issue #306). The main graph carries aggregated, high-level
+# theory-operation nodes; the equation_detail graph keeps one node per
+# derivation step; the debug layer holds fallback / inferred nodes.
+GRAPH_LAYER_MAIN = "main"
+GRAPH_LAYER_EQUATION_DETAIL = "equation_detail"
+GRAPH_LAYER_DEBUG = "debug"
+GRAPH_LAYERS = [GRAPH_LAYER_MAIN, GRAPH_LAYER_EQUATION_DETAIL, GRAPH_LAYER_DEBUG]
+
+# Component-type vocabulary for the two graph layers (issue #306).
+THEORY_OPERATION_NODE = "TheoryOperationNode"  # aggregated, main graph
+EQUATION_OPERATION_NODE = "EquationOperationNode"  # per-step, detail graph
+
+# Map a node's source-backing status to a review_status (issue #306). A
+# source-backed node should not stay ``teacher_review_required`` by default;
+# inferred / review_required nodes must surface as review_required.
+REVIEW_STATUS_BY_BACKING = {
+    "source_backed": "source_backed",
+    "partially_source_backed": "teacher_review_required",
+    "inferred": "review_required",
+    "review_required": "review_required",
+}
+
+
+def review_status_for_backing(source_backing_status: str) -> str:
+    """Return the review_status implied by a node's source-backing status."""
+    key = str(source_backing_status or "").strip().lower()
+    return REVIEW_STATUS_BY_BACKING.get(key, "review_required")
+
 # Full operation name → (verb, edge_type) for ontology operations that do not
 # follow the simple ``<prefix>_<object>`` shape.
 _OPERATION_FULL_MAP = {
@@ -191,6 +219,11 @@ class ComponentGraphNode:
     # Set explicitly by the normalizer; "" means not yet classified.
     source_backing_status: str = ""
     review_reasons: list[str] = field(default_factory=list)
+    # Layer linkage (issue #306). A main TheoryOperationNode lists the
+    # equation_detail nodes it aggregates in ``member_component_ids``; each
+    # equation_detail node points back at its main node via ``parent_component_id``.
+    parent_component_id: str = ""
+    member_component_ids: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -291,6 +324,8 @@ class ComponentGraphResult:
                     "linked_evidence_ids": n.linked_evidence_ids,
                     "source_backing_status": n.source_backing_status,
                     "review_reasons": n.review_reasons,
+                    "parent_component_id": n.parent_component_id,
+                    "member_component_ids": n.member_component_ids,
                 }
                 for n in self.nodes
             ],

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -193,6 +193,34 @@ def test_source_backed_node_is_not_teacher_review_required():
     assert backed.linked_evidence_ids == ["ev_1"]
 
 
+def test_evidence_backed_node_without_atomic_claim_keeps_warning():
+    # A step backed by an equation + evidence link but no atomic claim is
+    # source_backed (acceptance: backing exists) yet must still warn that no
+    # minimal atomic claim supports the node's meaning (issue #306).
+    derivations = DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[DerivationChainRecord(
+            derivation_id="deriv",
+            document_id="doc",
+            source_section_ids=[],
+            steps=[
+                _step("derive_result", ["eq_a"], ["eq_b"], source_evidence_ids=["ev_1"]),
+            ],
+        )],
+    )
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    node = next(n for n in _layer(result, "main"))
+    assert node.linked_evidence_ids == ["ev_1"]
+    assert node.linked_claim_ids == []
+    # Backed by evidence → source_backed, but the atomic-claim gap is retained.
+    assert node.source_backing_status == "source_backed"
+    assert node.review_status == "source_backed"
+    assert node.review_reasons == ["missing_atomic_claim"]
+
+
 def test_equation_only_node_flags_missing_atomic_claim():
     result = _normalized()
     define = next(n for n in _layer(result, "main") if n.operation == "define")

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -1,6 +1,7 @@
 from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
 from episteme_graph.agents.component_graph.normalizer import (
     ComponentGraphNormalizer,
+    _claim_is_atomic,
     _edge_backing,
 )
 from episteme_graph.agents.component_graph.schema import GRAPH_SCHEMA_VERSION, ComponentGraphResult
@@ -78,94 +79,227 @@ def _empty_graph():
     )
 
 
-def _normalized():
-    return ComponentGraphNormalizer().normalize(_empty_graph(), _empty_components(), _derivations())
+def _normalized(claim_index=None):
+    return ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _derivations(), claim_index=claim_index
+    )
 
 
-def test_normalizer_builds_domain_independent_theory_graph():
+def _layer(result, layer):
+    return [n for n in result.nodes if n.graph_layer == layer]
+
+
+# --- layering (acceptance #1, #2, #12) --------------------------------------
+
+
+def test_main_graph_is_smaller_than_detail_graph():
     result = _normalized()
-    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
+    main_nodes = _layer(result, "main")
+    detail_nodes = _layer(result, "equation_detail")
+    debug_nodes = _layer(result, "debug")
 
-    # One theory-operation node per derivation step, all typed and source-linked.
-    assert len(main_nodes) == 6
+    # 6 derivation steps → 5 non-generic steps become main nodes (one per
+    # operation family), and every step is preserved in the detail/debug layer.
+    assert len(main_nodes) == 5
+    assert len(detail_nodes) + len(debug_nodes) == 6
+    assert len(main_nodes) < len(detail_nodes) + len(debug_nodes)
     assert all(n.component_type == "TheoryOperationNode" for n in main_nodes)
-    assert all(n.operation for n in main_nodes)
+    assert all(n.component_type == "EquationOperationNode" for n in detail_nodes)
 
-    # No bare generic labels in the main graph (acceptance #9).
-    labels = {n.label for n in main_nodes}
-    assert "Define" not in labels
-    assert "Transform" not in labels
-    assert "Relate" not in labels
-    assert "Result" not in labels
 
-    # Labels are derived deterministically from operation + equations.
-    assert "Define eq_b" in labels
+def test_equation_steps_aggregate_into_one_main_node():
+    # Two linearization steps in the same chain collapse into a single main node.
+    derivations = DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[DerivationChainRecord(
+            derivation_id="deriv",
+            document_id="doc",
+            source_section_ids=[],
+            steps=[
+                _step("define", ["eq_a"], ["eq_b"]),
+                _step("linearize_first", ["eq_b"], ["eq_c"]),
+                _step("linearize_second", ["eq_c"], ["eq_d"]),
+            ],
+        )],
+    )
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_nodes = _layer(result, "main")
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(main_nodes) == 2  # defines + linearizes
+    assert len(detail_nodes) == 3
+    linearizes = next(n for n in main_nodes if n.operation.startswith("linearize"))
+    assert len(linearizes.member_component_ids) == 2
+
+
+def test_detail_nodes_point_back_at_main_node():
+    result = _normalized()
+    main_by_id = {n.component_id: n for n in _layer(result, "main")}
+    for detail in _layer(result, "equation_detail"):
+        assert detail.parent_component_id in main_by_id
+        assert detail.component_id in main_by_id[detail.parent_component_id].member_component_ids
+
+
+# --- labels (acceptance #3, #4) ---------------------------------------------
+
+
+def test_main_labels_are_not_bare_generic():
+    result = _normalized()
+    labels = {n.label for n in _layer(result, "main")}
+    for generic in ("Define", "Transform", "Relate", "Result"):
+        assert generic not in labels
+    # Labels are operation + object phrases.
+    assert any(l.startswith("Linearize") for l in labels)
     assert any(l.startswith("Eliminate second order parameter") for l in labels)
 
 
-def test_normalizer_maps_operations_to_edge_types():
-    result = _normalized()
-    edge_types = {edge.edge_type for edge in result.edges}
-    # define -> defines isn't produced as an edge unless its output is consumed;
-    # the consuming operations drive the edge type (acceptance #5).
-    assert "solves" not in edge_types  # no solve_* step in this chain
-    assert {"linearizes", "eliminates", "derives", "diagnoses"} <= edge_types
+def test_main_label_prefers_atomic_claim_text():
+    claim_index = {
+        "claim_1": {"text": "second-order moment vanishes", "evidence_text": "p.4", "is_atomic": True},
+    }
+    result = _normalized(claim_index)
+    eliminate = next(n for n in _layer(result, "main") if n.operation.startswith("eliminate"))
+    assert "second-order moment vanishes" in eliminate.label
 
-    # Every backed edge carries derivation + equation evidence (acceptance #2).
-    backed = [e for e in result.edges if e.review_status == "source_backed"]
-    assert backed
-    for edge in backed:
+
+# --- generic operations (acceptance #5) -------------------------------------
+
+
+def test_generic_operations_excluded_from_main_graph():
+    result = _normalized()
+    main_ops = {n.operation for n in _layer(result, "main")}
+    assert "transform" not in main_ops
+
+    # The generic step is kept in the debug layer, flagged as inferred.
+    debug = _layer(result, "debug")
+    generic = next(n for n in debug if n.operation == "transform")
+    assert generic.source_backing_status == "inferred"
+    assert "fallback_or_inferred_node" in generic.review_reasons
+
+
+# --- source backing / review status (acceptance #6, #7, #8, #9) -------------
+
+
+def test_source_backed_node_is_not_teacher_review_required():
+    result = _normalized()
+    backed = next(n for n in _layer(result, "main") if n.operation.startswith("eliminate"))
+    assert backed.source_backing_status == "source_backed"
+    assert backed.review_status == "source_backed"
+    assert backed.review_reasons == []
+    assert backed.publish_ready is True
+    assert backed.linked_claim_ids == ["claim_1"]
+    assert backed.linked_evidence_ids == ["ev_1"]
+
+
+def test_equation_only_node_flags_missing_atomic_claim():
+    result = _normalized()
+    define = next(n for n in _layer(result, "main") if n.operation == "define")
+    # Backed only by equation IDs → partially source-backed, never source_backed.
+    assert define.source_backing_status == "partially_source_backed"
+    assert "missing_atomic_claim" in define.review_reasons
+    assert define.review_status == "teacher_review_required"
+
+
+def test_review_required_nodes_and_edges_have_reasons():
+    result = _normalized()
+    for node in result.nodes:
+        if node.review_status == "review_required":
+            assert node.review_reasons, f"{node.component_id} missing review_reasons"
+    for edge in result.edges:
+        if edge.review_status == "review_required":
+            assert edge.review_reasons, f"{edge.edge_id} missing review_reasons"
+
+
+def test_no_node_is_uniformly_teacher_review_required():
+    result = _normalized()
+    statuses = {n.review_status for n in result.nodes}
+    # The mapping yields a spread of statuses, not a single default.
+    assert "source_backed" in statuses
+    assert statuses != {"teacher_review_required"}
+
+
+# --- edges (acceptance #2, #5) ----------------------------------------------
+
+
+def test_main_edges_carry_operation_edge_types():
+    result = _normalized()
+    main_ids = {n.component_id for n in _layer(result, "main")}
+    main_edges = [e for e in result.edges if e.source in main_ids and e.target in main_ids]
+    edge_types = {e.edge_type for e in main_edges}
+    assert {"linearizes", "eliminates", "derives", "diagnoses"} <= edge_types
+    assert "solves" not in edge_types
+    for edge in main_edges:
         assert edge.evidence_equation_ids
         assert edge.evidence_derivation_ids
 
 
-def test_normalizer_flags_generic_operations_for_review():
+def test_generic_step_edge_in_detail_is_review_required():
     result = _normalized()
-    generic = next(n for n in result.nodes if n.operation == "transform")
-    assert generic.source_backing_status == "inferred"
-    assert "fallback_or_inferred_node" in generic.review_reasons
-
-    # The edge into the generic node is review_required with explicit reasons.
-    generic_edges = [e for e in result.edges if e.target == generic.component_id]
-    assert generic_edges
-    assert all(e.review_status == "review_required" for e in generic_edges)
-    assert all(e.review_reasons for e in generic_edges)
+    debug_ids = {n.component_id for n in _layer(result, "debug")}
+    into_generic = [e for e in result.edges if e.target in debug_ids]
+    assert into_generic
+    assert all(e.review_status == "review_required" for e in into_generic)
+    assert all(e.review_reasons for e in into_generic)
 
 
-def test_normalizer_promotes_fully_backed_nodes():
-    result = _normalized()
-    # The eliminate step carries a claim + evidence link → source_backed.
-    backed = next(n for n in result.nodes if n.operation == "eliminate_second_order_parameter")
-    assert backed.source_backing_status == "source_backed"
-    assert backed.review_reasons == []
-    assert backed.linked_claim_ids == ["claim_1"]
-    assert backed.linked_evidence_ids == ["ev_1"]
-    assert backed.linked_equation_ids
-    assert backed.linked_derivation_ids
-    assert backed.eliminated_symbols == ["b2"]
+# --- atomic claim selection (acceptance #10, #11) ---------------------------
 
 
-def test_normalizer_review_required_nodes_have_reasons():
-    result = _normalized()
-    for node in result.nodes:
-        if node.source_backing_status == "review_required":
-            assert node.review_reasons, f"{node.component_id} missing review_reasons"
+def test_non_atomic_claim_is_not_strong_backing():
+    # claim_1 is a long, paper-level claim with empty evidence → not strong.
+    claim_index = {
+        "claim_1": {
+            "text": "x" * 400,
+            "evidence_text": "",
+            "claim_level": "paper",
+            "is_atomic": False,
+        },
+    }
+    result = _normalized(claim_index)
+    eliminate = next(n for n in _layer(result, "main") if n.operation.startswith("eliminate"))
+    # It still has evidence (ev_1) so it remains source-backed via evidence, but
+    # the claim itself must not be treated as the atomic backing.
+    assert "claim_1" in eliminate.linked_claim_ids
 
 
-def test_normalizer_diagnostic_backed_by_upstream_results():
-    result = _normalized()
-    diagnostic = next(n for n in result.nodes if n.operation == "apply_criterion")
-    incoming = {e.source for e in result.edges if e.target == diagnostic.component_id}
-    # The diagnostic node is fed by the upstream derivation node (acceptance #7).
-    derive_node = next(n for n in result.nodes if n.operation == "derive_consistency_relation")
-    assert derive_node.component_id in incoming
+def test_empty_evidence_claim_does_not_make_node_source_backed():
+    derivations = DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[DerivationChainRecord(
+            derivation_id="deriv",
+            document_id="doc",
+            source_section_ids=[],
+            steps=[
+                _step("derive_result", ["eq_a"], ["eq_b"], required_claim_ids=["claim_x"]),
+            ],
+        )],
+    )
+    claim_index = {
+        "claim_x": {"text": "x" * 400, "evidence_text": "", "claim_level": "paper"},
+    }
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations, claim_index=claim_index
+    )
+    node = next(n for n in _layer(result, "main"))
+    # No evidence and only a non-atomic claim → not source_backed.
+    assert node.source_backing_status != "source_backed"
+    assert "missing_atomic_claim" in node.review_reasons
 
 
-# --- issue #304 regression tests --------------------------------------------
+def test_claim_is_atomic_heuristic():
+    assert _claim_is_atomic({"text": "short atomic claim", "evidence_text": "p1"})
+    assert not _claim_is_atomic({"text": "x" * 400})
+    assert not _claim_is_atomic({"text": "ok", "claim_level": "paper"})
+    assert not _claim_is_atomic({"text": "ok", "is_atomic": False})
+
+
+# --- issue #304 regression --------------------------------------------------
 
 
 def test_edge_backing_treats_derivation_evidence_as_source_backed():
-    """An edge with only evidence_derivation_ids is source-backed (issue #304)."""
     status, reasons = _edge_backing(
         evidence_equation_ids=[],
         is_generic=False,
@@ -175,7 +309,6 @@ def test_edge_backing_treats_derivation_evidence_as_source_backed():
     assert status == "source_backed"
     assert reasons == []
 
-    # No backing at all is still review_required with a reason.
     status, reasons = _edge_backing(
         evidence_equation_ids=[],
         is_generic=False,
@@ -202,7 +335,6 @@ def _short_derivations(steps):
 
 
 def test_normalizer_reflects_two_step_derivation_chain():
-    """A 1–2 step chain still produces operation-derived nodes/edges (issue #304)."""
     derivations = _short_derivations([
         _step("define", ["eq_a"], ["eq_b"]),
         _step("linearize_moment_equations", ["eq_b"], ["eq_c"]),
@@ -210,13 +342,8 @@ def test_normalizer_reflects_two_step_derivation_chain():
     result = ComponentGraphNormalizer().normalize(
         _empty_graph(), _empty_components(), derivations
     )
-    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
-    # Both derivation steps surface as main theory-operation nodes.
+    main_nodes = _layer(result, "main")
     assert len(main_nodes) == 2
-    assert all(n.component_type == "TheoryOperationNode" for n in main_nodes)
-
-    # The operation-derived edge type reaches the graph instead of being
-    # dropped back to the component fallback view.
     edge_types = {edge.edge_type for edge in result.edges}
     assert "linearizes" in edge_types
 
@@ -228,6 +355,6 @@ def test_normalizer_reflects_single_step_derivation_chain():
     result = ComponentGraphNormalizer().normalize(
         _empty_graph(), _empty_components(), derivations
     )
-    main_nodes = [n for n in result.nodes if n.graph_layer == "main"]
+    main_nodes = _layer(result, "main")
     assert len(main_nodes) == 1
     assert main_nodes[0].operation == "derive_consistency_relation"


### PR DESCRIPTION
## Summary

Refactor the ComponentGraph normalizer to produce a **two-layer theory graph** that separates aggregated, high-level theory operations (main layer) from equation-level derivation steps (equation_detail layer). This addresses issue #306 and improves graph readability while preserving full traceability.

## Key Changes

### Backend (Python)

- **Graph layering architecture**:
  - `main` layer: Aggregated theory-operation nodes (`TheoryOperationNode`) grouped by `(derivation_id, operation_family)`. Generic operations never form main nodes.
  - `equation_detail` layer: One node per derivation step (`EquationOperationNode`), preserving the full equation-by-equation trace.
  - `debug` layer: Fallback/inferred nodes and generic steps.

- **Normalizer refactoring** (`src/episteme_graph/agents/component_graph/normalizer.py`):
  - Replaced single-layer node generation with `_group_records()` to aggregate consecutive equation steps sharing a derivation and operation family.
  - Introduced `_main_node_from_group()` and `_detail_node_from_record()` to build nodes for each layer.
  - Added bidirectional linking: detail nodes reference their main node via `parent_component_id`; main nodes list detail members via `member_component_ids`.
  - Separated edge generation into `_main_edges_from_groups()` (high-level theory flow) and `_detail_edges_from_records()` (equation-level data flow).

- **Atomic claim preference** (acceptance #10/#11):
  - Added `claim_index` parameter to `normalize()` to enable atomic-claim-aware labeling and backing status.
  - Introduced `_atomic_claim_ids()` and `_claim_is_atomic()` to filter claims by `is_atomic` flag and evidence presence.
  - Main node labels now prefer atomic claim text over equation IDs; nodes without atomic backing are flagged with `missing_atomic_claim` reason.

- **Review status mapping** (acceptance #6–#9):
  - Introduced `review_status_for_backing()` function to map `source_backing_status` to `review_status`, ensuring source-backed nodes are not uniformly marked `teacher_review_required`.
  - Updated `_node_backing()` to accept `atomic_claim_ids` parameter for stronger backing detection.

- **Schema updates** (`src/episteme_graph/agents/component_graph/schema.py`):
  - Added layer constants: `GRAPH_LAYER_MAIN`, `GRAPH_LAYER_EQUATION_DETAIL`, `GRAPH_LAYER_DEBUG`.
  - Added component-type constants: `THEORY_OPERATION_NODE`, `EQUATION_OPERATION_NODE`.
  - Added `REVIEW_STATUS_BY_BACKING` mapping dictionary.
  - Extended `ComponentGraphNode` with `parent_component_id` and `member_component_ids` fields for layer linkage.

- **Agent integration** (`src/episteme_graph/agents/component_graph/agent.py`):
  - Added `_build_claim_index()` to extract atomic-claim metadata from claim objects.
  - Passes `claim_index` to normalizer for atomic-claim-aware processing.

### Frontend (JavaScript/CSS)

- **Graph layer toggle UI** (`frontend/public/js/admin.js`):
  - Added `graphLayerFilter` state to track the currently displayed layer (`"main"` | `"equation_detail"` | `"all"`).
  - Implemented `lsGraphLayerOptions()` to detect available layers and build toggle buttons.
  - Implemented `lsGraphLayerToolbar()` to render the layer-selection toolbar with node counts.
  - Implemented `lsGraphForCurrentLayer()` to filter nodes and edges based on the selected layer; edges are kept only when both endpoints remain visible.
  - Integrated toolbar binding and graph re-rendering on layer selection.

- **Styling** (`frontend/public/css/styles.css`):
  - Added `.ls-graph-layer-toolbar` and `.ls-graph-

https://claude.ai/code/session_013jMjEvSuvqCtgJXvLmUgTe