### PR TITLE
issue #317: LLM atomic rewrite responsibility moved to ClaimQualificationAgent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,9 +105,9 @@ PDF ファイル
     ↓  PaperSkeletonResult (JSON)
 [#218] RhetoricalRoleAgent      — chunk/span の論理役割判定（LLM-first）
     ↓  RhetoricalRoleResult (JSON)
-[#219] ClaimQualificationAgent  — Claim採否・区分・粒度（LLM-first）
-    ↓  ClaimQualificationResult (JSON)
-[#237] ClaimObjectBuilder       — 最終 claims.json の決定論的組立（非LLM）
+[#219] ClaimQualificationAgent  — Claim採否・区分・粒度 + atomic rewrite（LLM-first, #317）
+    ↓  ClaimQualificationResult (JSON; atomic_claims を含む)
+[#237] ClaimObjectBuilder       — 最終 claims.json の決定論的組立（非LLM, #317）
     ↓  ClaimObjectBuildResult (JSON)
 [#220] EquationSemanticsAgent   — 数式ブロック意味役割復元（LLM-first）
                                   + to_equations_export() で equations.json 化
@@ -165,6 +165,19 @@ examples/          → サンプル入出力JSON
 **DocumentStructureAgent (#216)**: structure-first（パーサ・レイアウト優先）。意味解釈は行わない。曖昧なblockのみLLM補助。
 
 **PaperSkeletonAgent (#217) 以降**: LLM-first。生成・採否・関係付けの高次判断はLLMに委ねる。入力整形・validation・repairは非LLMで処理する。
+
+**Claim atomic rewrite の責務分担 (#317)**: 長い / paper-level / 複数命題の claim を
+1 claim = 1 minimal proposition に再構成する atomic rewrite は **ClaimQualificationAgent**
+の正式ステップ（LLM-first）が担当し、結果を `QualifiedSpanRecord.atomic_claims`
+（`text` / `normalized_text` / `claim_type_candidate` / `atomicity` / `status` /
+`source_span_id` / `evidence_quote` / `qualification_reason` / `confidence`）に出力する。
+atomic 化できない箇所は `atomicity="non_atomic"` / `status="review_required"` で保持する
+（情報を落とさない）。**ClaimObjectBuilder** は atomic rewrite を行わず、その候補を
+ClaimObjectRecord に変換・リンク・検証するだけに責務を限定する。LLM 候補が無い場合の
+deterministic split は `atomicity="split_pending"` / `support_status="review_required"`
+の review suggestion に留め、確定 `source_backed` atomic claim にはしない。非 atomic /
+split_pending claim（`is_atomic=False`）は ComponentGraph / TheoryOperationGraph の
+強い backing に使わない。ExportValidationGate は非 atomic / split_pending を明示 report する。
 
 **全Agent共通ルール**:
 1. **cartridge-aware**: active cartridgeが指定されていれば語彙・検証ルールに使う。cartridgeがなくても単独動作すること

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -2021,6 +2021,7 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "edge_type": str(edge.get("edge_type") or raw_relation or "stored_pipeline_edge"),
             "confidence": float(edge.get("confidence") or 0.8),
             "support_status": str(edge.get("support_status") or "source_inferred"),
+            "source_backing_status": str(edge.get("source_backing_status") or ""),
             "review_status": str(edge.get("review_status") or "review_required"),
             "review_reasons": edge.get("review_reasons") if isinstance(edge.get("review_reasons"), list) else [],
             "evidence": edge.get("evidence") if isinstance(edge.get("evidence"), dict) else {"reason": edge.get("reason") or ""},

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -762,9 +762,24 @@ class ExportValidationGate:
         """
         for claim in getattr(claim_objects, "claims", []) or []:
             atomicity = str(getattr(claim, "atomicity", "atomic") or "atomic")
+            claim_id = getattr(claim, "claim_id", "?")
+            # Deterministic-split suggestions (issue #317) are never confirmed atomic
+            # backing; surface them so a teacher confirms the split before reuse.
+            if atomicity == "split_pending":
+                review_items.append(ValidationEntry(
+                    code="SPLIT_PENDING_CLAIM_NEEDS_CONFIRMATION",
+                    message=(
+                        f"claim {claim_id!r} is a deterministic-split suggestion "
+                        "(split_pending); confirm via ClaimQualificationAgent atomic "
+                        "rewrite before using it to back a component or graph node"
+                    ),
+                    artifact="claim_object_builder",
+                    path=f"$.claims[{claim_id}].atomicity",
+                    source_stage="export_validation",
+                ))
+                continue
             if atomicity != "non_atomic":
                 continue
-            claim_id = getattr(claim, "claim_id", "?")
             claim_type = str(getattr(claim, "claim_type", "") or "")
             if claim_type in _MAIN_RESULT_CLAIM_TYPES:
                 errors.append(ValidationEntry(

--- a/backend/tests/test_theory_graph_source_backing.py
+++ b/backend/tests/test_theory_graph_source_backing.py
@@ -56,6 +56,23 @@ class TestRoutePropagatesSourceBacking:
         for relation in ("solves", "substitutes", "eliminates", "compares", "constructs"):
             assert f'"{relation}"' in source, f"_GRAPH_RELATIONS missing {relation}"
 
+    def test_stored_graph_normalization_propagates_edge_source_backing(self):
+        """Issue #311: stored-graph edges must also carry source_backing_status.
+
+        The live-generated edge path (_add_graph_edge) and the stored-graph node
+        path already expose source_backing_status; the stored-graph edge path must
+        not drop it. Within _normalize_stored_component_graph the field appears for
+        both the node dict and the edge dict (>= 2 occurrences).
+        """
+        source = _read(ROUTES)
+        start = source.index("def _normalize_stored_component_graph")
+        end = source.index("\ndef ", start)
+        body = source[start:end]
+        assert body.count('"source_backing_status"') >= 2, (
+            "_normalize_stored_component_graph must propagate source_backing_status "
+            "on both nodes and edges"
+        )
+
 
 class TestGraphLayering:
     """Issue #306: main / equation_detail layering plumbing."""

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -3,13 +3,20 @@
 QualifiedSpanRecord（ClaimQualificationAgent の出力）と EvidenceRegistry を入力に
 最終 ClaimObjectRecord を組み立てる。
 
-このモジュールは LLM を使わない。1 span = 1 claim を厳守する。
+このモジュールは LLM を使わない。atomic rewrite（複数命題 claim の分割）は
+ClaimQualificationAgent の正式ステップが担当し (issue #317)、builder は
+その atomic candidates を ClaimObjectRecord に変換・リンク・検証するだけに責務を
+限定する。LLM の atomic rewrite が無い場合のみ、deterministic split を
+``split_pending`` / ``review_required`` の review suggestion として保持する
+（確定 source_backed atomic claim にはしない）。
+
 concepts / equation_ids は外部から渡される concept resolver / equation index に
 基づいて付与する。
 """
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field as _dc_field
 from typing import Callable, Iterable, Optional
 
 from .schema import (
@@ -44,6 +51,23 @@ _DOMAIN_CONCEPT_FALLBACKS: dict[str, tuple[str, str]] = {
     "higher-order moment": ("higher-order moment", "observable"),
     "gravity diagnostic": ("gravity diagnostic", "diagnostic"),
 }
+
+
+@dataclass
+class _BuildCtx:
+    """Per-span context shared between the build paths (issue #317)."""
+    document_id: str
+    span: object
+    block_id: str | None
+    section_id: str | None
+    role_labels: list = _dc_field(default_factory=list)
+    span_id: str | None = None
+    confidence: float = 0.0
+    evidence_ids: list = _dc_field(default_factory=list)
+    review_note: str = ""
+    review_status: str = "teacher_review_required"
+    claim_type: str = "unknown"
+    text: str = ""
 
 
 class ClaimObjectBuilder:
@@ -134,120 +158,44 @@ class ClaimObjectBuilder:
             review_note = self._extract_review_note(span)
             review_status = self._derive_review_status(qual)
 
-            # Split into atomic claims (issue #312). Prefer upstream split_claims
-            # (LLM-proposed by ClaimQualificationAgent); otherwise deterministically
-            # split a detected non-atomic claim into atomic propositions so that the
-            # final claims are minimal single propositions usable as component /
-            # graph-node backing (criteria #1 / #2 / #7).
-            edits = getattr(span, "edit_suggestions", {}) or {}
-            split_candidates = edits.get("split_claims") or []
-            auto_split = False
+            ctx = _BuildCtx(
+                document_id=document_id,
+                span=span,
+                block_id=block_id,
+                section_id=section_id,
+                role_labels=role_labels,
+                span_id=span_id,
+                confidence=confidence,
+                evidence_ids=evidence_ids,
+                review_note=review_note,
+                review_status=review_status,
+                claim_type=claim_type,
+                text=text,
+            )
+
+            # Atomic rewrite responsibility (issue #317): the LLM atomic rewrite is
+            # performed by ClaimQualificationAgent. The builder no longer rewrites;
+            # it consumes the agent's atomic candidates and only constructs / links /
+            # validates ClaimObjectRecords.
+            llm_atomic = self._gather_llm_atomic_candidates(span, claim_type)
+            if llm_atomic:
+                self._emit_llm_atomic_claims(
+                    claims, issues, seen_claim_ids, counter, base_claim_id, ctx, llm_atomic
+                )
+                continue
+
+            # No LLM rewrite available. Classify the span text deterministically.
             text_atomicity, text_qual_reason = self._analyze_atomicity(text)
-            if not (split_candidates and isinstance(split_candidates, list)):
-                if text_atomicity == "non_atomic":
-                    auto_parts = self._split_into_atomic(text)
-                    if len(auto_parts) >= 2:
-                        split_candidates = [
-                            {"text": p, "claim_type": claim_type} for p in auto_parts
-                        ]
-                        auto_split = True
-            if split_candidates and isinstance(split_candidates, list):
-                parent_id = base_claim_id
-                if parent_id in seen_claim_ids:
-                    parent_id = f"{parent_id}_{counter}"
-                seen_claim_ids.add(parent_id)
-                subclaim_ids: list[str] = []
-                for sub_idx, sub in enumerate(split_candidates, start=1):
-                    sub_text = str(sub.get("text", "")).strip() if isinstance(sub, dict) else text
-                    if not sub_text:
-                        continue
-                    sub_type = self._normalize_claim_type(
-                        (sub.get("claim_type") if isinstance(sub, dict) else None)
-                        or claim_type
-                    )
-                    sub_id = f"{parent_id}_sub{sub_idx:02d}"
-                    if sub_id in seen_claim_ids:
-                        sub_id = f"{sub_id}_{counter}"
-                    seen_claim_ids.add(sub_id)
-                    subclaim_ids.append(sub_id)
-                    sub_concepts = self._resolve_concepts(sub_text, role_labels, span)
-                    sub_eqs = self._link_equations(sub_text, sub_type, role_labels, block_id, section_id)
-                    claims.append(ClaimObjectRecord(
-                        claim_id=sub_id,
-                        document_id=document_id,
-                        claim_type=sub_type,
-                        text=sub_text,
-                        source_evidence_ids=evidence_ids,
-                        source_span_ids=[span_id] if span_id else [],
-                        concepts=sub_concepts,
-                        equation_ids=sub_eqs,
-                        figure_ids=[],
-                        table_ids=[],
-                        support_status="source_backed" if evidence_ids else "inferred",
-                        review_status=review_status,
-                        review_note=review_note,
-                        section_id=section_id,
-                        confidence=confidence,
-                        normalized_text=sub_text,
-                        atomicity="atomic",
-                        is_atomic=True,
-                        qualification_reason=None,
-                        parent_claim_id=parent_id,
-                        subclaim_ids=[],
-                    ))
-                # Compound parent record (no text of its own, just tracks subclaims).
-                # The parent is split into atomic children, so it is itself not
-                # atomic backing (is_atomic=False) — graph nodes prefer the children.
-                parent_concepts = self._resolve_concepts(text, role_labels, span)
-                parent_eqs = self._link_equations(text, claim_type, role_labels, block_id, section_id)
-                claims.append(ClaimObjectRecord(
-                    claim_id=parent_id,
-                    document_id=document_id,
-                    claim_type=claim_type,
-                    text=text,
-                    source_evidence_ids=evidence_ids,
-                    source_span_ids=[span_id] if span_id else [],
-                    concepts=parent_concepts,
-                    equation_ids=parent_eqs,
-                    figure_ids=[],
-                    table_ids=[],
-                    support_status="source_backed" if evidence_ids else "inferred",
-                    review_status=review_status,
-                    review_note=review_note,
-                    section_id=section_id,
-                    confidence=confidence,
-                    normalized_text=text,
-                    atomicity="compound",
-                    is_atomic=False,
-                    qualification_reason=(
-                        "deterministically split into atomic child claims; verify split"
-                        if auto_split
-                        else "split into atomic child claims"
-                    ),
-                    parent_claim_id=None,
-                    subclaim_ids=subclaim_ids,
-                ))
-                self._add_issues_for_record(parent_id, evidence_ids, parent_concepts, claim_type, parent_eqs, issues)
-                if auto_split and subclaim_ids:
-                    issues.append(ValidationIssue(
-                        rule_id="claim_auto_split",
-                        severity="warning",
-                        message=(
-                            f"claim {parent_id} was deterministically split into "
-                            f"{len(subclaim_ids)} atomic claims; review the split"
-                        ),
-                        field=parent_id,
-                    ))
-                if not subclaim_ids:
-                    issues.append(ValidationIssue(
-                        rule_id="split_required_but_no_children",
-                        severity="warning",
-                        message=(
-                            f"claim {parent_id} was marked for splitting but no child "
-                            "claims were produced"
-                        ),
-                        field=parent_id,
-                    ))
+
+            # Non-atomic span with no LLM rewrite: the deterministic split is kept
+            # only as a review suggestion (issue #317 criteria #4 / #6). Neither the
+            # parent nor the suggested children are confirmed source_backed atomic
+            # claims, so they are not used as strong graph backing.
+            if text_atomicity == "non_atomic":
+                self._emit_fallback_split(
+                    claims, issues, seen_claim_ids, counter, base_claim_id, ctx,
+                    text_qual_reason,
+                )
                 continue
 
             # Single atomic claim
@@ -294,38 +242,8 @@ class ClaimObjectBuilder:
 
             figure_ids, table_ids = self._link_figures_tables(role_labels, claim_type)
 
-            # Atomicity (issue #312): a multi-proposition claim that could neither
-            # be split upstream nor deterministically split here is not a confirmed
-            # atomic claim. Keep the information (never drop it) but mark it
-            # review_required so graph nodes do not treat it as strong atomic backing.
-            atomicity, qualification_reason = text_atomicity, text_qual_reason
-            if atomicity == "non_atomic":
-                support_status = "review_required"
-                is_atomic = False
-                issues.append(ValidationIssue(
-                    rule_id="claim_text_multiple_propositions",
-                    severity="warning",
-                    message=(
-                        f"claim {claim_id} contains multiple propositions; "
-                        "split into atomic claims required"
-                    ),
-                    field=claim_id,
-                ))
-                if claim_type in MAIN_RESULT_CLAIM_TYPES:
-                    issues.append(ValidationIssue(
-                        rule_id="main_result_claim_non_atomic",
-                        severity="error",
-                        message=(
-                            f"main-result claim {claim_id} ({claim_type}) is non_atomic; "
-                            "a main result must be a single minimal proposition"
-                        ),
-                        field=claim_id,
-                    ))
-            else:
-                support_status = "source_backed" if evidence_ids else "inferred"
-                is_atomic = True
-                qualification_reason = None
-
+            # Single, already-atomic claim (non-atomic spans were routed to the
+            # LLM-atomic or deterministic-fallback paths above, issue #317).
             record = ClaimObjectRecord(
                 claim_id=claim_id,
                 document_id=document_id,
@@ -337,15 +255,15 @@ class ClaimObjectBuilder:
                 equation_ids=equation_ids,
                 figure_ids=figure_ids,
                 table_ids=table_ids,
-                support_status=support_status,
+                support_status="source_backed" if evidence_ids else "inferred",
                 review_status=review_status,
                 review_note=review_note,
                 section_id=section_id,
                 confidence=confidence,
                 normalized_text=text,
-                atomicity=atomicity,
-                is_atomic=is_atomic,
-                qualification_reason=qualification_reason,
+                atomicity="atomic",
+                is_atomic=True,
+                qualification_reason=None,
                 parent_claim_id=None,
                 subclaim_ids=[],
             )
@@ -389,6 +307,320 @@ class ClaimObjectBuilder:
                 severity="warning",
                 message=f"claim {claim_id} of type {claim_type} should reference equations",
                 field=claim_id,
+            ))
+
+    # ------------------------------------------------------------------
+    # Atomic-claim sourcing (issue #317).
+    # ------------------------------------------------------------------
+    def _gather_llm_atomic_candidates(
+        self, span: object, default_claim_type: str
+    ) -> list[dict]:
+        """Collect LLM-rewritten atomic claim candidates from the span.
+
+        Primary source is ``span.atomic_claims`` (produced by ClaimQualificationAgent,
+        issue #317). For backward compatibility, falls back to the legacy
+        ``edit_suggestions.split_claims`` ({text, claim_type}) list. Returns an empty
+        list when the agent provided no atomic rewrite — in that case the builder
+        only keeps a deterministic split as a review suggestion.
+        """
+        normalized: list[dict] = []
+        for cand in getattr(span, "atomic_claims", None) or []:
+            if not isinstance(cand, dict):
+                continue
+            text = str(cand.get("text", "")).strip()
+            if not text:
+                continue
+            atomicity = str(cand.get("atomicity", "atomic")).strip().lower()
+            if atomicity not in ("atomic", "non_atomic"):
+                atomicity = "atomic"
+            status = str(cand.get("status", "")).strip().lower()
+            if status not in ("accepted", "review_required"):
+                status = "review_required" if atomicity == "non_atomic" else "accepted"
+            normalized.append({
+                "text": text,
+                "normalized_text": str(cand.get("normalized_text") or text).strip(),
+                "claim_type": self._normalize_claim_type(
+                    cand.get("claim_type_candidate")
+                    or cand.get("claim_type")
+                    or default_claim_type
+                ),
+                "atomicity": atomicity,
+                "status": status,
+                "qualification_reason": str(cand.get("qualification_reason", "") or ""),
+                "source_span_id": str(cand.get("source_span_id", "") or ""),
+            })
+        if normalized:
+            return normalized
+
+        # Legacy: edit_suggestions.split_claims (LLM-proposed atomic objects).
+        edits = getattr(span, "edit_suggestions", {}) or {}
+        for cand in edits.get("split_claims") or []:
+            if not isinstance(cand, dict):
+                continue
+            text = str(cand.get("text", "")).strip()
+            if not text:
+                continue
+            normalized.append({
+                "text": text,
+                "normalized_text": text,
+                "claim_type": self._normalize_claim_type(
+                    cand.get("claim_type") or default_claim_type
+                ),
+                "atomicity": "atomic",
+                "status": "accepted",
+                "qualification_reason": "",
+                "source_span_id": "",
+            })
+        return normalized
+
+    @staticmethod
+    def _dedup_id(base: str, counter: int, seen: set[str]) -> str:
+        cid = base
+        if cid in seen:
+            cid = f"{cid}_{counter}"
+        while cid in seen:
+            cid = f"{cid}_x"
+        seen.add(cid)
+        return cid
+
+    def _emit_llm_atomic_claims(
+        self,
+        claims: list[ClaimObjectRecord],
+        issues: list[ValidationIssue],
+        seen: set[str],
+        counter: int,
+        base_claim_id: str,
+        ctx: _BuildCtx,
+        candidates: list[dict],
+    ) -> None:
+        """Build ClaimObjectRecords from LLM atomic candidates (issue #317).
+
+        The builder performs no rewrite — it only constructs / links / validates.
+        A single accepted atomic candidate becomes one atomic claim; multiple
+        candidates become a compound parent (not atomic backing) with atomic
+        children.
+        """
+        accepted = [
+            c for c in candidates if c["atomicity"] == "atomic" and c["status"] == "accepted"
+        ]
+        if len(candidates) == 1 and len(accepted) == 1:
+            claim_id = self._dedup_id(base_claim_id, counter, seen)
+            self._append_atomic_child(claims, issues, ctx, claim_id, candidates[0], parent_id=None)
+            return
+
+        parent_id = self._dedup_id(base_claim_id, counter, seen)
+        subclaim_ids: list[str] = []
+        for idx, cand in enumerate(candidates, start=1):
+            sub_id = self._dedup_id(f"{parent_id}_sub{idx:02d}", counter, seen)
+            subclaim_ids.append(sub_id)
+            self._append_atomic_child(claims, issues, ctx, sub_id, cand, parent_id=parent_id)
+
+        # Compound parent: tracks the original span but is not atomic backing.
+        parent_concepts = self._resolve_concepts(ctx.text, ctx.role_labels, ctx.span)
+        parent_eqs = self._link_equations(
+            ctx.text, ctx.claim_type, ctx.role_labels, ctx.block_id, ctx.section_id
+        )
+        claims.append(ClaimObjectRecord(
+            claim_id=parent_id,
+            document_id=ctx.document_id,
+            claim_type=ctx.claim_type,
+            text=ctx.text,
+            source_evidence_ids=ctx.evidence_ids,
+            source_span_ids=[ctx.span_id] if ctx.span_id else [],
+            concepts=parent_concepts,
+            equation_ids=parent_eqs,
+            figure_ids=[],
+            table_ids=[],
+            support_status="source_backed" if ctx.evidence_ids else "inferred",
+            review_status=ctx.review_status,
+            review_note=ctx.review_note,
+            section_id=ctx.section_id,
+            confidence=ctx.confidence,
+            normalized_text=ctx.text,
+            atomicity="compound",
+            is_atomic=False,
+            qualification_reason="atomic rewrite by ClaimQualificationAgent",
+            parent_claim_id=None,
+            subclaim_ids=subclaim_ids,
+        ))
+        self._add_issues_for_record(
+            parent_id, ctx.evidence_ids, parent_concepts, ctx.claim_type, parent_eqs, issues
+        )
+
+    def _append_atomic_child(
+        self,
+        claims: list[ClaimObjectRecord],
+        issues: list[ValidationIssue],
+        ctx: _BuildCtx,
+        claim_id: str,
+        cand: dict,
+        parent_id: str | None,
+    ) -> None:
+        text = cand.get("normalized_text") or cand["text"]
+        claim_type = cand["claim_type"]
+        concepts = self._resolve_concepts(text, ctx.role_labels, ctx.span)
+        equation_ids = self._link_equations(
+            text, claim_type, ctx.role_labels, ctx.block_id, ctx.section_id
+        )
+        source_span_id = cand.get("source_span_id") or ctx.span_id
+
+        if cand["atomicity"] == "atomic" and cand["status"] == "accepted":
+            atomicity = "atomic"
+            is_atomic = True
+            support_status = "source_backed" if ctx.evidence_ids else "inferred"
+            qualification_reason = None
+        else:
+            # The agent flagged this piece as not confidently atomized.
+            atomicity = "non_atomic"
+            is_atomic = False
+            support_status = "review_required"
+            qualification_reason = (
+                cand.get("qualification_reason")
+                or "atomic rewrite incomplete; review required"
+            )
+            issues.append(ValidationIssue(
+                rule_id="atomic_claim_needs_review",
+                severity="warning",
+                message=(
+                    f"atomic claim {claim_id} was flagged non_atomic by "
+                    "ClaimQualificationAgent; review required"
+                ),
+                field=claim_id,
+            ))
+
+        claims.append(ClaimObjectRecord(
+            claim_id=claim_id,
+            document_id=ctx.document_id,
+            claim_type=claim_type,
+            text=text,
+            source_evidence_ids=ctx.evidence_ids,
+            source_span_ids=[source_span_id] if source_span_id else [],
+            concepts=concepts,
+            equation_ids=equation_ids,
+            figure_ids=[],
+            table_ids=[],
+            support_status=support_status,
+            review_status=ctx.review_status,
+            review_note=ctx.review_note,
+            section_id=ctx.section_id,
+            confidence=ctx.confidence,
+            normalized_text=text,
+            atomicity=atomicity,
+            is_atomic=is_atomic,
+            qualification_reason=qualification_reason,
+            parent_claim_id=parent_id,
+            subclaim_ids=[],
+        ))
+        self._add_issues_for_record(
+            claim_id, ctx.evidence_ids, concepts, claim_type, equation_ids, issues
+        )
+
+    def _emit_fallback_split(
+        self,
+        claims: list[ClaimObjectRecord],
+        issues: list[ValidationIssue],
+        seen: set[str],
+        counter: int,
+        base_claim_id: str,
+        ctx: _BuildCtx,
+        text_qual_reason: str | None,
+    ) -> None:
+        """Deterministic split kept as a review suggestion only (issue #317 #4/#6).
+
+        The builder does NOT confirm a deterministic split as atomic / source_backed.
+        The original span is kept as a non_atomic parent (review_required) and the
+        mechanical split is attached as ``split_pending`` children (review_required).
+        Neither is used as strong graph backing (is_atomic=False).
+        """
+        parent_id = self._dedup_id(base_claim_id, counter, seen)
+        parts = self._split_into_atomic(ctx.text)
+        subclaim_ids: list[str] = []
+        for idx, part in enumerate(parts, start=1):
+            part = (part or "").strip()
+            if not part:
+                continue
+            sub_id = self._dedup_id(f"{parent_id}_sub{idx:02d}", counter, seen)
+            subclaim_ids.append(sub_id)
+            sub_concepts = self._resolve_concepts(part, ctx.role_labels, ctx.span)
+            sub_eqs = self._link_equations(
+                part, ctx.claim_type, ctx.role_labels, ctx.block_id, ctx.section_id
+            )
+            claims.append(ClaimObjectRecord(
+                claim_id=sub_id,
+                document_id=ctx.document_id,
+                claim_type=ctx.claim_type,
+                text=part,
+                source_evidence_ids=ctx.evidence_ids,
+                source_span_ids=[ctx.span_id] if ctx.span_id else [],
+                concepts=sub_concepts,
+                equation_ids=sub_eqs,
+                figure_ids=[],
+                table_ids=[],
+                support_status="review_required",
+                review_status=ctx.review_status,
+                review_note=ctx.review_note,
+                section_id=ctx.section_id,
+                confidence=ctx.confidence,
+                normalized_text=part,
+                atomicity="split_pending",
+                is_atomic=False,
+                qualification_reason="deterministic split requires review",
+                parent_claim_id=parent_id,
+                subclaim_ids=[],
+            ))
+
+        parent_concepts = self._resolve_concepts(ctx.text, ctx.role_labels, ctx.span)
+        parent_eqs = self._link_equations(
+            ctx.text, ctx.claim_type, ctx.role_labels, ctx.block_id, ctx.section_id
+        )
+        claims.append(ClaimObjectRecord(
+            claim_id=parent_id,
+            document_id=ctx.document_id,
+            claim_type=ctx.claim_type,
+            text=ctx.text,
+            source_evidence_ids=ctx.evidence_ids,
+            source_span_ids=[ctx.span_id] if ctx.span_id else [],
+            concepts=parent_concepts,
+            equation_ids=parent_eqs,
+            figure_ids=[],
+            table_ids=[],
+            support_status="review_required",
+            review_status=ctx.review_status,
+            review_note=ctx.review_note,
+            section_id=ctx.section_id,
+            confidence=ctx.confidence,
+            normalized_text=ctx.text,
+            atomicity="non_atomic",
+            is_atomic=False,
+            qualification_reason=(
+                text_qual_reason
+                or "contains multiple propositions; LLM atomic rewrite required"
+            ),
+            parent_claim_id=None,
+            subclaim_ids=subclaim_ids,
+        ))
+        self._add_issues_for_record(
+            parent_id, ctx.evidence_ids, parent_concepts, ctx.claim_type, parent_eqs, issues
+        )
+        issues.append(ValidationIssue(
+            rule_id="claim_split_pending_review",
+            severity="warning",
+            message=(
+                f"claim {parent_id} contains multiple propositions; the deterministic "
+                f"split ({len(subclaim_ids)} parts) is kept as a review suggestion and "
+                "must be confirmed by ClaimQualificationAgent before use as backing"
+            ),
+            field=parent_id,
+        ))
+        if ctx.claim_type in MAIN_RESULT_CLAIM_TYPES:
+            issues.append(ValidationIssue(
+                rule_id="main_result_claim_non_atomic",
+                severity="error",
+                message=(
+                    f"main-result claim {parent_id} ({ctx.claim_type}) is non_atomic; "
+                    "a main result must be a single minimal proposition"
+                ),
+                field=parent_id,
             ))
 
     # ------------------------------------------------------------------

--- a/src/episteme_graph/agents/claim_qualification/agent.py
+++ b/src/episteme_graph/agents/claim_qualification/agent.py
@@ -132,6 +132,7 @@ class ClaimQualificationAgent:
         deferred: list[dict] = []
         split_suggested = 0
         merge_suggested = 0
+        atomic_claims_total = 0
 
         for record in records:
             status = record.qualification.get("status")
@@ -149,6 +150,7 @@ class ClaimQualificationAgent:
                 or record.edit_suggestions.get("should_merge_with_next")
             ):
                 merge_suggested += 1
+            atomic_claims_total += len(getattr(record, "atomic_claims", None) or [])
 
         return ClaimQualificationResult(
             document_id=document_id,
@@ -162,5 +164,6 @@ class ClaimQualificationAgent:
                 "deferred": len(deferred),
                 "split_suggested": split_suggested,
                 "merge_suggested": merge_suggested,
+                "atomic_claims": atomic_claims_total,
             },
         )

--- a/src/episteme_graph/agents/claim_qualification/examples/sample_output.json
+++ b/src/episteme_graph/agents/claim_qualification/examples/sample_output.json
@@ -22,18 +22,89 @@
         "should_merge_with_next": false,
         "normalized_text_hint": "The correction originates from use of the physical hadron mass spectrum."
       },
+      "atomic_claims": [],
       "reason": "Reusable source-backed correction statement with explicit causal content.",
       "confidence": 0.92
+    },
+    {
+      "span_id": "span_002",
+      "block_id": "blk_007_0031",
+      "section_id": "sample_paper:sec_5",
+      "text": "The paper derives consistency relations by eliminating nuisance parameters and shows they can be used to test a target theory.",
+      "role_labels": ["result"],
+      "qualification": {
+        "status": "accepted",
+        "claim_tier": "paper_core",
+        "claim_type_candidate": "main_result",
+        "granularity": "too_broad",
+        "evidence_adequacy": "sufficient",
+        "reviewability": "good"
+      },
+      "edit_suggestions": {
+        "should_split": true,
+        "should_merge_with_prev": false,
+        "should_merge_with_next": false,
+        "normalized_text_hint": ""
+      },
+      "atomic_claims": [
+        {
+          "text": "Nuisance parameters appear in the observable equations.",
+          "normalized_text": "Nuisance parameters appear in the observable equations.",
+          "claim_type_candidate": "structural_property",
+          "atomicity": "atomic",
+          "status": "accepted",
+          "source_span_id": "span_002",
+          "evidence_quote": "eliminating nuisance parameters",
+          "qualification_reason": "single minimal proposition extracted from the paper-level summary.",
+          "confidence": 0.88
+        },
+        {
+          "text": "The nuisance parameters can be eliminated algebraically.",
+          "normalized_text": "The nuisance parameters can be eliminated algebraically.",
+          "claim_type_candidate": "derivation_result",
+          "atomicity": "atomic",
+          "status": "accepted",
+          "source_span_id": "span_002",
+          "evidence_quote": "eliminating nuisance parameters",
+          "qualification_reason": "single minimal proposition extracted from the paper-level summary.",
+          "confidence": 0.88
+        },
+        {
+          "text": "The elimination yields consistency relations.",
+          "normalized_text": "The elimination yields consistency relations.",
+          "claim_type_candidate": "derivation_result",
+          "atomicity": "atomic",
+          "status": "accepted",
+          "source_span_id": "span_002",
+          "evidence_quote": "derives consistency relations",
+          "qualification_reason": "single minimal proposition extracted from the paper-level summary.",
+          "confidence": 0.9
+        },
+        {
+          "text": "The consistency relations can be used to test the target theory.",
+          "normalized_text": "The consistency relations can be used to test the target theory.",
+          "claim_type_candidate": "main_result",
+          "atomicity": "atomic",
+          "status": "accepted",
+          "source_span_id": "span_002",
+          "evidence_quote": "can be used to test a target theory",
+          "qualification_reason": "single minimal proposition extracted from the paper-level summary.",
+          "confidence": 0.9
+        }
+      ],
+      "reason": "Paper-level summary; rewritten into atomic claims so each is a single minimal proposition.",
+      "confidence": 0.85
     }
   ],
   "rejected_spans": [],
   "deferred_spans": [],
   "summary_stats": {
-    "accepted": 1,
+    "accepted": 2,
     "rejected": 0,
     "deferred": 0,
-    "split_suggested": 0,
-    "merge_suggested": 0
+    "split_suggested": 1,
+    "merge_suggested": 0,
+    "atomic_claims": 4
   },
   "validation_issues": []
 }

--- a/src/episteme_graph/agents/claim_qualification/prompt.py
+++ b/src/episteme_graph/agents/claim_qualification/prompt.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 
 from .schema import (
+    ATOMIC_CLAIM_ATOMICITY,
+    ATOMIC_CLAIM_STATUSES,
     CLAIM_TIERS,
     CORE_CLAIM_TYPE_FALLBACKS,
     EVIDENCE_ADEQUACY,
@@ -15,17 +17,20 @@ from .schema import (
 )
 
 _SYSTEM_CONTENT = """\
-You are evaluating whether a span from a scientific paper should become a reusable claim.
+You are evaluating whether a span from a scientific paper should become a reusable claim,
+and—when the span mixes several statements—rewriting it into atomic claims.
 
 Your task is NOT to summarize the paper.
-Your task is to judge whether the span is a reusable minimal claim suitable for \
-downstream knowledge structuring.
+Your task is to (a) judge whether the span is a reusable minimal claim and
+(b) perform atomic rewrite: turn a long / paper-level / multi-proposition span into
+a list of atomic claims, each a single minimal proposition.
 
-A good claim should be:
+A good (atomic) claim should be:
 1. content-bearing
-2. minimally scoped
-3. reviewable against source text
-4. reusable in downstream components as input/output/precondition/caution
+2. one minimal proposition (1 claim = 1 fact / relation / step)
+3. a standalone sentence — full subject, no unresolved pronoun/anaphora
+4. reviewable against the source text
+5. reusable in downstream components as input/output/precondition/caution
 
 Rules:
 - role_labels are context, not final adoption decisions.
@@ -33,8 +38,24 @@ Rules:
 - Prior-work statements may be preserved, but must not be paper_core.
 - If uncertain, prefer deferred over an overconfident rejected/accepted decision.
 - Prefer cartridge-normalized terminology when available.
-- If a span contains multiple reusable propositions, set should_split=true and
-  provide split_claims as atomic claim objects with text and claim_type.
+
+Atomic rewrite (the formal responsibility of this step):
+- If the span contains multiple propositions (long sentence, several sentences,
+  coordinated clauses, or a paper-level summary), set should_split=true and emit
+  one entry per minimal proposition in `atomic_claims`.
+- Each atomic claim MUST be a complete standalone sentence:
+  * supply the omitted subject (do NOT start with "Shows ...", "And yields ...").
+  * resolve pronouns / "this result" into the concrete referent.
+  * never begin with a connector (and / but / therefore / then / thus / hence / moreover ...).
+- Preserve the full meaning of the original span across the atomic claims; drop nothing.
+- For each atomic claim set atomicity="atomic" and status="accepted".
+- If you CANNOT confidently atomize part of the span, keep that piece as an
+  atomic_claims entry with atomicity="non_atomic", status="review_required" and a
+  qualification_reason such as "contains multiple propositions; split required".
+- If the span is already a single minimal proposition, leave `atomic_claims` empty
+  and set should_split=false.
+- Each atomic claim must stay traceable: set source_span_id to the input span_id and
+  copy the supporting source phrase into evidence_quote.
 - Return ONLY valid JSON matching the provided schema.
 """
 
@@ -54,13 +75,23 @@ _OUTPUT_SCHEMA = {
     },
     "edit_suggestions": {
         "should_split": False,
-        "split_claims": [
-            {"text": "atomic claim text", "claim_type": "definition"}
-        ],
         "should_merge_with_prev": False,
         "should_merge_with_next": False,
         "normalized_text_hint": "string or empty",
     },
+    "atomic_claims": [
+        {
+            "text": "a single standalone minimal proposition",
+            "normalized_text": "normalized phrasing (cartridge terms when available)",
+            "claim_type_candidate": "core fallback type or cartridge-defined type",
+            "atomicity": "atomic | non_atomic",
+            "status": "accepted | review_required",
+            "source_span_id": "span_id this claim came from",
+            "evidence_quote": "supporting phrase copied from the source span",
+            "qualification_reason": "why this is (or is not) a confirmed atomic claim",
+            "confidence": 0.0,
+        }
+    ],
     "reason": "short reason grounded in the span and context",
     "confidence": 0.0,
 }
@@ -168,13 +199,18 @@ class ClaimQualificationPromptFactory:
             "claim_type_candidate core fallbacks: "
             + ", ".join(CORE_CLAIM_TYPE_FALLBACKS)
         )
+        parts.append(f"atomic_claims[].atomicity: {', '.join(ATOMIC_CLAIM_ATOMICITY)}")
+        parts.append(f"atomic_claims[].status: {', '.join(ATOMIC_CLAIM_STATUSES)}")
 
         parts.append("\n## Constraints")
         parts.append(
             "- accepted spans should be content-bearing and reviewable\n"
             "- prior_work may be accepted as prior_work tier, but must not be paper_core\n"
             "- figure_narration / section_meta / meta_discourse should usually be rejected as meta\n"
-            "- too_broad spans should normally set should_split=true\n"
+            "- too_broad / multi-proposition spans MUST set should_split=true and fill atomic_claims\n"
+            "- every atomic claim must be a standalone sentence (full subject, no leading connector)\n"
+            "- atomic claims together must preserve the full meaning of the span (drop nothing)\n"
+            "- if a piece cannot be atomized set its atomicity=non_atomic, status=review_required\n"
             "- too_narrow spans should normally be deferred/rejected or suggest merge\n"
             "- confidence must be between 0.0 and 1.0\n"
             "- Return ONLY valid JSON, no markdown fences"

--- a/src/episteme_graph/agents/claim_qualification/repair.py
+++ b/src/episteme_graph/agents/claim_qualification/repair.py
@@ -78,6 +78,8 @@ def _parse_record(raw: dict, llm_input: QualificationLLMInput) -> QualifiedSpanR
     except (TypeError, ValueError):
         confidence = 0.5
 
+    atomic_claims = _normalize_atomic_claims(raw, edit_suggestions, llm_input)
+
     return QualifiedSpanRecord(
         span_id=raw.get("span_id", llm_input.span_id),
         block_id=raw.get("block_id", llm_input.block_id),
@@ -88,7 +90,67 @@ def _parse_record(raw: dict, llm_input: QualificationLLMInput) -> QualifiedSpanR
         edit_suggestions=edit_suggestions,
         reason=str(raw.get("reason", "")),
         confidence=max(0.0, min(1.0, confidence)),
+        atomic_claims=atomic_claims,
     )
+
+
+def _normalize_atomic_claims(
+    raw: dict,
+    edit_suggestions: dict,
+    llm_input: QualificationLLMInput,
+) -> list[dict]:
+    """Normalize LLM atomic-rewrite output (issue #317).
+
+    Reads the rich ``atomic_claims`` field; for backward compatibility, falls back
+    to legacy ``edit_suggestions.split_claims`` ({text, claim_type}) entries.
+    Every entry is coerced to the full atomic-claim shape so the downstream
+    ClaimObjectBuilder can treat them as confirmed LLM-rewritten candidates.
+    """
+    entries = raw.get("atomic_claims")
+    legacy = False
+    if not isinstance(entries, list) or not entries:
+        # Backward compat: older prompt emitted edit_suggestions.split_claims.
+        entries = (raw.get("edit_suggestions") or {}).get("split_claims")
+        legacy = True
+    if not isinstance(entries, list):
+        return []
+
+    normalized: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        atomicity = str(entry.get("atomicity", "atomic")).strip().lower()
+        if atomicity not in ("atomic", "non_atomic"):
+            atomicity = "atomic"
+        status = str(entry.get("status", "")).strip().lower()
+        if status not in ("accepted", "review_required"):
+            status = "review_required" if atomicity == "non_atomic" else "accepted"
+        try:
+            conf = float(entry.get("confidence", llm_input and 0.0))
+        except (TypeError, ValueError):
+            conf = 0.0
+        normalized.append({
+            "text": text,
+            "normalized_text": str(entry.get("normalized_text", "") or text).strip(),
+            "claim_type_candidate": str(
+                entry.get("claim_type_candidate")
+                or entry.get("claim_type")
+                or ""
+            ).strip(),
+            "atomicity": atomicity,
+            "status": status,
+            "source_span_id": str(entry.get("source_span_id") or llm_input.span_id),
+            "evidence_quote": str(entry.get("evidence_quote", "") or ""),
+            "qualification_reason": str(
+                entry.get("qualification_reason", "")
+                or ("legacy split_claims candidate" if legacy else "")
+            ),
+            "confidence": max(0.0, min(1.0, conf)),
+        })
+    return normalized
 
 
 def _fallback_record(llm_input: QualificationLLMInput, reason: str) -> QualifiedSpanRecord:

--- a/src/episteme_graph/agents/claim_qualification/schema.py
+++ b/src/episteme_graph/agents/claim_qualification/schema.py
@@ -10,6 +10,24 @@ GRANULARITIES = ["good", "too_broad", "too_narrow"]
 EVIDENCE_ADEQUACY = ["sufficient", "weak", "broken"]
 REVIEWABILITY = ["good", "moderate", "poor"]
 
+# Atomic rewrite vocabulary (issue #317). The ClaimQualificationAgent is the
+# formal step that turns a long / paper-level / multi-proposition span into
+# atomic claim candidates. Each candidate carries its own atomicity verdict:
+#   atomic        — single minimal proposition (usable as confirmed backing)
+#   non_atomic    — still mixes propositions; could not be atomized (review only)
+ATOMIC_CLAIM_ATOMICITY = ["atomic", "non_atomic"]
+# Per-atomic-claim status. ``review_required`` is used when the agent could not
+# produce a confident single proposition and the candidate must be reviewed.
+ATOMIC_CLAIM_STATUSES = ["accepted", "review_required"]
+
+# Connectors / discourse markers that an atomic claim must NOT begin with
+# (criterion #3): a fragment starting with these is not a standalone proposition.
+ATOMIC_CLAIM_LEADING_CONNECTORS = {
+    "and", "but", "or", "so", "then", "thus", "hence", "therefore",
+    "moreover", "furthermore", "however", "whereas", "while", "also",
+    "additionally", "besides", "nor", "yet", "because", "since",
+}
+
 CORE_CLAIM_TYPE_FALLBACKS = [
     "definition",
     "observable_definition",
@@ -29,6 +47,17 @@ CORE_CLAIM_TYPE_FALLBACKS = [
     "background",
     "prior_work",
     "meta",
+    # issue #312 / #317 required vocabulary (kept compatible with the builder's
+    # CLAIM_TYPE_ONTOLOGY) so atomic claims can be typed without collapsing to
+    # "unknown".
+    "problem_statement",
+    "method",
+    "structural_property",
+    "derivation_result",
+    "main_result",
+    "interpretation",
+    "conclusion",
+    "comparison",
     "unknown",
 ]
 
@@ -83,6 +112,11 @@ class QualifiedSpanRecord:
     edit_suggestions: dict
     reason: str
     confidence: float
+    # Atomic claim candidates produced by the LLM atomic-rewrite step (issue #317).
+    # Each entry is a dict with: text, normalized_text, claim_type_candidate,
+    # atomicity, status, source_span_id, evidence_quote, qualification_reason,
+    # confidence. Empty when the span is already atomic or no rewrite was needed.
+    atomic_claims: list[dict] = field(default_factory=list)
 
 
 @dataclass

--- a/src/episteme_graph/agents/claim_qualification/validator.py
+++ b/src/episteme_graph/agents/claim_qualification/validator.py
@@ -1,7 +1,12 @@
 """Validation for ClaimQualificationAgent outputs."""
 from __future__ import annotations
 
+import re
+
 from .schema import (
+    ATOMIC_CLAIM_ATOMICITY,
+    ATOMIC_CLAIM_LEADING_CONNECTORS,
+    ATOMIC_CLAIM_STATUSES,
     CLAIM_TIERS,
     CORE_CLAIM_TYPE_FALLBACKS,
     EVIDENCE_ADEQUACY,
@@ -37,6 +42,7 @@ class ClaimQualificationValidator:
         issues += self._check_confidence(records)
         issues += self._check_consistency(records)
         issues += self._check_claim_type_candidates(records, cartridge)
+        issues += self._check_atomic_claims(records)
         return issues
 
     def _all_records(self, result: ClaimQualificationResult) -> list[QualifiedSpanRecord]:
@@ -67,6 +73,7 @@ class ClaimQualificationValidator:
             edit_suggestions=raw.get("edit_suggestions", {}),
             reason=raw.get("reason", ""),
             confidence=float(raw.get("confidence", 0.0)),
+            atomic_claims=list(raw.get("atomic_claims", []) or []),
         )
 
     def _check_required_vocabularies(
@@ -186,6 +193,102 @@ class ClaimQualificationValidator:
                     message=f"{record.span_id} has unsupported claim_type_candidate={value!r}",
                     field=f"{record.span_id}.qualification.claim_type_candidate",
                 ))
+        return issues
+
+    def _check_atomic_claims(
+        self, records: list[QualifiedSpanRecord]
+    ) -> list[ValidationIssue]:
+        """Validate LLM atomic-rewrite output (issue #317, criteria #2 / #3 / #9)."""
+        issues: list[ValidationIssue] = []
+        for record in records:
+            atomic_claims = getattr(record, "atomic_claims", None) or []
+            suggestions = record.edit_suggestions or {}
+            granularity = record.qualification.get("granularity")
+
+            # too_broad / should_split spans should carry atomic claims (criterion #1).
+            if (
+                record.qualification.get("status") == "accepted"
+                and (granularity == "too_broad" or suggestions.get("should_split"))
+                and not atomic_claims
+            ):
+                issues.append(ValidationIssue(
+                    rule_id="split_required_without_atomic_claims",
+                    severity="warning",
+                    message=(
+                        f"{record.span_id} is marked for splitting but has no atomic_claims"
+                    ),
+                    field=f"{record.span_id}.atomic_claims",
+                ))
+
+            for idx, claim in enumerate(atomic_claims):
+                path = f"{record.span_id}.atomic_claims[{idx}]"
+                if not isinstance(claim, dict):
+                    issues.append(ValidationIssue(
+                        rule_id="atomic_claim_not_object",
+                        severity="error",
+                        message=f"{path} is not an object",
+                        field=path,
+                    ))
+                    continue
+                text = str(claim.get("text", "")).strip()
+                if not text:
+                    issues.append(ValidationIssue(
+                        rule_id="atomic_claim_empty_text",
+                        severity="error",
+                        message=f"{path} has empty text",
+                        field=path,
+                    ))
+                    continue
+                atomicity = str(claim.get("atomicity", "atomic"))
+                if atomicity not in ATOMIC_CLAIM_ATOMICITY:
+                    issues.append(ValidationIssue(
+                        rule_id="invalid_atomic_claim_atomicity",
+                        severity="error",
+                        message=f"{path} has invalid atomicity={atomicity!r}",
+                        field=f"{path}.atomicity",
+                    ))
+                status = str(claim.get("status", "accepted"))
+                if status not in ATOMIC_CLAIM_STATUSES:
+                    issues.append(ValidationIssue(
+                        rule_id="invalid_atomic_claim_status",
+                        severity="error",
+                        message=f"{path} has invalid status={status!r}",
+                        field=f"{path}.status",
+                    ))
+                # criterion #3: a confirmed atomic claim must be a standalone
+                # proposition — no leading connector and not a bare fragment.
+                if atomicity == "atomic" and status == "accepted":
+                    first = re.findall(r"[A-Za-z]+", text)
+                    if first and first[0].lower() in ATOMIC_CLAIM_LEADING_CONNECTORS:
+                        issues.append(ValidationIssue(
+                            rule_id="atomic_claim_starts_with_connector",
+                            severity="error",
+                            message=(
+                                f"{path} starts with connector {first[0]!r}; "
+                                "an atomic claim must be a standalone proposition"
+                            ),
+                            field=f"{path}.text",
+                        ))
+                    if len(text.split()) < 3:
+                        issues.append(ValidationIssue(
+                            rule_id="atomic_claim_too_short",
+                            severity="warning",
+                            message=f"{path} is too short to be a full proposition",
+                            field=f"{path}.text",
+                        ))
+                    # criterion #5: confirmed atomic claims must stay traceable.
+                    if not str(claim.get("source_span_id", "")).strip() and not str(
+                        claim.get("evidence_quote", "")
+                    ).strip():
+                        issues.append(ValidationIssue(
+                            rule_id="atomic_claim_missing_source",
+                            severity="warning",
+                            message=(
+                                f"{path} has no source_span_id or evidence_quote; "
+                                "it cannot be traced back to the source"
+                            ),
+                            field=path,
+                        ))
         return issues
 
     @staticmethod

--- a/src/tests/agents/claim_object_builder/test_builder.py
+++ b/src/tests/agents/claim_object_builder/test_builder.py
@@ -223,35 +223,112 @@ def test_atomic_claim_marks_is_atomic_and_normalized_text():
     assert claim.qualification_reason is None
 
 
-def test_non_atomic_claim_is_split_into_atomic_children():
-    # The core of #312: a long undivided claim is deterministically split into
-    # atomic child claims (compound parent + atomic children), not just flagged.
+def test_non_atomic_claim_without_llm_rewrite_is_split_pending():
+    # Issue #317 criteria #4 / #6: with no LLM atomic rewrite, the builder keeps the
+    # deterministic split only as a review suggestion. Neither the non_atomic parent
+    # nor the split_pending children are confirmed source_backed atomic claims.
     registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
     spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="method_choice")]
     builder = ClaimObjectBuilder(evidence_registry=registry)
     result = builder.build("doc_test", spans)
 
-    parent = [c for c in result.claims if c.atomicity == "compound"]
-    children = [c for c in result.claims if c.parent_claim_id and c.atomicity == "atomic"]
+    parent = [c for c in result.claims if c.atomicity == "non_atomic"]
+    children = [c for c in result.claims if c.parent_claim_id and c.atomicity == "split_pending"]
     assert len(parent) == 1
     assert parent[0].is_atomic is False
+    assert parent[0].support_status == "review_required"
     assert len(children) >= 2
-    assert all(c.is_atomic for c in children)
+    assert all(not c.is_atomic for c in children)
+    assert all(c.support_status == "review_required" for c in children)
+    assert all(c.qualification_reason == "deterministic split requires review" for c in children)
     rules = {i.rule_id for i in result.validation_issues}
-    assert "claim_auto_split" in rules
+    assert "claim_split_pending_review" in rules
 
 
-def test_main_result_long_claim_is_split_not_paper_summary():
-    # Criterion #3: a main-result claim must not remain a paper-level summary;
-    # it is split into atomic propositions and produces no non-atomic hard error.
+def test_main_result_long_claim_is_not_confirmed_without_llm_rewrite():
+    # Criterion #4: a long main-result claim must NOT be confirmed as a paper-level
+    # summary. Without an LLM atomic rewrite it stays non_atomic and is flagged.
     registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
     spans = [_make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="result")]
     builder = ClaimObjectBuilder(evidence_registry=registry)
     result = builder.build("doc_test", spans)
 
