### PR TITLE
Refactor main graph aggregation to theory stages (issue #308)

### DIFF
--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -283,8 +283,9 @@ prefix から導出し、特定分野・特定論文の用語をハードコー�
   `linearizes・approximates・substitutes→equation_system` / `solves・eliminates→elimination` /
   `derives・constrains→consistency_relation` / `diagnoses・compares→diagnostic_application`)、
   全 derivation を跨いで集約する。stage 語彙は `schema.THEORY_STAGES`、表示名は
-  `schema.THEORY_STAGE_LABELS`。main label は stage label を基本とし、atomic claim/reason があれば
-  `Stage: phrase` で補助する。**equation ID fallback は使わない**ので `Define eq_...` /
+  `schema.THEORY_STAGE_LABELS`。main label は短い stage label **そのもの**を使い、atomic claim/reason
+  のような長い説明は label に詰めず node の `description` フィールドへ入れて UI 詳細ペインで表示する
+  （`Stage: 長い説明` の形にはしない）。**equation ID fallback は使わない**ので `Define eq_...` /
   `Derive result eq_...` は main に出ない。generic operation
   (`transform`/`relate`/`connect`/`support`/`associate`) も main にしない。validator は main node の
   equation-id label・generic operation を hard error として検出する (#308)。

--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -274,14 +274,30 @@ cd src && python -m pytest tests/ -v
 決定論的に構築する。node label / edge type は `schema.classify_operation()` が `operation` の
 prefix から導出し、特定分野・特定論文の用語をハードコードしない。
 
-グラフは 2 層に分離する (#306):
+グラフは 2 層に分離する (#306 / #308):
 
 - **main 層** (`graph_layer="main"`, `component_type="TheoryOperationNode"`): 上位理論構成。
-  式 step を `(derivation_id, operation family)` で集約した少数 node。generic operation
-  (`transform`/`relate`/`connect`/`support`/`associate`) は main にしない。
+  式 step を **theory stage** で集約した少数 node（5–8 個程度のバックボーン）。stage は
+  `schema.stage_for_edge_type()` が operation の edge_type family から domain-neutral に導出し
+  (`defines→theory_basis` / `constructs・normalizes→observable_construction` /
+  `linearizes・approximates・substitutes→equation_system` / `solves・eliminates→elimination` /
+  `derives・constrains→consistency_relation` / `diagnoses・compares→diagnostic_application`)、
+  全 derivation を跨いで集約する。stage 語彙は `schema.THEORY_STAGES`、表示名は
+  `schema.THEORY_STAGE_LABELS`。main label は stage label を基本とし、atomic claim/reason があれば
+  `Stage: phrase` で補助する。**equation ID fallback は使わない**ので `Define eq_...` /
+  `Derive result eq_...` は main に出ない。generic operation
+  (`transform`/`relate`/`connect`/`support`/`associate`) も main にしない。validator は main node の
+  equation-id label・generic operation を hard error として検出する (#308)。
 - **equation_detail 層** (`graph_layer="equation_detail"`, `component_type="EquationOperationNode"`):
-  derivation step ごとの式単位 node。`parent_component_id` で main node を、main node は
-  `member_component_ids` で detail node を相互参照する。generic step は `debug` 層へ。
+  derivation step ごとの式単位 node（ここでは equation ID 入り label を許容）。`parent_component_id` で
+  main node を、main node は `member_component_ids` で detail node を相互参照する。generic step は
+  `debug` 層へ。
+- **ComponentRefiner は「1 component = 1 reusable theory unit」(#308)**:
+  `component_assembly/component_refiner.py` は derivation step を **operation family** 単位の
+  再利用可能な理論ユニットに分割する（式 step 1 個 = 1 component ではない）。同 family の複数 step は
+  1 component に集約し `internal_flow` に保持する。generic operation だけでは child component を作らず、
+  近接ユニットの `internal_flow` に畳み込む。component の label/summary は generic 操作名ではなく
+  理論対象を表す。
 
 その他の必須ルール:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,12 +195,26 @@ examples/          → サンプル入出力JSON
   `fallback_or_inferred_node` / `source_span_missing` から選ぶ）。
 - **fallback / inferred node を main graph で確定扱いしない**: `deterministic_fallback` や
   `inferred` の node は `graph_layer = "debug"` に分離し、`source_backed` にしてはならない（hard error）。
-- **graph を 2 層に分離する (#306)**: main graph は上位理論構成を表す少数の集約 node
+- **graph を 2 層に分離する (#306 / #308)**: main graph は上位理論構成を表す少数の集約 node
   (`graph_layer = "main"`, `component_type = "TheoryOperationNode"`)、式単位の step は
   (`graph_layer = "equation_detail"`, `component_type = "EquationOperationNode"`) に保持する。
-  式 step は `(derivation_id, operation family)` で集約して main node を作り、各 detail node は
-  `parent_component_id`、各 main node は `member_component_ids` で相互参照する。
+  各 detail node は `parent_component_id`、各 main node は `member_component_ids` で相互参照する。
   generic operation は main node にしない（detail / debug に置き `inferred`）。
+- **main graph は theory stage 単位で集約する (#308)**: 式 step は `(derivation_id, operation family)`
+  ではなく **theory stage** で集約する。stage は `schema.stage_for_edge_type()` が operation の
+  edge_type family から domain-neutral に導出する（`defines → theory_basis` /
+  `constructs・normalizes → observable_construction` / `linearizes・approximates・substitutes →
+  equation_system` / `solves・eliminates → elimination` / `derives・constrains →
+  consistency_relation` / `diagnoses・compares → diagnostic_application`）。stage は全 derivation
+  を跨いで集約されるため、main graph は理論構成 5–8 個程度のバックボーンになる。stage の候補語彙は
+  `schema.THEORY_STAGES` / 表示名は `schema.THEORY_STAGE_LABELS`。特定分野・特定論文の用語は使わない。
+- **main label は theory stage label にする (#308)**: main node の label は stage label
+  （`Theory basis` / `Observation model` / `Observable construction` / `Equation system` /
+  `Elimination` / `Consistency relation` / `Diagnostic / application`）を基本とし、atomic claim /
+  meaningful reason があれば `Stage: phrase` で補助する。**equation ID fallback は使わない**ので
+  `Define eq_2_7` / `Derive result eq_...` のような label は main に出ない。validator は main node の
+  equation-id label (`main_graph_node_equation_id_label`) と generic operation
+  (`main_graph_generic_operation`) を hard error として検出する。
 - **review_status は source_backing_status から導出する (#306)**: `schema.review_status_for_backing()`
   が `source_backed → source_backed` / `partially_source_backed → teacher_review_required` /
   `inferred・review_required → review_required` にマップする。全 node を一律

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,13 +208,14 @@ examples/          → サンプル入出力JSON
   consistency_relation` / `diagnoses・compares → diagnostic_application`）。stage は全 derivation
   を跨いで集約されるため、main graph は理論構成 5–8 個程度のバックボーンになる。stage の候補語彙は
   `schema.THEORY_STAGES` / 表示名は `schema.THEORY_STAGE_LABELS`。特定分野・特定論文の用語は使わない。
-- **main label は theory stage label にする (#308)**: main node の label は stage label
+- **main label は短い theory stage label にする (#308)**: main node の label は stage label
   （`Theory basis` / `Observation model` / `Observable construction` / `Equation system` /
-  `Elimination` / `Consistency relation` / `Diagnostic / application`）を基本とし、atomic claim /
-  meaningful reason があれば `Stage: phrase` で補助する。**equation ID fallback は使わない**ので
-  `Define eq_2_7` / `Derive result eq_...` のような label は main に出ない。validator は main node の
-  equation-id label (`main_graph_node_equation_id_label`) と generic operation
-  (`main_graph_generic_operation`) を hard error として検出する。
+  `Elimination` / `Consistency relation` / `Diagnostic / application`）**そのもの**を使い、短く保つ。
+  atomic claim text や step reason のような長い説明は label に詰め込まず、node の `description`
+  フィールドに入れて UI 詳細ペインで表示する（`Stage: 長い説明文` のような label は作らない）。
+  **equation ID fallback は使わない**ので `Define eq_2_7` / `Derive result eq_...` のような label は
+  main に出ない。validator は main node の equation-id label (`main_graph_node_equation_id_label`) と
+  generic operation (`main_graph_generic_operation`) を hard error として検出する。
 - **review_status は source_backing_status から導出する (#306)**: `schema.review_status_for_backing()`
   が `source_backed → source_backed` / `partially_source_backed → teacher_review_required` /
   `inferred・review_required → review_required` にマップする。全 node を一律

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -1951,6 +1951,7 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "summary": str(node.get("summary") or (component.summary if component else "")),
             "operation": str(node.get("operation") or ""),
             "theory_object": str(node.get("theory_object") or ""),
+            "description": str(node.get("description") or ""),
             "graph_layer": str(node.get("graph_layer") or "main"),
             "maturity_source": str(node.get("maturity_source") or ""),
             "publish_ready": bool(node.get("publish_ready", False)),

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5465,6 +5465,9 @@
       });
       html += '</ul></div>';
     }
+    if (node.description) {
+      html += '<div class="ls-graph-detail-section"><b>説明</b><p>' + escHtml(node.description) + '</p></div>';
+    }
     var links = lsGraphSourceLinksHtml(node);
     if (links) {
       html += '<div class="ls-graph-detail-section"><b>出典リンク</b>' + links + '</div>';

--- a/src/episteme_graph/agents/component_assembly/component_refiner.py
+++ b/src/episteme_graph/agents/component_assembly/component_refiner.py
@@ -13,10 +13,19 @@ the real theory structure (one step = one operation, with input/output equations
 eliminated/retained symbols) — to detect over-large components and split them so
 that:
 
-    1 component = 1 main theoretical operation
+    1 component = 1 reusable theory unit
+
+A *reusable theory unit* is a theory-operation **family** (linearize / solve /
+eliminate / derive / …), not a single equation step (issue #308). Several
+equation steps of the same family collapse into one component and are preserved
+in its ``internal_flow``. Generic operations (``transform`` / ``relate`` /
+``connect`` / ``support`` / empty) never spawn a standalone child — they are kept
+inside the nearest unit's ``internal_flow`` so the catalogue of reusable
+components stays at the theory-unit altitude. Component labels/summaries describe
+the theory object, not a bare operation name.
 
 The boundary is decided by *theory structure*, not explanation style:
-inputs change, outputs change, the operation changes, eliminated symbols change.
+inputs change, outputs change, the operation family changes, symbols change.
 """
 from __future__ import annotations
 
@@ -38,6 +47,11 @@ _DERIVATION_TYPES = {
     "MethodComponent",
     "CorrectionComponent",
 }
+
+# Generic operations that do not name a reusable theory unit (issue #308). Steps
+# carrying these never form a standalone child component; they are folded into
+# the nearest unit's internal_flow instead.
+_GENERIC_OPERATIONS = {"transform", "relate", "connect", "support", "associate", ""}
 
 
 @dataclass
@@ -136,7 +150,7 @@ class ComponentRefiner:
         chains: list,
         report: RefinementReport,
     ) -> list[ComponentRecord]:
-        groups = self._operation_groups(component, chains)
+        groups, generic_steps = self._operation_groups(component, chains)
 
         if component.component_type not in _DERIVATION_TYPES or len(groups) < 2:
             # Nothing to split: make sure the component still has a single
@@ -144,9 +158,15 @@ class ComponentRefiner:
             self._finalize_single(component, eq_index, groups)
             return [component]
 
+        # Generic steps never form their own component; fold them into the unit
+        # whose equations they touch (else the last unit) so they survive in the
+        # internal_flow without polluting the reusable-component catalogue.
+        family_steps = {family: list(steps) for family, steps in groups.items()}
+        self._absorb_generic_steps(family_steps, generic_steps)
+
         children: list[ComponentRecord] = []
-        for idx, (op_key, steps) in enumerate(groups.items(), start=1):
-            child = self._build_child(component, idx, op_key, steps, eq_index)
+        for idx, (family, steps) in enumerate(family_steps.items(), start=1):
+            child = self._build_child(component, idx, family, steps, eq_index)
             children.append(child)
 
         # Chain the children sequentially so the derivation order is preserved.
@@ -154,7 +174,7 @@ class ComponentRefiner:
             nxt.dependencies.append({
                 "dependency_type": "depends_on",
                 "component_refs": [prev.component_id],
-                "reason": "Sequential theory-operation dependency from ComponentRefiner.",
+                "reason": "Sequential theory-unit dependency from ComponentRefiner.",
             })
 
         report.split_actions.append(RefinementAction(
@@ -163,21 +183,26 @@ class ComponentRefiner:
             child_component_ids=[c.component_id for c in children],
             operations=[c.operation for c in children],
             reason=(
-                f"Component bundled {len(groups)} distinct theoretical operations; "
-                "split into one component per operation (issue #300)."
+                f"Component bundled {len(family_steps)} distinct reusable theory "
+                "units; split into one component per theory-operation family "
+                "(issue #308)."
             ),
         ))
         return children
 
-    def _operation_groups(self, component: ComponentRecord, chains: list) -> dict:
-        """Group derivation steps relevant to the component by their operation.
+    def _operation_groups(self, component: ComponentRecord, chains: list) -> tuple[dict, list]:
+        """Group derivation steps relevant to the component by theory-unit family.
 
-        Order is preserved (first-seen operation first) so children keep the
-        natural derivation order.
+        Returns ``(family_groups, generic_steps)``. Steps are bucketed by their
+        operation *family* (issue #308) so several equation steps of the same
+        family form one reusable unit; order is preserved (first-seen family
+        first). Generic-operation steps are collected separately and never become
+        their own family.
         """
         component_eqs = set(_all_equation_ids(component))
         linked_ids = set(component.linked_derivation_ids or [])
         groups: dict[str, list] = {}
+        generic_steps: list = []
         for chain in chains:
             chain_id = getattr(chain, "derivation_id", None)
             linked_components = set(getattr(chain, "linked_component_ids", []) or [])
@@ -194,8 +219,37 @@ class ComponentRefiner:
                 operation = str(getattr(step, "operation", "") or "").strip()
                 if not operation:
                     continue
-                groups.setdefault(operation, []).append(step)
-        return groups
+                if _is_generic_operation(operation):
+                    generic_steps.append(step)
+                    continue
+                family = _operation_family(operation)
+                groups.setdefault(family, []).append(step)
+        return groups, generic_steps
+
+    @staticmethod
+    def _absorb_generic_steps(family_steps: dict, generic_steps: list) -> None:
+        """Fold generic steps into the family unit they share equations with."""
+        if not generic_steps or not family_steps:
+            return
+        family_eqs = {
+            family: {
+                eid
+                for step in steps
+                for eid in _step_field(step, "input_equation_ids") + _step_field(step, "output_equation_ids")
+            }
+            for family, steps in family_steps.items()
+        }
+        families = list(family_steps.keys())
+        for step in generic_steps:
+            eqs = set(
+                _step_field(step, "input_equation_ids")
+                + _step_field(step, "output_equation_ids")
+            )
+            target = next(
+                (family for family in families if eqs & family_eqs[family]),
+                families[-1],
+            )
+            family_steps[target].append(step)
 
     def _build_child(
         self,
@@ -227,7 +281,11 @@ class ComponentRefiner:
         )
 
         family = _operation_family(operation)
-        label = _humanize_operation(operation, parent.label)
+        # Label / summary describe the theory object (the parent's theoretical
+        # subject) qualified by the reusable unit's family — not a bare operation
+        # name like "Transform" / "Relate" (issue #308).
+        label = _theory_unit_label(family, parent, eliminated or retained)
+        summary = _theory_unit_summary(label, family, parent, len(steps))
 
         internal_flow = _build_internal_flow(steps, family)
         review_required = bool(classification.review_required_equation_ids) or any(
@@ -242,7 +300,7 @@ class ComponentRefiner:
             component_id=f"{parent.component_id}__op{idx}",
             component_type=parent.component_type,
             label=label,
-            summary=f"{label} (refined theory operation derived from {parent.label}).",
+            summary=summary,
             inputs=[{"name": eid, "equation_ids": [eid]} for eid in input_eqs] or list(parent.inputs),
             outputs=[{"name": eid, "equation_ids": [eid]} for eid in output_eqs] or list(parent.outputs),
             preconditions=list(parent.preconditions),
@@ -375,6 +433,36 @@ def _humanize_operation(operation: str, parent_label: str) -> str:
     if not words:
         return parent_label
     return words[:1].upper() + words[1:]
+
+
+def _is_generic_operation(operation: str) -> bool:
+    """True if an operation is too generic to name a reusable theory unit."""
+    return str(operation or "").strip().lower() in _GENERIC_OPERATIONS
+
+
+def _theory_unit_label(family: str, parent: ComponentRecord, symbols: list[str]) -> str:
+    """Theory-object-centric label for a refined reusable unit (issue #308).
+
+    The label leads with the parent's theoretical subject (its label) and
+    qualifies it with the reusable unit's family, so it never collapses to a bare
+    operation name. When the unit carries distinguishing symbols they are used as
+    the more specific theory object.
+    """
+    verb = _humanize_operation(family, "")
+    object_phrase = ", ".join(symbols[:3]) if symbols else str(parent.label or "").strip()
+    if not object_phrase:
+        return verb or "Theory unit"
+    if not verb:
+        return object_phrase
+    return f"{verb}: {object_phrase}"
+
+
+def _theory_unit_summary(label: str, family: str, parent: ComponentRecord, step_count: int) -> str:
+    subject = str(parent.label or "").strip() or "the parent theory unit"
+    return (
+        f"Reusable theory unit ({family}) within {subject}; "
+        f"covers {step_count} equation step(s)."
+    )
 
 
 def _build_internal_flow(steps: list, family: str) -> list[dict]:

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -20,9 +20,11 @@ Two layers are produced (issue #306):
     … → ``diagnostic_application``, issue #308) so the main graph stays small
     (5–8 nodes) and shows the theory backbone rather than one node per equation
     or operation. The stage is derived domain-neutrally from each step's
-    operation edge_type family; main labels are stage labels (optionally enriched
-    by an atomic claim) and never bare equation IDs. Generic operations
-    (``transform`` / ``relate`` / …) never become confirmed main nodes.
+    operation edge_type family. Main labels are short stage names and never bare
+    equation IDs; any longer atomic-claim / reason phrase is kept in the node's
+    ``description`` (shown in the UI detail pane) rather than crammed into the
+    label. Generic operations (``transform`` / ``relate`` / …) never become
+    confirmed main nodes.
 
 ``equation_detail`` (EquationOperationNode)
     One node per derivation step, preserving the full equation-by-equation
@@ -335,10 +337,13 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
     )
 
     rep = group.get("rep") or _representative_record(records)
-    # Main labels are theory-stage labels (issue #308), optionally enriched by an
-    # atomic claim / meaningful reason. They are never equation-id fallbacks, so
-    # ``eq_...`` can no longer leak into the main graph.
-    label = _build_main_label(stage, records, atomic_claim_ids, claim_index)
+    # Main labels are SHORT theory-stage labels (issue #308): ``Theory basis`` …
+    # ``Diagnostic / application``. They are never equation-id fallbacks, so
+    # ``eq_...`` can no longer leak into the main graph. The longer atomic-claim /
+    # reason phrase that used to be appended to the label now lives in
+    # ``description`` and is shown in the UI's detail pane instead.
+    label = theory_stage_label(stage)
+    description = _build_main_description(records, atomic_claim_ids, claim_index)
 
     definitions = outputs if edge_type == "defines" else []
     constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
@@ -352,6 +357,7 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
         origin="derivation_chain",
         operation=rep["operation"],
         theory_object=_theory_object(rep, atomic_claim_ids, claim_index),
+        description=description,
         graph_layer=GRAPH_LAYER_MAIN,
         maturity_source="derivation_aggregated",
         publish_ready=status == "source_backed",
@@ -692,32 +698,29 @@ def _representative_record(records: list[dict]) -> dict:
     return max(records, key=lambda r: (len(str(r["operation"] or "")), -r["order"]))
 
 
-def _build_main_label(
-    stage: str,
+def _build_main_description(
     records: list[dict],
     atomic_claim_ids: list[str],
     claim_index: dict[str, dict],
 ) -> str:
-    """Theory-stage label for a main node (issue #308).
+    """Longer explanation for a main node, shown in the UI detail pane (issue #308).
 
-    The base label is the stage's human-readable name (``Theory basis`` …
-    ``Diagnostic / application``). When an atomic claim or a meaningful step
-    reason is available it enriches the label as ``Stage: phrase``. Equation IDs
-    are never used, so a main node can never be labelled ``Define eq_...`` /
-    ``Derive result eq_...``.
+    The main node's *label* stays short (the theory-stage name). This description
+    carries the human-readable detail: the atomic-claim text if one backs the
+    node, otherwise the first meaningful step reason. Equation-id-only reasons are
+    skipped so the description never degenerates into an equation reference.
+    Returns ``""`` when no meaningful phrase is available.
     """
-    stage_label = theory_stage_label(stage)
-    # 1. atomic claim text (preferred enrichment)
-    claim_phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index)
+    # 1. atomic claim text (preferred)
+    claim_phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index, limit=240)
     if claim_phrase:
-        return f"{stage_label}: {claim_phrase}"
+        return claim_phrase
     # 2. meaningful step reason (skip bare generic words / equation-id-only text)
     for rec in records:
         reason = str(getattr(rec["step"], "reason", "") or "").strip()
         if reason and reason.lower() not in _GENERIC_LABELS and not _looks_like_equation_id(reason):
-            return f"{stage_label}: {reason[:80]}"
-    # 3. stage label alone — always a readable, non-equation backbone label
-    return stage_label
+            return reason[:240]
+    return ""
 
 
 def _looks_like_equation_id(text: str) -> bool:
@@ -732,14 +735,18 @@ def _looks_like_equation_id(text: str) -> bool:
     return bool(re.fullmatch(r"(eq[_\.\s]*\(?\s*[\dA-Za-z\.\)]+\s*[, ]*)+", stripped, re.IGNORECASE))
 
 
-def _atomic_claim_phrase(atomic_claim_ids: list[str], claim_index: dict[str, dict]) -> str:
+def _atomic_claim_phrase(
+    atomic_claim_ids: list[str],
+    claim_index: dict[str, dict],
+    limit: int = 80,
+) -> str:
     for cid in atomic_claim_ids:
         meta = claim_index.get(cid)
         if not meta:
             continue
         text = str(meta.get("text") or meta.get("predicate") or "").strip()
         if text:
-            return text[:80]
+            return text[:limit]
     return ""
 
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -15,11 +15,14 @@ domain-independent: node labels and edge types are derived from each step's
 Two layers are produced (issue #306):
 
 ``main`` (TheoryOperationNode)
-    Aggregated, high-level theory operations. Equation-level steps that share a
-    derivation and an operation family collapse into a single node so the main
-    graph stays small and shows the theory backbone rather than one node per
-    equation. Generic operations (``transform`` / ``relate`` / …) never become
-    confirmed main nodes.
+    Aggregated, high-level theory operations. Equation-level steps collapse into
+    a single node per *theory stage* (``theory_basis`` → ``observation_model`` →
+    … → ``diagnostic_application``, issue #308) so the main graph stays small
+    (5–8 nodes) and shows the theory backbone rather than one node per equation
+    or operation. The stage is derived domain-neutrally from each step's
+    operation edge_type family; main labels are stage labels (optionally enriched
+    by an atomic claim) and never bare equation IDs. Generic operations
+    (``transform`` / ``relate`` / …) never become confirmed main nodes.
 
 ``equation_detail`` (EquationOperationNode)
     One node per derivation step, preserving the full equation-by-equation
@@ -28,6 +31,7 @@ Two layers are produced (issue #306):
 """
 from __future__ import annotations
 
+import re
 from dataclasses import replace
 
 from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
@@ -39,11 +43,14 @@ from .schema import (
     GRAPH_LAYER_EQUATION_DETAIL,
     GRAPH_LAYER_MAIN,
     THEORY_OPERATION_NODE,
+    THEORY_STAGES,
     ComponentGraphEdge,
     ComponentGraphNode,
     ComponentGraphResult,
     classify_operation,
     review_status_for_backing,
+    stage_for_edge_type,
+    theory_stage_label,
 )
 
 _GENERIC_LABELS = {"define", "transform", "relate", "result", "operation"}
@@ -249,44 +256,59 @@ class ComponentGraphNormalizer:
 # ---------------------------------------------------------------------- #
 
 def _group_records(records: list[dict]) -> list[dict]:
-    """Aggregate non-generic step records into main theory-operation groups.
+    """Aggregate non-generic step records into main theory-stage groups.
 
-    Grouping key: ``(derivation_id, operation family)``. Consecutive equation
-    steps that share a derivation and an operation family collapse into one
-    high-level node; generic operations never form a main node (issue #306).
+    Grouping key: the *theory stage* derived from each step's operation edge_type
+    family (issue #308). Steps from every derivation that share a stage collapse
+    into one high-level node, so the main graph reads as a backbone of 5–8 stages
+    rather than one node per equation/operation. Generic operations never form a
+    main node (issue #306/#308); unmapped non-generic edge types fall back to the
+    edge type itself as a pseudo-stage so no concrete operation is dropped.
     """
+    index: dict[str, dict] = {}
     groups: list[dict] = []
-    index: dict[tuple[str, str], dict] = {}
-    order = 0
     for rec in records:
         if rec["is_generic"]:
             continue
-        key = (rec["derivation_id"], rec["edge_type"])
-        group = index.get(key)
+        stage = stage_for_edge_type(rec["edge_type"]) or rec["edge_type"]
+        group = index.get(stage)
         if group is None:
-            order += 1
-            group = {
-                "node_id": f"theory_op_{order:04d}",
-                "order": order,
-                "derivation_id": rec["derivation_id"],
-                "edge_type": rec["edge_type"],
-                "records": [],
-            }
-            index[key] = group
+            group = {"stage": stage, "records": []}
+            index[stage] = group
             groups.append(group)
         group["records"].append(rec)
+
+    # Order groups by the canonical theory-stage progression so the main graph
+    # reads top-to-bottom (basis → … → diagnostic). Unknown stages sort last but
+    # keep first-seen order among themselves.
+    def _stage_rank(group: dict) -> tuple[int, int]:
+        stage = group["stage"]
+        canonical = THEORY_STAGES.index(stage) if stage in THEORY_STAGES else len(THEORY_STAGES)
+        first_order = min(rec["order"] for rec in group["records"])
+        return (canonical, first_order)
+
+    groups.sort(key=_stage_rank)
+    for order, group in enumerate(groups, start=1):
+        group["order"] = order
+        group["node_id"] = f"theory_op_{order:04d}"
+        # Representative record drives the node's operation and the edge_type used
+        # for definition/constraint roles and main edges.
+        rep = _representative_record(group["records"])
+        group["rep"] = rep
+        group["edge_type"] = rep["edge_type"]
     return groups
 
 
 def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> ComponentGraphNode:
     records = group["records"]
     edge_type = group["edge_type"]
+    stage = group["stage"]
 
     inputs = _ordered_unique([eq for rec in records for eq in rec["inputs"]])
     outputs = _ordered_unique([eq for rec in records for eq in rec["outputs"]])
     linked_equation_ids = _ordered_unique(inputs + outputs)
     linked_derivation_ids = _ordered_unique(
-        [group["derivation_id"]] + [rec["step_id"] for rec in records]
+        [rec["derivation_id"] for rec in records] + [rec["step_id"] for rec in records]
     )
     linked_claim_ids = _ordered_unique(
         [cid for rec in records for cid in _step_claim_ids(rec["step"])]
@@ -312,16 +334,11 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
         is_generic=False,
     )
 
-    rep = _representative_record(records)
-    label, label_from_eq_only = _build_main_label(
-        rep, records, inputs, outputs, eliminated, retained, atomic_claim_ids, claim_index
-    )
-    # A node whose label could only be built from an equation ID is, by
-    # definition, not backed by an atomic claim (acceptance #3 / #9). A
-    # source-backed node (it has evidence) keeps its status; only the
-    # remaining cases gain the missing_atomic_claim reason.
-    if label_from_eq_only and status != "source_backed":
-        reasons = _ordered_unique(reasons + ["missing_atomic_claim"])
+    rep = group.get("rep") or _representative_record(records)
+    # Main labels are theory-stage labels (issue #308), optionally enriched by an
+    # atomic claim / meaningful reason. They are never equation-id fallbacks, so
+    # ``eq_...`` can no longer leak into the main graph.
+    label = _build_main_label(stage, records, atomic_claim_ids, claim_index)
 
     definitions = outputs if edge_type == "defines" else []
     constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
@@ -411,8 +428,8 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
                 support_status="derivation_linked",
                 evidence_claims=[],
                 reasoning=(
-                    f"Theory flow: {src['group']['edge_type']} output feeds "
-                    f"{tgt['group']['edge_type']} ({', '.join(overlap)})."
+                    f"Theory flow: {theory_stage_label(src['group']['stage'])} output feeds "
+                    f"{theory_stage_label(tgt['group']['stage'])} ({', '.join(overlap)})."
                 ),
                 confidence=0.9,
                 evidence_equation_ids=overlap,
@@ -676,56 +693,43 @@ def _representative_record(records: list[dict]) -> dict:
 
 
 def _build_main_label(
-    rep: dict,
+    stage: str,
     records: list[dict],
-    inputs: list[str],
-    outputs: list[str],
-    eliminated: list[str],
-    retained: list[str],
     atomic_claim_ids: list[str],
     claim_index: dict[str, dict],
-) -> tuple[str, bool]:
-    """Domain-neutral ``operation + theory object`` label for a main node.
+) -> str:
+    """Theory-stage label for a main node (issue #308).
 
-    Returns ``(label, from_equation_id_only)``. The object phrase is taken, in
-    order, from: atomic claim text → step reason → eliminated/retained symbols →
-    equation ID (last resort, which flags the node, acceptance #3).
+    The base label is the stage's human-readable name (``Theory basis`` …
+    ``Diagnostic / application``). When an atomic claim or a meaningful step
+    reason is available it enriches the label as ``Stage: phrase``. Equation IDs
+    are never used, so a main node can never be labelled ``Define eq_...`` /
+    ``Derive result eq_...``.
     """
-    verb = str(rep["verb"] or "").strip()
-    # 1. atomic claim text
+    stage_label = theory_stage_label(stage)
+    # 1. atomic claim text (preferred enrichment)
     claim_phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index)
     if claim_phrase:
-        return _compose_label(verb, claim_phrase), False
-    # 2. step reason (skip bare generic words)
-    for rec in [rep] + records:
+        return f"{stage_label}: {claim_phrase}"
+    # 2. meaningful step reason (skip bare generic words / equation-id-only text)
+    for rec in records:
         reason = str(getattr(rec["step"], "reason", "") or "").strip()
-        if reason and reason.lower() not in _GENERIC_LABELS:
-            return _compose_label(verb, reason[:80]), False
-    # 3. eliminated / retained symbols
-    symbols = eliminated or retained
-    if symbols:
-        return _compose_label(verb, ", ".join(symbols[:3])), False
-    # 4. the verb already names a specific operation (multi-word from operation)
-    if " " in verb:
-        return verb, False
-    # 5. equation ID fallback only — flags the node as not atomically backed
-    obj = (outputs[:1] or inputs[:1] or [""])[0]
-    if obj:
-        return f"{verb} {obj}".strip(), True
-    return verb, True
+        if reason and reason.lower() not in _GENERIC_LABELS and not _looks_like_equation_id(reason):
+            return f"{stage_label}: {reason[:80]}"
+    # 3. stage label alone — always a readable, non-equation backbone label
+    return stage_label
 
 
-def _compose_label(verb: str, phrase: str) -> str:
-    verb = verb.strip()
-    phrase = phrase.strip()
-    if not phrase:
-        return verb
-    if not verb:
-        return phrase
-    # Avoid duplicating the verb if the phrase already starts with it.
-    if phrase.lower().startswith(verb.lower()):
-        return phrase
-    return f"{verb} {phrase}"
+def _looks_like_equation_id(text: str) -> bool:
+    """True if a phrase is dominated by equation-id tokens (e.g. ``eq_2_7``).
+
+    Used to avoid enriching a main label with text that is really just an
+    equation reference (acceptance: main labels are never equation-id based).
+    """
+    stripped = str(text or "").strip()
+    if not stripped:
+        return False
+    return bool(re.fullmatch(r"(eq[_\.\s]*\(?\s*[\dA-Za-z\.\)]+\s*[, ]*)+", stripped, re.IGNORECASE))
 
 
 def _atomic_claim_phrase(atomic_claim_ids: list[str], claim_index: dict[str, dict]) -> str:

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -88,6 +88,78 @@ GRAPH_LAYERS = [GRAPH_LAYER_MAIN, GRAPH_LAYER_EQUATION_DETAIL, GRAPH_LAYER_DEBUG
 THEORY_OPERATION_NODE = "TheoryOperationNode"  # aggregated, main graph
 EQUATION_OPERATION_NODE = "EquationOperationNode"  # per-step, detail graph
 
+# Theory stages (issue #308). The main graph aggregates equation-level steps into
+# a handful of high-level theory-construction stages so it reads as a backbone
+# (5–8 nodes) rather than one node per equation/operation. The vocabulary is
+# domain-neutral; a stage is assigned from an operation's *edge_type family*
+# (see classify_operation), never from paper- or field-specific terms.
+THEORY_STAGE_BASIS = "theory_basis"
+THEORY_STAGE_OBSERVATION_MODEL = "observation_model"
+THEORY_STAGE_OBSERVABLE_CONSTRUCTION = "observable_construction"
+THEORY_STAGE_EQUATION_SYSTEM = "equation_system"
+THEORY_STAGE_ELIMINATION = "elimination"
+THEORY_STAGE_CONSISTENCY_RELATION = "consistency_relation"
+THEORY_STAGE_DIAGNOSTIC_APPLICATION = "diagnostic_application"
+
+# Canonical ordering used for the main graph's top-to-bottom theory flow.
+THEORY_STAGES = [
+    THEORY_STAGE_BASIS,
+    THEORY_STAGE_OBSERVATION_MODEL,
+    THEORY_STAGE_OBSERVABLE_CONSTRUCTION,
+    THEORY_STAGE_EQUATION_SYSTEM,
+    THEORY_STAGE_ELIMINATION,
+    THEORY_STAGE_CONSISTENCY_RELATION,
+    THEORY_STAGE_DIAGNOSTIC_APPLICATION,
+]
+
+# Human-readable, UI-facing stage labels (issue #308). Used as the *base* label
+# of a main TheoryOperationNode; an atomic-claim / reason phrase may enrich it but
+# the equation-id fallback is never used for a main label.
+THEORY_STAGE_LABELS = {
+    THEORY_STAGE_BASIS: "Theory basis",
+    THEORY_STAGE_OBSERVATION_MODEL: "Observation model",
+    THEORY_STAGE_OBSERVABLE_CONSTRUCTION: "Observable construction",
+    THEORY_STAGE_EQUATION_SYSTEM: "Equation system",
+    THEORY_STAGE_ELIMINATION: "Elimination",
+    THEORY_STAGE_CONSISTENCY_RELATION: "Consistency relation",
+    THEORY_STAGE_DIAGNOSTIC_APPLICATION: "Diagnostic / application",
+}
+
+# Domain-neutral mapping from an operation edge_type family to a theory stage.
+# Every non-generic edge_type produced by classify_operation is covered so a main
+# node always has a stage (hence a non-equation label).
+_EDGE_TYPE_TO_STAGE = {
+    "defines": THEORY_STAGE_BASIS,
+    "constructs": THEORY_STAGE_OBSERVABLE_CONSTRUCTION,
+    "normalizes": THEORY_STAGE_OBSERVABLE_CONSTRUCTION,
+    "linearizes": THEORY_STAGE_EQUATION_SYSTEM,
+    "approximates": THEORY_STAGE_EQUATION_SYSTEM,
+    "substitutes": THEORY_STAGE_EQUATION_SYSTEM,
+    "solves": THEORY_STAGE_ELIMINATION,
+    "eliminates": THEORY_STAGE_ELIMINATION,
+    "derives": THEORY_STAGE_CONSISTENCY_RELATION,
+    "constrains": THEORY_STAGE_CONSISTENCY_RELATION,
+    "diagnoses": THEORY_STAGE_DIAGNOSTIC_APPLICATION,
+    "compares": THEORY_STAGE_DIAGNOSTIC_APPLICATION,
+}
+
+
+def stage_for_edge_type(edge_type: str) -> str:
+    """Map an operation edge_type family to a theory stage (domain-neutral).
+
+    Returns ``""`` for generic / unmapped edge types; callers keep such steps in
+    the equation_detail / debug layer rather than promoting them to a main node.
+    """
+    return _EDGE_TYPE_TO_STAGE.get(str(edge_type or "").strip().lower(), "")
+
+
+def theory_stage_label(stage: str) -> str:
+    """Human-readable label for a theory stage (falls back to a humanized form)."""
+    key = str(stage or "").strip().lower()
+    if key in THEORY_STAGE_LABELS:
+        return THEORY_STAGE_LABELS[key]
+    return key.replace("_", " ").capitalize() if key else "Theory stage"
+
 # Map a node's source-backing status to a review_status (issue #306). A
 # source-backed node should not stay ``teacher_review_required`` by default;
 # inferred / review_required nodes must surface as review_required.

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -271,6 +271,10 @@ class ComponentGraphNode:
     origin: str = "paper"
     operation: str = ""
     theory_object: str = ""
+    # Longer, human-readable explanation (atomic-claim text / step reason). The
+    # ``label`` stays short (a theory-stage name for main nodes); the descriptive
+    # sentence lives here and is shown in the UI's detail pane (issue #308).
+    description: str = ""
     graph_layer: str = "main"
     maturity_source: str = ""
     publish_ready: bool = False
@@ -378,6 +382,7 @@ class ComponentGraphResult:
                     "origin": n.origin,
                     "operation": n.operation,
                     "theory_object": n.theory_object,
+                    "description": n.description,
                     "graph_layer": n.graph_layer,
                     "maturity_source": n.maturity_source,
                     "publish_ready": n.publish_ready,

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -1,6 +1,8 @@
 """Validation for ComponentGraphAgent outputs (Issue #266)."""
 from __future__ import annotations
 
+import re
+
 from .schema import (
     GENERIC_EDGE_TYPES,
     GENERIC_OPERATIONS,
@@ -19,6 +21,11 @@ _GENERIC_EDGE_TYPES = {"RELATED_TO", "CORRELATES", "supports", "related_to", "co
 _BIAS_ELIMINATION_NEEDLES = ("bias elimination", "eliminate second", "eliminate third", "second-order bias", "third-order bias")
 # Operation edge types whose nodes must expose their output/constraint equations.
 _OUTPUT_BEARING_EDGE_TYPES = {"constrains", "derives", "diagnoses"}
+# Equation-id-based main labels are not allowed (issue #308): a main node must
+# show a theory stage / construction, not "Define eq_2_7" / "Derive result eq_...".
+_EQUATION_ID_LABEL_RE = re.compile(
+    r"(?:\beq_\w+)|(?:\beq\.?\s*\(?\s*\d)", re.IGNORECASE
+)
 
 
 class ComponentGraphValidator:
@@ -56,6 +63,15 @@ class ComponentGraphValidator:
                     "component_graph_node_label_generic",
                     "error",
                     f"main graph node {node.component_id!r} has generic label {label!r}",
+                    f"nodes[{node.component_id}].label",
+                ))
+            # Issue #308: a main node label must be a theory stage / construction,
+            # never an equation-id fallback ("Define eq_2_7", "Derive result eq_...").
+            if is_main and _EQUATION_ID_LABEL_RE.search(label):
+                issues.append(ValidationIssue(
+                    "main_graph_node_equation_id_label",
+                    "error",
+                    f"main graph node {node.component_id!r} has equation-id label {label!r}",
                     f"nodes[{node.component_id}].label",
                 ))
             if (
@@ -208,6 +224,16 @@ class ComponentGraphValidator:
                 f"node {cid!r} operation {operation!r} is too generic for the main graph",
                 f"nodes[{cid}].operation",
             ))
+            # Issue #308: generic operations must never reach the main graph —
+            # they belong in the equation_detail / debug layer. A main-layer
+            # TheoryOperationNode carrying one is a hard error.
+            if is_main:
+                issues.append(ValidationIssue(
+                    "main_graph_generic_operation",
+                    "error",
+                    f"main graph node {cid!r} has generic operation {operation!r}",
+                    f"nodes[{cid}].operation",
+                ))
 
         return issues
 

--- a/src/tests/agents/component_assembly/test_component_refiner.py
+++ b/src/tests/agents/component_assembly/test_component_refiner.py
@@ -80,21 +80,26 @@ def _bias_derivation():
     return DerivationChainResult(document_id="doc", cartridge_id=None, chains=[chain])
 
 
-def test_coarse_component_split_into_theory_operations():
+def test_coarse_component_split_into_reusable_theory_units():
     result = _result([_coarse_component()])
     refined = REFINER.refine(result, llm_input=None, derivations=_bias_derivation())
 
     # Acceptance criterion #1: the coarse component is gone, replaced by children.
     ids = [c.component_id for c in refined.components]
     assert "comp_bias" not in ids
-    # 7 distinct operations -> 7 children.
-    assert len(refined.components) == 7
+    # Issue #308: split by reusable theory-unit family, not per equation step.
+    # 7 operations across {linearize, solve, derive} -> 3 reusable units.
+    assert len(refined.components) == 3
+    assert {c.operation for c in refined.components} == {"linearize", "solve", "derive"}
 
     for child in refined.components:
-        # criterion #2/#3: one main operation, non-empty inputs/operation/outputs.
+        # criterion #2/#3: a reusable unit with non-empty inputs/operation/outputs.
         assert child.operation
         assert child.inputs
         assert child.outputs
+        # Labels/summaries are theory-object centric, never a bare generic op.
+        assert child.label.lower() not in ("transform", "relate", "")
+        assert "refined theory operation" not in child.summary.lower()
         # criterion #4: derivation children have internal_flow.
         assert child.internal_flow
         # criterion #5: equation roles populated.
@@ -105,14 +110,25 @@ def test_coarse_component_split_into_theory_operations():
         }
 
 
-def test_consistency_relation_children_expose_output_equations():
+def test_multiple_equation_steps_collapse_into_one_unit():
+    # Issue #308: the derive family bundles 3 consistency-relation steps into a
+    # single reusable unit whose internal_flow keeps every step.
     result = _result([_coarse_component()])
     refined = REFINER.refine(result, llm_input=None, derivations=_bias_derivation())
-    consistency = [c for c in refined.components if "consistency" in c.label.lower()]
-    assert consistency
-    for child in consistency:
-        # criterion #7: consistency relation components expose output equation IDs.
-        assert child.output_equation_ids
+    derive_unit = next(c for c in refined.components if c.operation == "derive")
+    assert len(derive_unit.internal_flow) >= 3
+    # It carries the consistency-relation outputs from all three steps.
+    assert "eq_cons_skew" in derive_unit.output_equation_ids
+    assert "eq_cons_kurt1" in derive_unit.output_equation_ids
+    assert "eq_cons_kurt2" in derive_unit.output_equation_ids
+
+
+def test_derive_unit_exposes_output_equations():
+    result = _result([_coarse_component()])
+    refined = REFINER.refine(result, llm_input=None, derivations=_bias_derivation())
+    derive_unit = next(c for c in refined.components if c.operation == "derive")
+    # criterion #7: consistency-relation (derive) unit exposes output equation IDs.
+    assert derive_unit.output_equation_ids
 
 
 def test_refinement_report_records_split():
@@ -122,7 +138,7 @@ def test_refinement_report_records_split():
     assert report["split_count"] == 1
     action = report["split_actions"][0]
     assert action["parent_component_id"] == "comp_bias"
-    assert len(action["child_component_ids"]) == 7
+    assert len(action["child_component_ids"]) == 3
 
 
 def test_review_required_equation_propagates_to_child_status():
@@ -138,6 +154,34 @@ def test_review_required_equation_propagates_to_child_status():
     for child in solving:
         assert child.review_status == "teacher_review_required"
         assert "eq_b2" in child.review_required_equation_ids
+
+
+def test_generic_operation_does_not_form_its_own_unit():
+    # Issue #308: a generic "transform"/"relate" step must not become a standalone
+    # reusable component; it is folded into a real unit's internal_flow.
+    operations = [
+        ("linearize_skewness_bias_dependence", ["eq_skew"], ["eq_skew_lin"]),
+        ("transform", ["eq_skew_lin"], ["eq_mid"]),
+        ("solve_second_order_bias", ["eq_mid"], ["eq_b2"]),
+        ("derive_skewness_consistency_relation", ["eq_b2"], ["eq_cons"]),
+    ]
+    steps = [
+        DerivationStep(step_id=f"step_{i}", input_equation_ids=inp, operation=op, output_equation_ids=out)
+        for i, (op, inp, out) in enumerate(operations)
+    ]
+    chain = DerivationChainRecord(
+        derivation_id="deriv_bias", document_id="doc", source_section_ids=["s3"],
+        steps=steps, linked_component_ids=["comp_bias"],
+    )
+    derivations = DerivationChainResult(document_id="doc", cartridge_id=None, chains=[chain])
+    refined = REFINER.refine(_result([_coarse_component()]), llm_input=None, derivations=derivations)
+
+    # 3 non-generic families -> 3 units; no unit is named for the generic op.
+    assert {c.operation for c in refined.components} == {"linearize", "solve", "derive"}
+    assert "transform" not in {c.operation for c in refined.components}
+    # The generic step's equations survive inside some unit's internal_flow.
+    flows = [f for c in refined.components for f in c.internal_flow]
+    assert any(f.get("relation") == "transform" for f in flows)
 
 
 def test_single_operation_component_not_split():

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -134,6 +134,35 @@ def test_equation_steps_aggregate_into_one_main_node():
     assert len(linearizes.member_component_ids) == 2
 
 
+def test_steps_from_multiple_derivations_share_a_stage_node():
+    # Issue #308: stage aggregation is global — define steps from two different
+    # derivations collapse into a single "Theory basis" main node.
+    derivations = DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[
+            DerivationChainRecord(
+                derivation_id="deriv_a",
+                document_id="doc",
+                source_section_ids=[],
+                steps=[_step("define_kernel", ["eq_a"], ["eq_b"])],
+            ),
+            DerivationChainRecord(
+                derivation_id="deriv_b",
+                document_id="doc",
+                source_section_ids=[],
+                steps=[_step("define_observable", ["eq_x"], ["eq_y"])],
+            ),
+        ],
+    )
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    basis_nodes = [n for n in _layer(result, "main") if n.label == "Theory basis"]
+    assert len(basis_nodes) == 1
+    assert len(basis_nodes[0].member_component_ids) == 2
+
+
 def test_detail_nodes_point_back_at_main_node():
     result = _normalized()
     main_by_id = {n.component_id: n for n in _layer(result, "main")}
@@ -145,14 +174,31 @@ def test_detail_nodes_point_back_at_main_node():
 # --- labels (acceptance #3, #4) ---------------------------------------------
 
 
-def test_main_labels_are_not_bare_generic():
+def test_main_labels_are_theory_stages_not_equation_ids():
+    # Issue #308: main labels are high-level theory stages, never bare generic
+    # operations and never equation-id fallbacks ("Define eq_...", etc.).
     result = _normalized()
     labels = {n.label for n in _layer(result, "main")}
     for generic in ("Define", "Transform", "Relate", "Result"):
         assert generic not in labels
-    # Labels are operation + object phrases.
-    assert any(l.startswith("Linearize") for l in labels)
-    assert any(l.startswith("Eliminate second order parameter") for l in labels)
+    # No main label contains an equation id.
+    for label in labels:
+        assert "eq_" not in label.lower()
+        assert not label.lower().startswith("define eq")
+        assert not label.lower().startswith("derive result eq")
+    # Labels are the canonical theory-stage backbone.
+    assert "Theory basis" in labels  # define step
+    assert "Equation system" in labels  # linearize step
+    assert "Elimination" in labels  # eliminate step
+    assert "Consistency relation" in labels  # derive step
+    assert "Diagnostic / application" in labels  # apply_criterion step
+
+
+def test_main_graph_has_five_to_eight_stage_nodes():
+    # Acceptance: the main graph collapses to a handful of theory stages.
+    result = _normalized()
+    main_nodes = _layer(result, "main")
+    assert 1 <= len(main_nodes) <= 8
 
 
 def test_main_label_prefers_atomic_claim_text():

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -192,6 +192,10 @@ def test_main_labels_are_theory_stages_not_equation_ids():
     assert "Elimination" in labels  # eliminate step
     assert "Consistency relation" in labels  # derive step
     assert "Diagnostic / application" in labels  # apply_criterion step
+    # Labels stay short: the stage name only, never a "Stage: long phrase" form.
+    for label in labels:
+        assert ":" not in label.replace("Diagnostic / application", "")
+        assert len(label) <= 40
 
 
 def test_main_graph_has_five_to_eight_stage_nodes():
@@ -201,13 +205,16 @@ def test_main_graph_has_five_to_eight_stage_nodes():
     assert 1 <= len(main_nodes) <= 8
 
 
-def test_main_label_prefers_atomic_claim_text():
+def test_main_label_stays_short_and_description_holds_claim_text():
+    # Issue #308: the atomic-claim phrase enriches the node's *description*, not
+    # its label. The label stays a short theory-stage name.
     claim_index = {
         "claim_1": {"text": "second-order moment vanishes", "evidence_text": "p.4", "is_atomic": True},
     }
     result = _normalized(claim_index)
     eliminate = next(n for n in _layer(result, "main") if n.operation.startswith("eliminate"))
-    assert "second-order moment vanishes" in eliminate.label
+    assert eliminate.label == "Elimination"
+    assert "second-order moment vanishes" in eliminate.description
 
 
 # --- generic operations (acceptance #5) -------------------------------------

--- a/src/tests/agents/component_graph/test_validator.py
+++ b/src/tests/agents/component_graph/test_validator.py
@@ -255,6 +255,62 @@ class TestSourceBackingRules:
         issues = self.validator.validate(_result([node], []))
         assert any(i.rule_id == "theory_node_generic_operation" for i in issues)
 
+    def test_main_graph_generic_operation_is_error(self):
+        # Issue #308: a generic operation must never reach the main graph.
+        node = _theory_node("c1", operation="transform", label="Theory basis")
+        issues = self.validator.validate(_result([node], []))
+        assert any(
+            i.rule_id == "main_graph_generic_operation" and i.severity == "error"
+            for i in issues
+        )
+
+    def test_detail_layer_generic_operation_is_not_error(self):
+        # The same generic operation in the equation_detail layer is allowed.
+        node = _theory_node(
+            "c1",
+            operation="transform",
+            label="Transform eq_1",
+            graph_layer="equation_detail",
+            component_type="EquationOperationNode",
+        )
+        issues = self.validator.validate(_result([node], []))
+        assert not any(i.rule_id == "main_graph_generic_operation" for i in issues)
+
+    def test_main_graph_equation_id_label_is_error(self):
+        # Issue #308: main labels must be theory stages, not "Define eq_2_7".
+        node = _theory_node("c1", label="Define eq_2_7")
+        issues = self.validator.validate(_result([node], []))
+        assert any(
+            i.rule_id == "main_graph_node_equation_id_label" and i.severity == "error"
+            for i in issues
+        )
+
+    def test_main_graph_derive_result_equation_label_is_error(self):
+        node = _theory_node("c1", operation="derive_result", label="Derive result eq_2_10")
+        issues = self.validator.validate(_result([node], []))
+        assert any(i.rule_id == "main_graph_node_equation_id_label" for i in issues)
+
+    def test_theory_stage_label_is_accepted(self):
+        # A clean theory-stage label produces no label/operation errors.
+        node = _theory_node("c1", label="Equation system", operation="linearize_moment_equations")
+        issues = self.validator.validate(_result([node], []))
+        label_errors = [
+            i for i in issues
+            if i.rule_id in ("main_graph_node_equation_id_label", "main_graph_generic_operation")
+        ]
+        assert label_errors == []
+
+    def test_equation_detail_label_with_equation_id_is_allowed(self):
+        # Equation ids are fine in the detail layer (traceability).
+        node = _theory_node(
+            "c1",
+            label="Define eq_2_7",
+            graph_layer="equation_detail",
+            component_type="EquationOperationNode",
+        )
+        issues = self.validator.validate(_result([node], []))
+        assert not any(i.rule_id == "main_graph_node_equation_id_label" for i in issues)
+
     def test_edge_without_evidence_warns(self):
         nodes = [_theory_node("c1"), _theory_node("c2")]
         edge = ComponentGraphEdge(


### PR DESCRIPTION
## Summary

Restructure the component graph's main layer to aggregate equation-level steps by **theory stage** rather than by `(derivation_id, operation_family)` pairs. This produces a compact 5–8 node backbone representing the canonical theory-construction progression (basis → observation model → equation system → elimination → consistency relation → diagnostic application) instead of one node per equation or operation.

## Key Changes

### Component Graph Normalizer (`normalizer.py`)
- **Theory stage aggregation**: Replace `_group_records()` grouping key from `(derivation_id, edge_type)` to a domain-neutral stage derived from each step's operation edge_type family via new `stage_for_edge_type()` function
- **Stage-based main labels**: Rewrite `_build_main_label()` to use theory-stage labels (e.g., "Theory basis", "Equation system") as the base, optionally enriched by atomic claims or meaningful step reasons—never equation-id fallbacks
- **Canonical stage ordering**: Sort aggregated groups by `THEORY_STAGES` canonical progression so the main graph reads top-to-bottom
- **Representative record per group**: Each stage group selects a representative record to drive the node's operation and edge_type for definition/constraint roles
- **New schema exports**: Add `THEORY_STAGES`, `THEORY_STAGE_LABELS`, `stage_for_edge_type()`, and `theory_stage_label()` to `schema.py`
- **Equation-id detection**: Introduce `_looks_like_equation_id()` regex to prevent equation references from enriching main labels

### Component Refiner (`component_refiner.py`)
- **Reusable theory units**: Refactor to split components by operation **family** (not per equation step), so multiple steps of the same family (e.g., three `derive` steps) collapse into one reusable component with `internal_flow` preserving all steps
- **Generic operation handling**: Introduce `_GENERIC_OPERATIONS` set and `_is_generic_operation()` check; generic steps never form standalone components but are absorbed into the nearest unit's `internal_flow` via new `_absorb_generic_steps()` method
- **Theory-object-centric labels**: Replace bare operation names with `_theory_unit_label()` that leads with the parent's theoretical subject and qualifies it by family, and `_theory_unit_summary()` for consistent component descriptions
- **Family-based grouping**: Update `_operation_groups()` to return `(family_groups, generic_steps)` tuple and use `_operation_family()` to bucket steps

### Schema (`schema.py`)
- **Theory stage vocabulary**: Define `THEORY_STAGE_*` constants and `THEORY_STAGES` canonical list
- **Stage labels**: Add `THEORY_STAGE_LABELS` mapping for human-readable UI display
- **Edge-type-to-stage mapping**: Implement `_EDGE_TYPE_TO_STAGE` dictionary covering all non-generic edge types (`defines→theory_basis`, `constructs/normalizes→observable_construction`, `linearizes/approximates/substitutes→equation_system`, `solves/eliminates→elimination`, `derives/constrains→consistency_relation`, `diagnoses/compares→diagnostic_application`)
- **Helper functions**: Export `stage_for_edge_type()` and `theory_stage_label()` for domain-neutral stage derivation and display

### Validator (`validator.py`)
- **Main graph equation-id label error**: Add `main_graph_node_equation_id_label` hard error rule using regex to detect equation-id patterns in main node labels (issue #308)
- **Main graph generic operation error**: Upgrade generic-operation check to hard error for main layer (existing warning for detail layer remains)
- **Regex pattern**: Use `_EQUATION_ID_LABEL_RE` to match `eq_...` and `eq(...)` patterns case-insensitively

### Tests
- **Normalizer tests**: Add `test_steps_from_multiple_derivations_share_a_stage_node()` to verify cross-derivation stage aggregation; update `test_main_labels_are_theory_stages_not_

https://claude.ai/code/session_011Poiosw8WMzBphLMEjp9UB