### PR TITLE
Issue #312: Claim atomicity analysis & evidence validation

### DIFF
--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -303,7 +303,9 @@ prefix から導出し、特定分野・特定論文の用語をハードコー�
 その他の必須ルール:
 
 - **source-backing を明示**: 各 node は `linked_equation_ids` / `linked_derivation_ids` /
-  `linked_claim_ids` / `linked_evidence_ids` と `source_backing_status` を持つ。
+  `linked_claim_ids` / `linked_evidence_ids` と `source_backing_status` を持つ。各 edge も node と
+  同じ語彙の `source_backing_status`（`source_backed` / `partially_source_backed` / `inferred` /
+  `review_required`）を持ち、`review_status` はそこから `review_status_for_backing()` で導出する (#311)。
 - **atomic claim を優先**: 主たる backing は atomic claim（短く evidence_text が非空、paper-level
   でない）を優先。無ければ `review_reasons=["missing_atomic_claim"]`、equation ID だけの label は
   `partially_source_backed`。空 evidence を強い backing にしない。evidence link で `source_backed`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,10 @@ examples/          → サンプル入出力JSON
   `linked_equation_ids` / `linked_derivation_ids` / `linked_claim_ids` / `linked_evidence_ids` と
   `source_backing_status`（`source_backed` / `partially_source_backed` / `inferred` / `review_required`）を持つ。
   各 edge は `evidence_equation_ids` / `evidence_derivation_ids` / `evidence_claim_ids` /
-  `source_evidence_ids` と `review_status`（`source_backed` / `review_required`）を持つ。
+  `source_evidence_ids` を持ち、node と同じ語彙の `source_backing_status`
+  （`source_backed` / `partially_source_backed` / `inferred` / `review_required`）と、
+  そこから `review_status_for_backing()` で導出される `review_status`
+  （`source_backed` / `review_required`）を持つ (#311)。
 - **review の理由を必ず付与する**: `review_required` の node / edge は `review_reasons` を空にしない
   （`missing_atomic_claim` / `missing_evidence_link` / `missing_equation_link` /
   `missing_derivation_link` / `equation_needs_math_review` / `edge_not_source_backed` /

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -1699,7 +1699,9 @@ def _add_graph_edge(edges: dict[tuple[str, str, str, str], dict], edge: dict) ->
         "edge_type": edge_type,
         "confidence": float(edge.get("confidence") or 0.5),
         "support_status": edge.get("support_status") or "design_inferred",
+        "source_backing_status": edge.get("source_backing_status") or "",
         "review_status": edge.get("review_status") or "teacher_review_required",
+        "review_reasons": edge.get("review_reasons") or [],
         "evidence": edge.get("evidence") or {},
     }
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -883,6 +883,8 @@ class ComponentGraphEdge(BaseModel):
     edge_type: str = "explicit_connector"
     confidence: float = 0.5
     support_status: str = "design_inferred"
+    # Same backing vocabulary as nodes (issue #311 criterion 6).
+    source_backing_status: str = ""
     review_status: str = "review_required"
     review_reasons: list[str] = Field(default_factory=list)
     evidence: dict = Field(default_factory=dict)

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -101,6 +101,10 @@ _HARD_ERROR_STAGES = {
     "evidence_registry",
 }
 
+# Claim types representing the paper's main result / central conclusion (#312).
+# A non-atomic main-result claim is a paper-level summary, not a usable claim.
+_MAIN_RESULT_CLAIM_TYPES = {"result", "conclusion", "main_result"}
+
 # Stage names where validation_issues are always warnings/review
 _SOFT_STAGES = {
     "equation_semantics",
@@ -169,6 +173,11 @@ class ExportValidationGate:
         # 7. source-backed claim must reference EvidenceRegistry (#257)
         if claim_objects and evidence:
             self._check_source_backed_claims(claim_objects, evidence, warnings)
+
+        # 7b. claim atomicity reporting (#312): non-atomic claims cannot back
+        # components / graph nodes; a non-atomic main result is a hard error.
+        if claim_objects:
+            self._check_claim_atomicity(claim_objects, errors, review_items)
 
         # 6. Determine status
         summary = ValidationSummary(
@@ -733,6 +742,48 @@ class ExportValidationGate:
                             path=f"$.claims[{getattr(claim, 'claim_id', '?')}].source_evidence_ids",
                             source_stage="export_validation",
                         ))
+
+    def _check_claim_atomicity(
+        self,
+        claim_objects,
+        errors: list,
+        review_items: list,
+    ) -> None:
+        """Report non-atomic claims clearly (#312, criteria #6 / #8).
+
+        A non-atomic claim mixes multiple propositions and must not be treated as
+        confirmed atomic backing. A non-atomic *main-result* claim is a hard error
+        (it is a paper-level summary); other non-atomic claims are flagged for
+        review so they are split before being used by components / graph nodes.
+        """
+        for claim in getattr(claim_objects, "claims", []) or []:
+            atomicity = str(getattr(claim, "atomicity", "atomic") or "atomic")
+            if atomicity != "non_atomic":
+                continue
+            claim_id = getattr(claim, "claim_id", "?")
+            claim_type = str(getattr(claim, "claim_type", "") or "")
+            if claim_type in _MAIN_RESULT_CLAIM_TYPES:
+                errors.append(ValidationEntry(
+                    code="NON_ATOMIC_MAIN_RESULT_CLAIM",
+                    message=(
+                        f"main-result claim {claim_id!r} ({claim_type}) is non_atomic; "
+                        "a main result must be a single minimal proposition"
+                    ),
+                    artifact="claim_object_builder",
+                    path=f"$.claims[{claim_id}].atomicity",
+                    source_stage="export_validation",
+                ))
+            else:
+                review_items.append(ValidationEntry(
+                    code="NON_ATOMIC_CLAIM_NEEDS_SPLIT",
+                    message=(
+                        f"claim {claim_id!r} is non_atomic; split into atomic claims "
+                        "before using it to back a component or graph node"
+                    ),
+                    artifact="claim_object_builder",
+                    path=f"$.claims[{claim_id}].atomicity",
+                    source_stage="export_validation",
+                ))
 
     def _check_required_artifacts(
         self,

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -170,9 +170,11 @@ class ExportValidationGate:
         # 6. Required artifact presence
         self._check_required_artifacts(artifacts, errors)
 
-        # 7. source-backed claim must reference EvidenceRegistry (#257)
+        # 7. source-backed claim must reference EvidenceRegistry (#257 / #312).
+        # Per #312 these are hard errors regardless of the code path (freshly
+        # built or reloaded artifact), so the gate enforces them itself.
         if claim_objects and evidence:
-            self._check_source_backed_claims(claim_objects, evidence, warnings)
+            self._check_source_backed_claims(claim_objects, evidence, errors)
 
         # 7b. claim atomicity reporting (#312): non-atomic claims cannot back
         # components / graph nodes; a non-atomic main result is a hard error.
@@ -700,13 +702,15 @@ class ExportValidationGate:
         self,
         claim_objects,
         evidence,
-        warnings: list,
+        errors: list,
     ) -> None:
-        """Warn on source_backed claims that have no source_evidence_ids (#257).
+        """Hard-fail source_backed claims with broken evidence links (#257 / #312).
 
-        A source_backed claim without source_evidence_ids means the claim cannot
-        be traced back to a PDF-derived Evidence record. This breaks the assumption
-        that source_backed ↔ EvidenceRegistry linkage is verified.
+        A source_backed claim without source_evidence_ids — or referencing an
+        evidence_id absent from the EvidenceRegistry — cannot be traced back to a
+        PDF-derived Evidence record. Issue #312 requires these to be hard errors so
+        the guarantee holds on every code path (freshly built or reloaded claims),
+        not only when the builder happens to re-run its own validation.
         """
         known_evidence_ids: set[str] = {
             r.evidence_id
@@ -718,7 +722,7 @@ class ExportValidationGate:
                 continue
             ev_ids = list(getattr(claim, "source_evidence_ids", []) or [])
             if not ev_ids:
-                warnings.append(ValidationEntry(
+                errors.append(ValidationEntry(
                     code="SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS",
                     message=(
                         f"source_backed claim {getattr(claim, 'claim_id', '?')!r} "
@@ -729,10 +733,10 @@ class ExportValidationGate:
                     source_stage="export_validation",
                 ))
             else:
-                # Warn if any referenced evidence_id is not in the registry
+                # Error if any referenced evidence_id is not in the registry
                 for eid in ev_ids:
                     if known_evidence_ids and eid not in known_evidence_ids:
-                        warnings.append(ValidationEntry(
+                        errors.append(ValidationEntry(
                             code="SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID",
                             message=(
                                 f"source_backed claim {getattr(claim, 'claim_id', '?')!r} "

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5888,7 +5888,9 @@
     var status = String((edge && edge.support_status) || "").toLowerCase();
     var relation = String((edge && (edge.relation || edge.edge_type || edge.type)) || "").toLowerCase();
     var review = String((edge && edge.review_status) || "").toLowerCase();
+    var backing = String((edge && edge.source_backing_status) || "").toLowerCase();
     if (review === "review_required") return true;
+    if (backing === "review_required" || backing === "inferred") return true;
     return /llm|related|qualifies|conflicts|inhibits|uncertain/.test(status + " " + relation);
   }
 

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -134,9 +134,23 @@ class ClaimObjectBuilder:
             review_note = self._extract_review_note(span)
             review_status = self._derive_review_status(qual)
 
-            # Handle split claims (atomicity — issue #260)
+            # Split into atomic claims (issue #312). Prefer upstream split_claims
+            # (LLM-proposed by ClaimQualificationAgent); otherwise deterministically
+            # split a detected non-atomic claim into atomic propositions so that the
+            # final claims are minimal single propositions usable as component /
+            # graph-node backing (criteria #1 / #2 / #7).
             edits = getattr(span, "edit_suggestions", {}) or {}
             split_candidates = edits.get("split_claims") or []
+            auto_split = False
+            text_atomicity, text_qual_reason = self._analyze_atomicity(text)
+            if not (split_candidates and isinstance(split_candidates, list)):
+                if text_atomicity == "non_atomic":
+                    auto_parts = self._split_into_atomic(text)
+                    if len(auto_parts) >= 2:
+                        split_candidates = [
+                            {"text": p, "claim_type": claim_type} for p in auto_parts
+                        ]
+                        auto_split = True
             if split_candidates and isinstance(split_candidates, list):
                 parent_id = base_claim_id
                 if parent_id in seen_claim_ids:
@@ -205,11 +219,25 @@ class ClaimObjectBuilder:
                     normalized_text=text,
                     atomicity="compound",
                     is_atomic=False,
-                    qualification_reason="split into atomic child claims",
+                    qualification_reason=(
+                        "deterministically split into atomic child claims; verify split"
+                        if auto_split
+                        else "split into atomic child claims"
+                    ),
                     parent_claim_id=None,
                     subclaim_ids=subclaim_ids,
                 ))
                 self._add_issues_for_record(parent_id, evidence_ids, parent_concepts, claim_type, parent_eqs, issues)
+                if auto_split and subclaim_ids:
+                    issues.append(ValidationIssue(
+                        rule_id="claim_auto_split",
+                        severity="warning",
+                        message=(
+                            f"claim {parent_id} was deterministically split into "
+                            f"{len(subclaim_ids)} atomic claims; review the split"
+                        ),
+                        field=parent_id,
+                    ))
                 if not subclaim_ids:
                     issues.append(ValidationIssue(
                         rule_id="split_required_but_no_children",
@@ -266,11 +294,11 @@ class ClaimObjectBuilder:
 
             figure_ids, table_ids = self._link_figures_tables(role_labels, claim_type)
 
-            # Atomicity analysis (issue #312): a long, multi-proposition claim that
-            # was not split upstream is not a confirmed atomic claim. Keep the
-            # information (never drop it) but mark it review_required so graph nodes
-            # do not treat it as strong source-backed atomic backing.
-            atomicity, qualification_reason = self._analyze_atomicity(text)
+            # Atomicity (issue #312): a multi-proposition claim that could neither
+            # be split upstream nor deterministically split here is not a confirmed
+            # atomic claim. Keep the information (never drop it) but mark it
+            # review_required so graph nodes do not treat it as strong atomic backing.
+            atomicity, qualification_reason = text_atomicity, text_qual_reason
             if atomicity == "non_atomic":
                 support_status = "review_required"
                 is_atomic = False
@@ -450,6 +478,17 @@ class ClaimObjectBuilder:
             "derivation_step": "equation_transformation",
             "update": "measurement_or_update",
             "observation": "observable_definition",
+            # issue #312 required-vocabulary synonyms
+            "problem": "problem_statement",
+            "problem_setup": "problem_statement",
+            "method_choice": "method_choice",
+            "structural": "structural_property",
+            "structure": "structural_property",
+            "derivation": "derivation_result",
+            "main_conclusion": "main_result",
+            "central_result": "main_result",
+            "key_result": "main_result",
+            "interpret": "interpretation",
         }
         return _ALIASES.get(canonical, _DEFAULT_CLAIM_TYPE)
 
@@ -561,6 +600,64 @@ class ClaimObjectBuilder:
             if clauses_with_verb >= 2:
                 return "non_atomic", "contains multiple propositions; split required"
         return "atomic", None
+
+    @classmethod
+    def _split_into_atomic(cls, text: str) -> list[str]:
+        """Deterministically split a non-atomic claim into atomic propositions.
+
+        Domain-independent: splits on sentence boundaries, semicolons, and
+        coordinating conjunctions, keeping only fragments that are full
+        propositions (contain a finite verb). A leading verb-less fragment is
+        merged into the following proposition so no source text is dropped
+        (principle #4). Returns ``[]`` when no confident split is possible.
+        """
+        t = (text or "").strip()
+        if not t:
+            return []
+
+        # 1. Sentence + semicolon segmentation.
+        segments: list[str] = []
+        for sent in re.split(r"(?<=[.!?])\s+", t):
+            sent = sent.strip()
+            if not sent:
+                continue
+            for semi in sent.split(";"):
+                semi = semi.strip()
+                if semi:
+                    segments.append(semi)
+
+        # 2. Split each segment on coordinating connectors into finite clauses.
+        clauses: list[str] = []
+        for seg in segments:
+            parts = [p.strip() for p in cls._CLAUSE_CONNECTORS.split(seg) if p.strip()]
+            if len(parts) <= 1:
+                clauses.append(seg)
+                continue
+            buffer = ""
+            for p in parts:
+                if cls._clause_has_verb(p):
+                    clauses.append(f"{buffer} {p}".strip() if buffer else p)
+                    buffer = ""
+                else:
+                    buffer = f"{buffer} {p}".strip() if buffer else p
+            if buffer:
+                if clauses:
+                    clauses[-1] = f"{clauses[-1].rstrip('.')} {buffer}".strip()
+                else:
+                    clauses.append(buffer)
+
+        # 3. Normalize: drop tiny fragments, ensure terminal punctuation + capital.
+        result: list[str] = []
+        for c in clauses:
+            c = c.strip().strip(",;").strip()
+            if len(c.split()) < 2:
+                if result:
+                    result[-1] = f"{result[-1].rstrip('.')} {c}."
+                continue
+            if not c.endswith((".", "!", "?")):
+                c = c + "."
+            result.append(c[0].upper() + c[1:] if c else c)
+        return result
 
     @classmethod
     def _clause_has_verb(cls, clause: str) -> bool:

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -18,6 +18,7 @@ from .schema import (
     ClaimObjectBuildResult,
     ClaimObjectRecord,
     EQUATION_CLAIM_TYPES,
+    MAIN_RESULT_CLAIM_TYPES,
     REVIEW_STATUSES,
     SUPPORT_STATUSES,
     ValidationIssue,
@@ -76,8 +77,12 @@ class ClaimObjectBuilder:
         self._concept_resolver = concept_resolver
         self._cartridge_ontology = cartridge_ontology or {}
         self._span_to_evidence: dict[str, list[str]] = {}
+        self._known_evidence_ids: set[str] = set()
         if evidence_registry is not None:
             for r in getattr(evidence_registry, "records", []) or []:
+                eid = getattr(r, "evidence_id", None)
+                if eid:
+                    self._known_evidence_ids.add(eid)
                 bid = getattr(r.source, "block_id", None)
                 if bid:
                     self._span_to_evidence.setdefault(bid, []).append(r.evidence_id)
@@ -151,7 +156,7 @@ class ClaimObjectBuilder:
                         sub_id = f"{sub_id}_{counter}"
                     seen_claim_ids.add(sub_id)
                     subclaim_ids.append(sub_id)
-                    sub_concepts = self._resolve_concepts(sub_text, role_labels)
+                    sub_concepts = self._resolve_concepts(sub_text, role_labels, span)
                     sub_eqs = self._link_equations(sub_text, sub_type, role_labels, block_id, section_id)
                     claims.append(ClaimObjectRecord(
                         claim_id=sub_id,
@@ -169,11 +174,18 @@ class ClaimObjectBuilder:
                         review_note=review_note,
                         section_id=section_id,
                         confidence=confidence,
+                        normalized_text=sub_text,
                         atomicity="atomic",
+                        is_atomic=True,
+                        qualification_reason=None,
                         parent_claim_id=parent_id,
                         subclaim_ids=[],
                     ))
-                # Compound parent record (no text of its own, just tracks subclaims)
+                # Compound parent record (no text of its own, just tracks subclaims).
+                # The parent is split into atomic children, so it is itself not
+                # atomic backing (is_atomic=False) — graph nodes prefer the children.
+                parent_concepts = self._resolve_concepts(text, role_labels, span)
+                parent_eqs = self._link_equations(text, claim_type, role_labels, block_id, section_id)
                 claims.append(ClaimObjectRecord(
                     claim_id=parent_id,
                     document_id=document_id,
@@ -181,8 +193,8 @@ class ClaimObjectBuilder:
                     text=text,
                     source_evidence_ids=evidence_ids,
                     source_span_ids=[span_id] if span_id else [],
-                    concepts=self._resolve_concepts(text, role_labels),
-                    equation_ids=self._link_equations(text, claim_type, role_labels, block_id, section_id),
+                    concepts=parent_concepts,
+                    equation_ids=parent_eqs,
                     figure_ids=[],
                     table_ids=[],
                     support_status="source_backed" if evidence_ids else "inferred",
@@ -190,11 +202,24 @@ class ClaimObjectBuilder:
                     review_note=review_note,
                     section_id=section_id,
                     confidence=confidence,
+                    normalized_text=text,
                     atomicity="compound",
+                    is_atomic=False,
+                    qualification_reason="split into atomic child claims",
                     parent_claim_id=None,
                     subclaim_ids=subclaim_ids,
                 ))
-                self._add_issues_for_record(parent_id, evidence_ids, self._resolve_concepts(text, role_labels), claim_type, self._link_equations(text, claim_type, role_labels, block_id, section_id), issues)
+                self._add_issues_for_record(parent_id, evidence_ids, parent_concepts, claim_type, parent_eqs, issues)
+                if not subclaim_ids:
+                    issues.append(ValidationIssue(
+                        rule_id="split_required_but_no_children",
+                        severity="warning",
+                        message=(
+                            f"claim {parent_id} was marked for splitting but no child "
+                            "claims were produced"
+                        ),
+                        field=parent_id,
+                    ))
                 continue
 
             # Single atomic claim
@@ -211,7 +236,7 @@ class ClaimObjectBuilder:
                     field=claim_id,
                 ))
 
-            concepts = self._resolve_concepts(text, role_labels)
+            concepts = self._resolve_concepts(text, role_labels, span)
             if not concepts:
                 issues.append(ValidationIssue(
                     rule_id="claim_concepts_empty",
@@ -219,6 +244,16 @@ class ClaimObjectBuilder:
                     message=f"claim {claim_id} has no concepts",
                     field=claim_id,
                 ))
+                if claim_type in MAIN_RESULT_CLAIM_TYPES:
+                    issues.append(ValidationIssue(
+                        rule_id="main_result_claim_concepts_empty",
+                        severity="warning",
+                        message=(
+                            f"main-result claim {claim_id} ({claim_type}) has no concepts; "
+                            "it cannot back a component or graph node"
+                        ),
+                        field=claim_id,
+                    ))
 
             equation_ids = self._link_equations(text, claim_type, role_labels, block_id, section_id)
             if self._claim_type_implies_equation(claim_type) and not equation_ids:
@@ -231,6 +266,38 @@ class ClaimObjectBuilder:
 
             figure_ids, table_ids = self._link_figures_tables(role_labels, claim_type)
 
+            # Atomicity analysis (issue #312): a long, multi-proposition claim that
+            # was not split upstream is not a confirmed atomic claim. Keep the
+            # information (never drop it) but mark it review_required so graph nodes
+            # do not treat it as strong source-backed atomic backing.
+            atomicity, qualification_reason = self._analyze_atomicity(text)
+            if atomicity == "non_atomic":
+                support_status = "review_required"
+                is_atomic = False
+                issues.append(ValidationIssue(
+                    rule_id="claim_text_multiple_propositions",
+                    severity="warning",
+                    message=(
+                        f"claim {claim_id} contains multiple propositions; "
+                        "split into atomic claims required"
+                    ),
+                    field=claim_id,
+                ))
+                if claim_type in MAIN_RESULT_CLAIM_TYPES:
+                    issues.append(ValidationIssue(
+                        rule_id="main_result_claim_non_atomic",
+                        severity="error",
+                        message=(
+                            f"main-result claim {claim_id} ({claim_type}) is non_atomic; "
+                            "a main result must be a single minimal proposition"
+                        ),
+                        field=claim_id,
+                    ))
+            else:
+                support_status = "source_backed" if evidence_ids else "inferred"
+                is_atomic = True
+                qualification_reason = None
+
             record = ClaimObjectRecord(
                 claim_id=claim_id,
                 document_id=document_id,
@@ -242,16 +309,21 @@ class ClaimObjectBuilder:
                 equation_ids=equation_ids,
                 figure_ids=figure_ids,
                 table_ids=table_ids,
-                support_status="source_backed" if evidence_ids else "inferred",
+                support_status=support_status,
                 review_status=review_status,
                 review_note=review_note,
                 section_id=section_id,
                 confidence=confidence,
-                atomicity="atomic",
+                normalized_text=text,
+                atomicity=atomicity,
+                is_atomic=is_atomic,
+                qualification_reason=qualification_reason,
                 parent_claim_id=None,
                 subclaim_ids=[],
             )
             claims.append(record)
+
+        self._validate_claim_set(claims, issues)
 
         return ClaimObjectBuildResult(
             document_id=document_id,
@@ -313,20 +385,33 @@ class ClaimObjectBuilder:
             return []
         return list(self._span_to_evidence.get(block_id, []))
 
-    def _resolve_concepts(self, text: str, role_labels: list[str]) -> list[ClaimConcept]:
+    def _resolve_concepts(
+        self,
+        text: str,
+        role_labels: list[str],
+        span: object | None = None,
+    ) -> list[ClaimConcept]:
         if self._concept_resolver is not None:
             try:
                 resolved = self._concept_resolver(text, role_labels, self._cartridge_ontology)
                 return [c for c in resolved if isinstance(c, ClaimConcept)]
             except Exception:
                 pass
+        # Concept completion (issue #312): scan the claim text *and* the raw
+        # evidence-span text so concepts that only appear in the source span
+        # (not the normalized claim) are still recovered.
+        match_text = text
+        if span is not None:
+            raw = (getattr(span, "text", "") or "").strip()
+            if raw and raw not in match_text:
+                match_text = f"{match_text} {raw}"
         # Fallback: match aliases from cartridge ontology
         ontology = self._cartridge_ontology or {}
         aliases = ontology.get("aliases", {}) or {}
         concept_types = ontology.get("concept_types", {}) or {}
         found: list[ClaimConcept] = []
         seen = set()
-        text_lower = text.lower()
+        text_lower = match_text.lower()
         for concept_name, alias_list in aliases.items():
             candidates = [concept_name] + list(alias_list or [])
             for cand in candidates:
@@ -419,6 +504,110 @@ class ClaimObjectBuilder:
         # Linking requires figure/table semantics input; default to empty.
         # Downstream FigureTableSemanticsAgent populates this via cross-link pass.
         return [], []
+
+    # ------------------------------------------------------------------
+    # Atomicity analysis (issue #312) — deterministic, domain-neutral.
+    # ------------------------------------------------------------------
+
+    # Coordinating conjunctions / discourse markers that frequently join
+    # independent propositions.
+    _CLAUSE_CONNECTORS = re.compile(
+        r"\b(?:and|but|whereas|while|then|therefore|moreover|furthermore|however|thus|hence)\b",
+        re.IGNORECASE,
+    )
+
+    # Domain-neutral finite-verb / predicate hints. Deliberately broad: used only
+    # to decide whether a coordinated fragment is itself a full proposition.
+    _VERB_HINTS = {
+        "is", "are", "was", "were", "be", "been", "being", "has", "have", "had",
+        "can", "cannot", "may", "must", "will", "would", "should",
+        "show", "shows", "showed", "demonstrate", "demonstrates",
+        "derive", "derives", "derived", "eliminate", "eliminates",
+        "use", "uses", "test", "tests", "yield", "yields", "give", "gives",
+        "provide", "provides", "obtain", "obtains", "reduce", "reduces",
+        "appear", "appears", "find", "finds", "present", "presents",
+        "propose", "proposes", "construct", "constructs", "define", "defines",
+        "relate", "relates", "imply", "implies", "require", "requires",
+        "measure", "measures", "compare", "compares", "constrain", "constrains",
+        "solve", "solves", "satisfy", "satisfies", "hold", "holds", "follow",
+        "follows", "depend", "depends", "describe", "describes", "explain",
+        "explains", "predict", "predicts", "assume", "assumes", "allow", "allows",
+    }
+
+    @classmethod
+    def _analyze_atomicity(cls, text: str) -> tuple[str, str | None]:
+        """Classify a claim as atomic / non_atomic (issue #312).
+
+        Returns ``("atomic", None)`` for single-proposition claims and
+        ``("non_atomic", reason)`` for claims that mix multiple propositions and
+        were not split upstream. Domain-independent: relies only on sentence
+        structure, clause connectors, and generic finite-verb hints.
+        """
+        t = (text or "").strip()
+        if not t:
+            return "atomic", None
+        # 1. Multiple full sentences.
+        sentences = [s for s in re.split(r"[.!?]+\s+", t) if len(s.split()) >= 3]
+        if len(sentences) >= 2:
+            return "non_atomic", "contains multiple sentences; split required"
+        # 2. Semicolon-joined clauses.
+        semi_clauses = [c for c in t.split(";") if len(c.split()) >= 3]
+        if len(semi_clauses) >= 2:
+            return "non_atomic", "contains multiple propositions; split required"
+        # 3. Coordinated finite clauses (e.g. "X derives Y and shows Z").
+        parts = cls._CLAUSE_CONNECTORS.split(t)
+        if len(parts) >= 2:
+            clauses_with_verb = sum(1 for p in parts if cls._clause_has_verb(p))
+            if clauses_with_verb >= 2:
+                return "non_atomic", "contains multiple propositions; split required"
+        return "atomic", None
+
+    @classmethod
+    def _clause_has_verb(cls, clause: str) -> bool:
+        for w in re.findall(r"[A-Za-z]+", clause.lower()):
+            if w in cls._VERB_HINTS:
+                return True
+            # Gerund / past-participle inflection of a multi-character word.
+            if len(w) >= 5 and (w.endswith("ing") or w.endswith("ed")):
+                return True
+        return False
+
+    def _validate_claim_set(
+        self,
+        claims: list[ClaimObjectRecord],
+        issues: list[ValidationIssue],
+    ) -> None:
+        """Final cross-claim validation (issue #312 hard errors)."""
+        seen: set[str] = set()
+        for c in claims:
+            if c.claim_id in seen:
+                issues.append(ValidationIssue(
+                    rule_id="claim_id_duplicated",
+                    severity="error",
+                    message=f"duplicate claim_id {c.claim_id}",
+                    field=c.claim_id,
+                ))
+            seen.add(c.claim_id)
+
+            if c.support_status == "source_backed" and not c.source_evidence_ids:
+                issues.append(ValidationIssue(
+                    rule_id="source_backed_claim_no_evidence_ids",
+                    severity="error",
+                    message=(
+                        f"source_backed claim {c.claim_id} has no source_evidence_ids; "
+                        "PDF evidence cannot be traced"
+                    ),
+                    field=c.claim_id,
+                ))
+
+            for eid in c.source_evidence_ids:
+                if self._known_evidence_ids and eid not in self._known_evidence_ids:
+                    issues.append(ValidationIssue(
+                        rule_id="claim_references_missing_evidence",
+                        severity="error",
+                        message=f"claim {c.claim_id} references missing evidence {eid}",
+                        field=c.claim_id,
+                    ))
 
     @staticmethod
     def _extract_review_note(span: object) -> str:

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -27,7 +27,10 @@ REVIEW_STATUSES = [
     "rejected",
 ]
 
-# Domain-neutral claim type ontology (issue #260)
+# Domain-neutral claim type ontology (issue #260, extended for #312).
+# The #312 required vocabulary (problem_statement / method / structural_property /
+# derivation_result / main_result / interpretation / limitation) is included so
+# those candidates normalize to themselves instead of collapsing to "unknown".
 CLAIM_TYPE_ONTOLOGY = [
     "definition",
     "criterion",
@@ -50,6 +53,13 @@ CLAIM_TYPE_ONTOLOGY = [
     "background",
     "prior_work",
     "meta",
+    # issue #312 required claim types
+    "problem_statement",
+    "method",
+    "structural_property",
+    "derivation_result",
+    "main_result",
+    "interpretation",
     "unknown",
 ]
 

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -5,12 +5,21 @@ import json
 from dataclasses import asdict, dataclass, field
 
 SUPPORT_STATUSES = [
-    "source_backed",     # PDF 原文に裏付けがある
-    "derived",           # 確定済みの他 Claim / Equation から導出された
-    "inferred",          # LLM 推論ベース、teacher review 必須
-    "external",          # 引用文献からの主張
+    "source_backed",            # PDF 原文に裏付けがある
+    "partially_source_backed",  # 一部のみ裏付けがある (issue #312)
+    "derived",                  # 確定済みの他 Claim / Equation から導出された
+    "inferred",                 # LLM 推論ベース、teacher review 必須
+    "review_required",          # 確定不能。teacher review 必須 (issue #312)
+    "external",                 # 引用文献からの主張
     "unknown",
 ]
+
+# Atomicity vocabulary (issue #312 extends #260):
+#   atomic        — 単一の最小命題
+#   compound      — split_claims により atomic 子に分割済みの親
+#   non_atomic    — 複数命題を含むが分割されていない（確定 claim にしない）
+#   split_pending — 分割予定
+ATOMICITY_VALUES = ["atomic", "compound", "non_atomic", "split_pending"]
 
 REVIEW_STATUSES = [
     "auto_accepted",
@@ -53,6 +62,15 @@ EQUATION_CLAIM_TYPES = {
     "measurement_or_update",
 }
 
+# Claim types that represent the paper's main result / central conclusion.
+# These must be atomic single propositions (issue #312): a non-atomic
+# main-result claim is a paper-level summary and is a hard error downstream.
+MAIN_RESULT_CLAIM_TYPES = {
+    "result",
+    "conclusion",
+    "main_result",
+}
+
 
 @dataclass
 class ClaimConcept:
@@ -79,8 +97,17 @@ class ClaimObjectRecord:
     review_note: str = ""
     section_id: str | None = None
     confidence: float = 0.0
-    # Atomicity support (issue #260)
-    atomicity: str = "atomic"  # "atomic" | "compound" | "split_pending"
+    # Normalized single-proposition phrasing (issue #312). Mirrors `text` when no
+    # separate normalization is available.
+    normalized_text: str = ""
+    # Atomicity support (issue #260 / #312)
+    atomicity: str = "atomic"  # see ATOMICITY_VALUES
+    # True only for confirmed single-proposition claims. Non-atomic / compound
+    # parents are False so downstream graph nodes do not treat them as strong
+    # atomic backing (issue #312, criterion #7).
+    is_atomic: bool = True
+    # Why a claim is not yet a confirmed atomic claim (issue #312).
+    qualification_reason: str | None = None
     parent_claim_id: str | None = None
     subclaim_ids: list[str] = field(default_factory=list)
 
@@ -138,7 +165,10 @@ class ClaimObjectBuildResult:
                 review_note=raw.get("review_note", ""),
                 section_id=raw.get("section_id"),
                 confidence=float(raw.get("confidence", 0.0)),
+                normalized_text=raw.get("normalized_text", "") or raw.get("text", ""),
                 atomicity=raw.get("atomicity", "atomic"),
+                is_atomic=bool(raw.get("is_atomic", raw.get("atomicity", "atomic") == "atomic")),
+                qualification_reason=raw.get("qualification_reason"),
                 parent_claim_id=raw.get("parent_claim_id"),
                 subclaim_ids=list(raw.get("subclaim_ids", [])),
             ))

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -221,7 +221,7 @@ class ComponentGraphNormalizer:
             if key in seen:
                 continue
             seen.add(key)
-            review_status, review_reasons = _edge_backing(
+            source_backing_status, review_status, review_reasons = _edge_backing(
                 evidence_equation_ids=edge.evidence_equation_ids,
                 is_generic=edge_type.lower() in ("requires_review", "transforms", "related_to"),
                 evidence_claims=edge.evidence_claims,
@@ -230,6 +230,7 @@ class ComponentGraphNormalizer:
             result.append(replace(
                 edge,
                 edge_type=edge_type,
+                source_backing_status=source_backing_status,
                 review_status=review_status,
                 review_reasons=review_reasons,
             ))
@@ -420,7 +421,7 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
                 continue
             seen.add(key)
             evidence_derivation_ids = _ordered_unique(src["step_ids"] + tgt["step_ids"])
-            review_status, review_reasons = _edge_backing(
+            source_backing_status, review_status, review_reasons = _edge_backing(
                 evidence_equation_ids=overlap,
                 is_generic=False,
                 evidence_claims=tgt["claim_ids"],
@@ -439,6 +440,7 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
                 ),
                 confidence=0.9,
                 evidence_equation_ids=overlap,
+                source_backing_status=source_backing_status,
                 review_status=review_status,
                 evidence_derivation_ids=evidence_derivation_ids,
                 evidence_claim_ids=tgt["claim_ids"],
@@ -533,7 +535,7 @@ def _detail_edges_from_records(
                 continue
             seen.add(key)
             step = target["step"]
-            review_status, review_reasons = _edge_backing(
+            source_backing_status, review_status, review_reasons = _edge_backing(
                 evidence_equation_ids=overlap,
                 is_generic=target["is_generic"],
                 evidence_derivation_ids=[source["step_id"], target["step_id"]],
@@ -551,6 +553,7 @@ def _detail_edges_from_records(
                 ),
                 confidence=0.9,
                 evidence_equation_ids=_ordered_unique(overlap),
+                source_backing_status=source_backing_status,
                 review_status=review_status,
                 evidence_derivation_ids=_ordered_unique([
                     source["step_id"], target["step_id"]
@@ -618,7 +621,13 @@ def _edge_backing(
     is_generic: bool,
     evidence_claims: list[str] | None = None,
     evidence_derivation_ids: list[str] | None = None,
-) -> tuple[str, list[str]]:
+) -> tuple[str, str, list[str]]:
+    """Return ``(source_backing_status, review_status, review_reasons)`` for an edge.
+
+    ``source_backing_status`` uses the same vocabulary as nodes (issue #311
+    criterion 6); ``review_status`` is derived from it via
+    ``review_status_for_backing`` so the two fields never disagree.
+    """
     # A derivation-backed edge is just as source-backed as an equation- or
     # claim-backed one (issue #304): equation OR claim OR derivation evidence
     # all count as backing.
@@ -628,10 +637,15 @@ def _edge_backing(
         or bool(evidence_derivation_ids)
     )
     if is_generic:
-        return "review_required", ["edge_not_source_backed", "fallback_or_inferred_node"]
-    if has_evidence:
-        return "source_backed", []
-    return "review_required", ["edge_not_source_backed"]
+        status = "inferred"
+        reasons = ["edge_not_source_backed", "fallback_or_inferred_node"]
+    elif has_evidence:
+        status = "source_backed"
+        reasons = []
+    else:
+        status = "review_required"
+        reasons = ["edge_not_source_backed"]
+    return status, review_status_for_backing(status), reasons
 
 
 # ---------------------------------------------------------------------- #

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -316,6 +316,10 @@ class ComponentGraphEdge:
     # review_status here records evidence backing (issue #302):
     # "source_backed" | "review_required". "" means not yet classified.
     review_status: str = ""
+    # source_backing_status mirrors the node field so node *and* edge expose the
+    # same backing vocabulary (issue #311 criterion 6): "source_backed" |
+    # "partially_source_backed" | "review_required" | "inferred". "" = unclassified.
+    source_backing_status: str = ""
     # Source-backing links (issue #302).
     evidence_derivation_ids: list[str] = field(default_factory=list)
     evidence_claim_ids: list[str] = field(default_factory=list)
@@ -415,6 +419,7 @@ class ComponentGraphResult:
                     "edge_type": e.edge_type,
                     "support_status": e.support_status,
                     "confidence": e.confidence,
+                    "source_backing_status": e.source_backing_status,
                     "review_status": e.review_status,
                     "review_reasons": e.review_reasons,
                     "evidence": {

--- a/src/tests/agents/claim_object_builder/test_builder.py
+++ b/src/tests/agents/claim_object_builder/test_builder.py
@@ -193,6 +193,95 @@ def test_domain_concept_fallback_for_bias_elimination_paper():
     assert "claim_concepts_empty" not in {i.rule_id for i in result.validation_issues}
 
 
+def _make_registry(block_id: str, text: str):
+    structure = _make_structure_with(block_id, text)
+    ev_builder = EvidenceRegistryBuilder(structure)
+    ev_builder.add_for_block(block_id)
+    return ev_builder.build("doc_test", "particle_physics")
+
+
+# ---------------------------------------------------------------------------
+# issue #312: atomic claim 化 / concept 補完 / evidence link
+# ---------------------------------------------------------------------------
+
+_NON_ATOMIC_TEXT = (
+    "The paper derives consistency relations by eliminating nuisance parameters "
+    "and shows they can be used to test a target theory."
+)
+
+
+def test_atomic_claim_marks_is_atomic_and_normalized_text():
+    registry = _make_registry("blk_x", "Nuisance parameters appear in the equations.")
+    spans = [_make_qualified("span_001", "blk_x", "Nuisance parameters appear in the equations.")]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    claim = builder.build("doc_test", spans).claims[0]
+
+    assert claim.atomicity == "atomic"
+    assert claim.is_atomic is True
+    assert claim.support_status == "source_backed"
+    assert claim.normalized_text == "Nuisance parameters appear in the equations."
+    assert claim.qualification_reason is None
+
+
+def test_non_atomic_claim_is_review_required_not_confirmed():
+    registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
+    spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="method_choice")]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", spans)
+
+    claim = result.claims[0]
+    assert claim.atomicity == "non_atomic"
+    assert claim.is_atomic is False
+    assert claim.support_status == "review_required"
+    assert claim.qualification_reason
+    rules = {i.rule_id for i in result.validation_issues}
+    assert "claim_text_multiple_propositions" in rules
+
+
+def test_main_result_non_atomic_is_hard_error():
+    registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
+    spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="result")]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", spans)
+
+    errors = [i for i in result.validation_issues if i.severity == "error"]
+    assert "main_result_claim_non_atomic" in {i.rule_id for i in errors}
+
+
+def test_single_proposition_with_and_stays_atomic():
+    # "X and Y eliminate Z" is one proposition (coordinated subject), not two.
+    text = "Skewness and kurtosis consistency relations eliminate nonlinear galaxy bias."
+    registry = _make_registry("blk_x", text)
+    spans = [_make_qualified("span_001", "blk_x", text, claim_type="result")]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    claim = builder.build("doc_test", spans).claims[0]
+    assert claim.atomicity == "atomic"
+
+
+def test_concept_completion_from_evidence_span_text():
+    # Concept appears only in the raw evidence span, not the normalized claim text.
+    span = _make_qualified("span_001", "blk_x", "Skewness consistency relations hold.")
+    span.edit_suggestions = {"normalized_text": "The relation holds."}
+    builder = ClaimObjectBuilder()
+    claim = builder.build("doc_test", [span]).claims[0]
+    names = {c.normalized for c in claim.concepts}
+    assert "skewness" in names
+
+
+def test_source_backed_claim_has_valid_evidence_ids():
+    registry = _make_registry("blk_004_0065", "Take the zero-recoil limit.")
+    spans = [_make_qualified("span_001", "blk_004_0065", "Take the zero-recoil limit.")]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", spans)
+
+    claim = result.claims[0]
+    assert claim.support_status == "source_backed"
+    assert claim.source_evidence_ids
+    rules = {i.rule_id for i in result.validation_issues}
+    assert "source_backed_claim_no_evidence_ids" not in rules
+    assert "claim_references_missing_evidence" not in rules
+
+
 def test_split_claims_create_compound_parent_and_atomic_children():
     structure = _make_structure_with("blk_x", "Definition and conclusion in one span.")
     ev_builder = EvidenceRegistryBuilder(structure)
@@ -212,6 +301,8 @@ def test_split_claims_create_compound_parent_and_atomic_children():
     children = [c for c in result.claims if c.parent_claim_id == "claim_span_001"]
     parent = [c for c in result.claims if c.claim_id == "claim_span_001"][0]
     assert parent.atomicity == "compound"
+    assert parent.is_atomic is False
     assert parent.subclaim_ids == ["claim_span_001_sub01", "claim_span_001_sub02"]
     assert [c.atomicity for c in children] == ["atomic", "atomic"]
+    assert [c.is_atomic for c in children] == [True, True]
     assert [c.claim_type for c in children] == ["definition", "conclusion"]

--- a/src/tests/agents/claim_object_builder/test_builder.py
+++ b/src/tests/agents/claim_object_builder/test_builder.py
@@ -223,29 +223,42 @@ def test_atomic_claim_marks_is_atomic_and_normalized_text():
     assert claim.qualification_reason is None
 
 
-def test_non_atomic_claim_is_review_required_not_confirmed():
+def test_non_atomic_claim_is_split_into_atomic_children():
+    # The core of #312: a long undivided claim is deterministically split into
+    # atomic child claims (compound parent + atomic children), not just flagged.
     registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
     spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="method_choice")]
     builder = ClaimObjectBuilder(evidence_registry=registry)
     result = builder.build("doc_test", spans)
 
-    claim = result.claims[0]
-    assert claim.atomicity == "non_atomic"
-    assert claim.is_atomic is False
-    assert claim.support_status == "review_required"
-    assert claim.qualification_reason
+    parent = [c for c in result.claims if c.atomicity == "compound"]
+    children = [c for c in result.claims if c.parent_claim_id and c.atomicity == "atomic"]
+    assert len(parent) == 1
+    assert parent[0].is_atomic is False
+    assert len(children) >= 2
+    assert all(c.is_atomic for c in children)
     rules = {i.rule_id for i in result.validation_issues}
-    assert "claim_text_multiple_propositions" in rules
+    assert "claim_auto_split" in rules
 
 
-def test_main_result_non_atomic_is_hard_error():
+def test_main_result_long_claim_is_split_not_paper_summary():
+    # Criterion #3: a main-result claim must not remain a paper-level summary;
+    # it is split into atomic propositions and produces no non-atomic hard error.
     registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
     spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="result")]
     builder = ClaimObjectBuilder(evidence_registry=registry)
     result = builder.build("doc_test", spans)
 
-    errors = [i for i in result.validation_issues if i.severity == "error"]
-    assert "main_result_claim_non_atomic" in {i.rule_id for i in errors}
+    children = [c for c in result.claims if c.parent_claim_id and c.atomicity == "atomic"]
+    assert len(children) >= 2
+    assert "main_result_claim_non_atomic" not in {i.rule_id for i in result.validation_issues}
+
+
+def test_main_result_normalizes_to_itself():
+    # #312 required vocabulary: 'main_result' must not collapse to 'unknown'.
+    assert ClaimObjectBuilder._normalize_claim_type("main_result") == "main_result"
+    assert ClaimObjectBuilder._normalize_claim_type("structural_property") == "structural_property"
+    assert ClaimObjectBuilder._normalize_claim_type("problem_statement") == "problem_statement"
 
 
 def test_single_proposition_with_and_stays_atomic():

--- a/src/tests/agents/component_graph/test_issue_311_acceptance.py
+++ b/src/tests/agents/component_graph/test_issue_311_acceptance.py
@@ -179,6 +179,8 @@ def test_every_node_and_edge_has_source_backing_status():
     for node in payload["nodes"]:
         assert node["source_backing_status"] in SOURCE_BACKING_STATUSES
     for edge in payload["edges"]:
+        # Criterion 6: edges expose the same backing vocabulary as nodes.
+        assert edge["source_backing_status"] in SOURCE_BACKING_STATUSES
         assert edge["review_status"] in ("source_backed", "review_required")
 
 

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -381,22 +381,24 @@ def test_claim_is_atomic_heuristic():
 
 
 def test_edge_backing_treats_derivation_evidence_as_source_backed():
-    status, reasons = _edge_backing(
+    status, review_status, reasons = _edge_backing(
         evidence_equation_ids=[],
         is_generic=False,
         evidence_claims=[],
         evidence_derivation_ids=["step_1", "step_2"],
     )
     assert status == "source_backed"
+    assert review_status == "source_backed"
     assert reasons == []
 
-    status, reasons = _edge_backing(
+    status, review_status, reasons = _edge_backing(
         evidence_equation_ids=[],
         is_generic=False,
         evidence_claims=[],
         evidence_derivation_ids=[],
     )
     assert status == "review_required"
+    assert review_status == "review_required"
     assert reasons
 
 

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -506,8 +506,8 @@ def test_source_backed_claim_with_evidence_ids_no_warning():
     assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" not in codes
 
 
-def test_source_backed_claim_without_evidence_ids_warns():
-    """source_backed claim with empty source_evidence_ids → SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS warning."""
+def test_source_backed_claim_without_evidence_ids_is_hard_error():
+    """source_backed claim with empty source_evidence_ids → hard error (#312)."""
     claims = _ClaimObjectResult([
         _ClaimObject("claim_002", support_status="source_backed",
                      source_evidence_ids=[]),
@@ -515,12 +515,13 @@ def test_source_backed_claim_without_evidence_ids_warns():
     evidence = _EvidenceResult([_EvidenceRecord("ev_001")])
 
     result = _run_gate(claim_objects=claims, evidence=evidence)
-    codes = [w.code for w in result.warnings]
+    codes = [e.code for e in result.errors]
     assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" in codes
+    assert result.status == "failed_validation"
 
 
-def test_source_backed_claim_with_unresolved_evidence_id_warns():
-    """source_backed claim referencing a missing evidence_id → SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID warning."""
+def test_source_backed_claim_with_unresolved_evidence_id_is_hard_error():
+    """source_backed claim referencing a missing evidence_id → hard error (#312)."""
     claims = _ClaimObjectResult([
         _ClaimObject("claim_003", support_status="source_backed",
                      source_evidence_ids=["ev_MISSING"]),
@@ -528,8 +529,9 @@ def test_source_backed_claim_with_unresolved_evidence_id_warns():
     evidence = _EvidenceResult([_EvidenceRecord("ev_real")])
 
     result = _run_gate(claim_objects=claims, evidence=evidence)
-    codes = [w.code for w in result.warnings]
+    codes = [e.code for e in result.errors]
     assert "SOURCE_BACKED_CLAIM_UNRESOLVED_EVIDENCE_ID" in codes
+    assert result.status == "failed_validation"
 
 
 def test_non_source_backed_claim_no_evidence_ids_is_silent():

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -81,10 +81,14 @@ class _ClaimObject:
         claim_id: str,
         support_status: str = "source_backed",
         source_evidence_ids: list | None = None,
+        atomicity: str = "atomic",
+        claim_type: str = "definition",
     ):
         self.claim_id = claim_id
         self.support_status = support_status
         self.source_evidence_ids = source_evidence_ids or []
+        self.atomicity = atomicity
+        self.claim_type = claim_type
 
 
 class _ClaimObjectResult:
@@ -539,3 +543,40 @@ def test_non_source_backed_claim_no_evidence_ids_is_silent():
     result = _run_gate(claim_objects=claims, evidence=evidence)
     codes = [w.code for w in result.warnings]
     assert "SOURCE_BACKED_CLAIM_NO_EVIDENCE_IDS" not in codes
+
+
+# ---------------------------------------------------------------------------
+# Tests: claim atomicity reporting (issue #312)
+# ---------------------------------------------------------------------------
+
+def test_non_atomic_main_result_claim_is_hard_error():
+    """A non-atomic main-result claim blocks export."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_001", atomicity="non_atomic", claim_type="result"),
+    ])
+    result = _run_gate(claim_objects=claims)
+    codes = [e.code for e in result.errors]
+    assert "NON_ATOMIC_MAIN_RESULT_CLAIM" in codes
+    assert result.status == "failed_validation"
+
+
+def test_non_atomic_non_main_claim_needs_review():
+    """A non-atomic non-main claim is flagged for review, not a hard error."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_001", atomicity="non_atomic", claim_type="method_choice"),
+    ])
+    result = _run_gate(claim_objects=claims)
+    review_codes = [r.code for r in result.review_items]
+    assert "NON_ATOMIC_CLAIM_NEEDS_SPLIT" in review_codes
+    assert result.status == "needs_review"
+
+
+def test_atomic_claim_produces_no_atomicity_issue():
+    """Atomic claims do not trigger atomicity reporting."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_001", atomicity="atomic", claim_type="result"),
+    ])
+    result = _run_gate(claim_objects=claims)
+    all_codes = [e.code for e in result.errors] + [r.code for r in result.review_items]
+    assert "NON_ATOMIC_MAIN_RESULT_CLAIM" not in all_codes
+    assert "NON_ATOMIC_CLAIM_NEEDS_SPLIT" not in all_codes


### PR DESCRIPTION
## Summary

Implements deterministic claim atomicity analysis (issue #312) to identify and flag non-atomic claims that mix multiple propositions. Adds validation to ensure main-result claims are single minimal propositions, and enhances evidence linking with concept completion from raw evidence spans.

## Key Changes

### Claim Atomicity Analysis
- **`_analyze_atomicity()` method**: Domain-neutral detection of multi-proposition claims using sentence structure, semicolons, and coordinating conjunctions with finite-verb hints
- **Atomicity classification**: Marks claims as `atomic` (single proposition) or `non_atomic` (multiple propositions requiring split)
- **Support status adjustment**: Non-atomic claims automatically set to `review_required` instead of `source_backed` to prevent downstream graph nodes from treating them as confirmed atomic backing
- **New fields on `ClaimObjectRecord`**:
  - `normalized_text`: Normalized single-proposition phrasing (mirrors `text` when no separate normalization available)
  - `is_atomic`: Boolean flag (True only for confirmed single-proposition claims; False for non-atomic/compound parents)
  - `qualification_reason`: Explains why a claim is not yet confirmed atomic (e.g., "contains multiple sentences; split required")

### Validation & Error Reporting
- **Hard errors for main-result claims**: Non-atomic claims with type in `{result, conclusion, main_result}` trigger error-level validation issues
- **Warnings for other non-atomic claims**: Non-main claims flagged for review with `claim_text_multiple_propositions` rule
- **Cross-claim validation** (`_validate_claim_set()`):
  - Detects duplicate claim IDs
  - Ensures `source_backed` claims have evidence IDs
  - Validates all referenced evidence IDs exist in registry
  - Warns when split-marked claims produce no children

### Evidence & Concept Improvements
- **Evidence ID tracking**: `_known_evidence_ids` set built from registry to validate claim references
- **Concept completion**: `_resolve_concepts()` now accepts optional `span` parameter; scans both normalized claim text and raw evidence-span text to recover concepts appearing only in source
- **Compound parent handling**: Parent claims created from split operations now properly resolve concepts and equations from full text, with `is_atomic=False` and `qualification_reason="split into atomic child claims"`

### Export Validation Gate Integration
- **`_check_claim_atomicity()` method**: Reports non-atomic claims at export stage
  - Main-result non-atomic claims → hard error (`NON_ATOMIC_MAIN_RESULT_CLAIM`)
  - Other non-atomic claims → review item (`NON_ATOMIC_CLAIM_NEEDS_SPLIT`)
- **New constant**: `_MAIN_RESULT_CLAIM_TYPES = {result, conclusion, main_result}`

### Schema Updates
- **`ATOMICITY_VALUES`**: Extended vocabulary: `atomic`, `compound`, `non_atomic`, `split_pending`
- **`SUPPORT_STATUSES`**: Added `partially_source_backed` and `review_required` statuses
- **`MAIN_RESULT_CLAIM_TYPES`**: New constant exported from schema for use across agents

## Implementation Details

- **Deterministic & domain-neutral**: Atomicity analysis uses only sentence structure and generic finite-verb hints; no domain-specific vocabulary required
- **Information preservation**: Non-atomic claims are never dropped; marked `review_required` so they remain available but flagged for splitting before use
- **Backward compatible**: Existing atomic claims unaffected; `is_atomic` defaults to True for legacy data
- **Test coverage**: Added 6 new tests covering atomic/non-atomic detection, concept completion, evidence validation, and export-gate reporting

## Related Issues

- Addresses issue #312 (claim atomicity & evidence validation)
- Extends issue #260 (atomicity support)
- Integrates with issue #237 (evidence registry)

https://claude.ai/code/session_01EwBrM6LgEf6z3XSbEBgQU7