-    children = [c for c in result.claims if c.parent_claim_id and c.atomicity == "atomic"]
-    assert len(children) >= 2
+    parent = [c for c in result.claims if c.atomicity == "non_atomic"][0]
+    assert parent.is_atomic is False
+    assert parent.support_status != "source_backed"
+    assert "main_result_claim_non_atomic" in {i.rule_id for i in result.validation_issues}
+
+
+# ---------------------------------------------------------------------------
+# issue #317: LLM atomic rewrite consumed from ClaimQualificationAgent
+# ---------------------------------------------------------------------------
+
+def test_llm_atomic_claims_become_confirmed_atomic_children():
+    # Criteria #1 / #5 / #7: LLM-provided atomic claims are converted into a
+    # compound parent + confirmed atomic children that are source_backed and
+    # traceable to evidence.
+    registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
+    span = _make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT, claim_type="result")
+    span.atomic_claims = [
+        {"text": "Nuisance parameters appear in the observable equations.",
+         "atomicity": "atomic", "status": "accepted", "claim_type_candidate": "result"},
+        {"text": "The nuisance parameters can be eliminated algebraically.",
+         "atomicity": "atomic", "status": "accepted", "claim_type_candidate": "result"},
+        {"text": "The elimination yields consistency relations.",
+         "atomicity": "atomic", "status": "accepted", "claim_type_candidate": "result"},
+    ]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", [span])
+
+    parent = [c for c in result.claims if c.atomicity == "compound"][0]
+    children = [c for c in result.claims if c.parent_claim_id == parent.claim_id]
+    assert parent.is_atomic is False
+    assert len(children) == 3
+    assert all(c.is_atomic and c.atomicity == "atomic" for c in children)
+    assert all(c.support_status == "source_backed" for c in children)
+    assert all(c.source_evidence_ids for c in children)
+    assert all(c.source_span_ids == ["span_001"] for c in children)
     assert "main_result_claim_non_atomic" not in {i.rule_id for i in result.validation_issues}
+
+
+def test_single_llm_atomic_claim_has_no_compound_wrapper():
+    registry = _make_registry("blk_x", "The relation reduces in the limit.")
+    span = _make_qualified("span_001", "blk_x", "The relation reduces in the limit.")
+    span.atomic_claims = [
+        {"text": "The relation reduces in the zero-recoil limit.",
+         "atomicity": "atomic", "status": "accepted"},
+    ]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", [span])
+
+    assert len(result.claims) == 1
+    claim = result.claims[0]
+    assert claim.atomicity == "atomic"
+    assert claim.is_atomic is True
+    assert claim.text == "The relation reduces in the zero-recoil limit."
+    assert claim.support_status == "source_backed"
+
+
+def test_llm_non_atomic_candidate_is_marked_review_required():
+    registry = _make_registry("blk_x", _NON_ATOMIC_TEXT)
+    span = _make_qualified("span_001", "blk_x", _NON_ATOMIC_TEXT)
+    span.atomic_claims = [
+        {"text": "Nuisance parameters appear in the equations.",
+         "atomicity": "atomic", "status": "accepted"},
+        {"text": "The remaining clause could not be atomized cleanly here.",
+         "atomicity": "non_atomic", "status": "review_required",
+         "qualification_reason": "contains multiple propositions; split required"},
+    ]
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", [span])
+
+    review_children = [
+        c for c in result.claims if c.parent_claim_id and c.atomicity == "non_atomic"
+    ]
+    assert len(review_children) == 1
+    assert review_children[0].is_atomic is False
+    assert review_children[0].support_status == "review_required"
+    assert "atomic_claim_needs_review" in {i.rule_id for i in result.validation_issues}
 
 
 def test_main_result_normalizes_to_itself():

--- a/src/tests/agents/claim_qualification/test_agent.py
+++ b/src/tests/agents/claim_qualification/test_agent.py
@@ -261,6 +261,59 @@ def test_repair_called_on_invalid_status():
     assert result.qualified_spans[0].qualification["status"] == "accepted"
 
 
+def test_atomic_claims_flow_through_to_qualified_span():
+    # issue #317: the agent's atomic rewrite output is preserved on the record and
+    # counted in summary_stats.
+    agent = ClaimQualificationAgent()
+    text = "The paper derives consistency relations and shows they test a theory."
+    structure = DocumentStructureResult(
+        document_id="doc_test",
+        source_file="/tmp/test.pdf",
+        cartridge_id=None,
+        metadata=DocumentMetadata(title="Test", pages=1),
+        sections=[Section("sec_1", "Results", 1, 1, 1)],
+        blocks=[_typed("b1", text)],
+    )
+    roles = RhetoricalRoleResult(
+        document_id="doc_test",
+        cartridge_id=None,
+        role_annotations=[
+            BlockRoleAnnotation("b1", "sec_1", "result", [_span("s1", text, ["result"])])
+        ],
+        summary_stats={},
+    )
+    response = _response(
+        "s1", "b1", text, ["result"], "accepted", "paper_core", "main_result",
+        granularity="too_broad", split=True,
+    )
+    response["atomic_claims"] = [
+        {
+            "text": "The paper derives consistency relations.",
+            "claim_type_candidate": "derivation_result",
+            "atomicity": "atomic",
+            "status": "accepted",
+            "source_span_id": "s1",
+            "evidence_quote": "derives consistency relations",
+        },
+        {
+            "text": "The consistency relations can test a theory.",
+            "claim_type_candidate": "main_result",
+            "atomicity": "atomic",
+            "status": "accepted",
+            "source_span_id": "s1",
+            "evidence_quote": "shows they test a theory",
+        },
+    ]
+    with patch.object(agent._llm_client, "generate", return_value=response):
+        result = agent.run(structure, _skeleton(), roles)
+
+    span = result.qualified_spans[0]
+    assert len(span.atomic_claims) == 2
+    assert span.atomic_claims[0]["atomicity"] == "atomic"
+    assert span.atomic_claims[0]["source_span_id"] == "s1"
+    assert result.summary_stats["atomic_claims"] == 2
+
+
 def test_llm_failure_returns_deferred_fallback_record():
     agent = ClaimQualificationAgent()
     with patch.object(agent._llm_client, "generate", side_effect=RuntimeError("LLM error")):

--- a/src/tests/agents/claim_qualification/test_schema.py
+++ b/src/tests/agents/claim_qualification/test_schema.py
@@ -43,3 +43,51 @@ def test_to_json_round_trip():
     loaded = json.loads(raw)
     restored = ClaimQualificationResult.from_dict(loaded)
     assert restored.qualified_spans[0].qualification["status"] == "accepted"
+    assert restored.qualified_spans[0].atomic_claims == []
+
+
+def test_atomic_claims_round_trip():
+    record = QualifiedSpanRecord(
+        span_id="s1",
+        block_id="b1",
+        section_id="sec_1",
+        text="The paper derives X and shows Y.",
+        role_labels=["result"],
+        qualification={
+            "status": "accepted",
+            "claim_tier": "paper_core",
+            "claim_type_candidate": "main_result",
+            "granularity": "too_broad",
+            "evidence_adequacy": "sufficient",
+            "reviewability": "good",
+        },
+        edit_suggestions={"should_split": True},
+        reason="paper-level summary; rewritten",
+        confidence=0.85,
+        atomic_claims=[
+            {
+                "text": "The paper derives X.",
+                "normalized_text": "The paper derives X.",
+                "claim_type_candidate": "derivation_result",
+                "atomicity": "atomic",
+                "status": "accepted",
+                "source_span_id": "s1",
+                "evidence_quote": "derives X",
+                "qualification_reason": "single proposition",
+                "confidence": 0.9,
+            }
+        ],
+    )
+    result = ClaimQualificationResult(
+        document_id="doc",
+        cartridge_id=None,
+        qualified_spans=[record],
+        rejected_spans=[],
+        deferred_spans=[],
+        summary_stats={"accepted": 1, "atomic_claims": 1},
+    )
+    restored = ClaimQualificationResult.from_dict(json.loads(result.to_json()))
+    atomic = restored.qualified_spans[0].atomic_claims
+    assert len(atomic) == 1
+    assert atomic[0]["atomicity"] == "atomic"
+    assert atomic[0]["source_span_id"] == "s1"

--- a/src/tests/agents/claim_qualification/test_validator.py
+++ b/src/tests/agents/claim_qualification/test_validator.py
@@ -103,3 +103,71 @@ def test_cartridge_claim_type_is_allowed():
     q = {**_record().qualification, "claim_type_candidate": "domain_relation"}
     issues = VALIDATOR.validate(_result(_record(qualification=q)), cartridge)
     assert not any(i.rule_id == "invalid_claim_type_candidate" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# issue #317: atomic rewrite validation
+# ---------------------------------------------------------------------------
+
+def _atomic(**kwargs):
+    base = {
+        "text": "The nuisance parameters can be eliminated algebraically.",
+        "normalized_text": "The nuisance parameters can be eliminated algebraically.",
+        "claim_type_candidate": "result",
+        "atomicity": "atomic",
+        "status": "accepted",
+        "source_span_id": "s1",
+        "evidence_quote": "eliminating nuisance parameters",
+        "qualification_reason": "single proposition",
+        "confidence": 0.9,
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_valid_atomic_claims_have_no_errors():
+    r = _record(atomic_claims=[_atomic(), _atomic(text="The elimination yields consistency relations.")])
+    issues = VALIDATOR.validate(_result(r))
+    assert not [i for i in issues if i.severity == "error"]
+
+
+def test_atomic_claim_starting_with_connector_is_error():
+    r = _record(atomic_claims=[_atomic(text="And yields consistency relations.")])
+    issues = VALIDATOR.validate(_result(r))
+    assert any(i.rule_id == "atomic_claim_starts_with_connector" for i in issues)
+
+
+def test_atomic_claim_empty_text_is_error():
+    r = _record(atomic_claims=[_atomic(text="   ")])
+    issues = VALIDATOR.validate(_result(r))
+    assert any(i.rule_id == "atomic_claim_empty_text" for i in issues)
+
+
+def test_invalid_atomic_claim_atomicity_is_error():
+    r = _record(atomic_claims=[_atomic(atomicity="maybe")])
+    issues = VALIDATOR.validate(_result(r))
+    assert any(i.rule_id == "invalid_atomic_claim_atomicity" for i in issues)
+
+
+def test_atomic_claim_missing_source_is_warning():
+    r = _record(atomic_claims=[_atomic(source_span_id="", evidence_quote="")])
+    issues = VALIDATOR.validate(_result(r))
+    assert any(i.rule_id == "atomic_claim_missing_source" for i in issues)
+
+
+def test_too_broad_without_atomic_claims_is_warning():
+    q = {**_record().qualification, "granularity": "too_broad"}
+    r = _record(qualification=q, edit_suggestions={"should_split": True})
+    issues = VALIDATOR.validate(_result(r))
+    assert any(i.rule_id == "split_required_without_atomic_claims" for i in issues)
+
+
+def test_non_atomic_review_claim_skips_connector_check():
+    # A non_atomic/review_required candidate is allowed to remain a fragment.
+    r = _record(atomic_claims=[_atomic(
+        text="And could not be atomized.",
+        atomicity="non_atomic",
+        status="review_required",
+    )])
+    issues = VALIDATOR.validate(_result(r))
+    assert not any(i.rule_id == "atomic_claim_starts_with_connector" for i in issues)

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -582,3 +582,15 @@ def test_atomic_claim_produces_no_atomicity_issue():
     all_codes = [e.code for e in result.errors] + [r.code for r in result.review_items]
     assert "NON_ATOMIC_MAIN_RESULT_CLAIM" not in all_codes
     assert "NON_ATOMIC_CLAIM_NEEDS_SPLIT" not in all_codes
+
+
+def test_split_pending_claim_needs_confirmation():
+    """Deterministic-split suggestions are surfaced for review (issue #317)."""
+    claims = _ClaimObjectResult([
+        _ClaimObject("claim_001_sub01", atomicity="split_pending", claim_type="result"),
+    ])
+    result = _run_gate(claim_objects=claims)
+    review_codes = [r.code for r in result.review_items]
+    assert "SPLIT_PENDING_CLAIM_NEEDS_CONFIRMATION" in review_codes
+    # split_pending must not be treated as a non-atomic hard error
+    assert "NON_ATOMIC_MAIN_RESULT_CLAIM" not in [e.code for e in result.errors]


### PR DESCRIPTION
## Summary

Implements issue #317 by transferring atomic-claim rewriting responsibility from `ClaimObjectBuilder` to `ClaimQualificationAgent`. The builder now consumes LLM-rewritten atomic candidates and only constructs/links/validates `ClaimObjectRecord`s, rather than performing deterministic splitting itself.

## Key Changes

### ClaimQualificationAgent (Atomic Rewrite Producer)
- **prompt.py**: Updated system prompt to formalize atomic rewrite as a core responsibility. Added detailed rules for standalone propositions (no leading connectors, resolved pronouns, complete sentences).
- **schema.py**: Added vocabulary for atomic claims:
  - `ATOMIC_CLAIM_ATOMICITY = ["atomic", "non_atomic"]`
  - `ATOMIC_CLAIM_STATUSES = ["accepted", "review_required"]`
  - `ATOMIC_CLAIM_LEADING_CONNECTORS` set for validation
- **repair.py**: Added `_normalize_atomic_claims()` to normalize LLM output into a consistent shape. Supports both new `atomic_claims` field and legacy `edit_suggestions.split_claims` for backward compatibility.
- **validator.py**: Added `_check_atomic_claims()` to validate atomic-claim structure, atomicity/status values, and criterion #3 (no leading connectors, standalone sentences).
- **agent.py**: Updated summary stats to track `atomic_claims_total`.

### ClaimObjectBuilder (Atomic Rewrite Consumer)
- **builder.py**: Refactored main build loop to route spans based on LLM atomic availability:
  - Added `_BuildCtx` dataclass to share per-span context across build paths
  - Added `_gather_llm_atomic_candidates()` to collect LLM-rewritten atoms from `span.atomic_claims` (or legacy `edit_suggestions.split_claims`)
  - Added `_emit_llm_atomic_claims()` to build confirmed atomic children from LLM candidates
  - Added `_append_atomic_child()` to construct individual `ClaimObjectRecord`s with proper atomicity/support_status
  - Added `_emit_fallback_split()` to handle non-atomic spans without LLM rewrite: deterministic split is kept only as a review suggestion (`split_pending` atomicity, `review_required` support_status)
  - Removed deterministic splitting from the main atomic-claim path; now only used as fallback
  - Single atomic claims (non-atomic spans routed elsewhere) are now always confirmed as `is_atomic=True` and `support_status="source_backed"` (if evidence exists)

### Validation & Export
- **export_validation_gate.py**: Added check for `split_pending` atomicity to surface deterministic-split suggestions for teacher review (issue #317 criteria #4/#6).
- **test_export_validation_gate.py**: Added test for split_pending review items.

### Tests
- **test_builder.py**: 
  - Renamed `test_non_atomic_claim_is_split_into_atomic_children()` → `test_non_atomic_claim_without_llm_rewrite_is_split_pending()` to reflect new behavior
  - Updated assertions: non-atomic parent with `split_pending` children (not confirmed atomic)
  - Added `test_llm_atomic_claims_become_confirmed_atomic_children()` to verify LLM-rewritten atoms become source-backed claims
  - Added `test_main_result_long_claim_is_not_confirmed_without_llm_rewrite()` to verify main-result claims stay non-atomic without LLM rewrite
- **test_validator.py**: Added comprehensive atomic-claim validation tests (empty text, invalid atomicity/status, leading connectors, missing source)
- **test_agent.py**: Added `test_atomic_claims_flow_through_to_qualified_span()` to verify atomic claims are preserved through the agent
- **test_schema.py**: Added `test_atomic_claims_round_trip()` for JSON serialization

### Documentation
- **CLAUDE.md**: Updated pipeline diagram to note ClaimQualificationAgent now includes atomic rewrite

https://claude.ai/code/session_01BgonXAYETZ96QDFJNYJXym