### PR TITLE
Step 4: DerivationGraphAligner – separate theory/operation graphs

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -83,6 +83,17 @@ def _empty_refinement_validation() -> dict:
     }
 
 
+def _empty_derivation_graph_alignment() -> dict:
+    return {
+        "errors": [],
+        "warnings": [],
+        "review_items": [],
+        "component_graph_clean": True,
+        "operation_graph_clean": True,
+        "support_map_renderable": True,
+    }
+
+
 @dataclass
 class ExportValidationResult:
     status: str                          # one of EXPORT_STATUSES
@@ -97,6 +108,8 @@ class ExportValidationResult:
     concept_validation: dict = field(default_factory=_empty_concept_validation)
     # ComponentRefiner Step 3 reporting (issue #324).
     component_refinement_validation: dict = field(default_factory=_empty_refinement_validation)
+    # DerivationGraphAligner Step 4 reporting (issue #325).
+    derivation_graph_alignment: dict = field(default_factory=_empty_derivation_graph_alignment)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -157,6 +170,17 @@ def _ordered_unique(values) -> list:
             seen.add(text)
             result.append(text)
     return result
+
+
+def _alignment_code(entry) -> str:
+    code = str(entry.get("code") if isinstance(entry, dict) else entry or "issue")
+    return code.upper()
+
+
+def _alignment_message(entry) -> str:
+    if isinstance(entry, dict):
+        return str(entry.get("message") or entry.get("code") or "")
+    return str(entry or "")
 
 
 def _claim_is_non_atomic(claim) -> bool:
@@ -330,6 +354,14 @@ class ExportValidationGate:
             component_result, errors, warnings, review_items
         )
 
+        # 7e. derivation graph alignment reporting (#325): aggregate the
+        # DerivationGraphAligner Step 4 results (dangling refs / operation graph
+        # equation refs / support map renderability) into the export buckets.
+        # The gate aggregates results here; it does not re-run alignment.
+        derivation_graph_alignment = self._check_derivation_graph_alignment(
+            component_result, errors, warnings, review_items
+        )
+
         # 6. Determine status
         summary = ValidationSummary(
             error_count=len(errors),
@@ -365,6 +397,7 @@ class ExportValidationGate:
             summary=summary,
             concept_validation=concept_validation,
             component_refinement_validation=component_refinement_validation,
+            derivation_graph_alignment=derivation_graph_alignment,
         )
 
     # ------------------------------------------------------------------
@@ -843,6 +876,57 @@ class ExportValidationGate:
                 message=f"component {original_id!r} refinement requires review before publish-ready export",
                 artifact="component_assembly",
                 path=f"$.component_refinement[{original_id}]",
+                source_stage="export_validation",
+            ))
+
+        return result
+
+    def _check_derivation_graph_alignment(
+        self,
+        component_result,
+        errors: list,
+        warnings: list,
+        review_items: list,
+    ) -> dict:
+        """Aggregate DerivationGraphAligner Step 4 results (issue #325).
+
+        Reads the ``derivation_graph_alignment`` contract emitted by
+        DerivationGraphAligner and folds its pre-computed errors / warnings /
+        review items into the export buckets. The alignment logic lives in the
+        aligner; this method only aggregates and re-codes the entries.
+        """
+        alignment = getattr(component_result, "derivation_graph_alignment", {}) or {}
+        if not isinstance(alignment, dict):
+            return _empty_derivation_graph_alignment()
+        block = alignment.get("export_validation")
+        if not isinstance(block, dict):
+            return _empty_derivation_graph_alignment()
+
+        result = _empty_derivation_graph_alignment()
+        result.update({k: block.get(k, v) for k, v in result.items()})
+
+        for entry in result["errors"]:
+            errors.append(ValidationEntry(
+                code=f"DERIVATION_GRAPH_ALIGNMENT_{_alignment_code(entry)}",
+                message=_alignment_message(entry),
+                artifact="component_assembly",
+                path="$.derivation_graph_alignment",
+                source_stage="export_validation",
+            ))
+        for entry in result["warnings"]:
+            warnings.append(ValidationEntry(
+                code=f"DERIVATION_GRAPH_ALIGNMENT_{_alignment_code(entry)}",
+                message=_alignment_message(entry),
+                artifact="component_assembly",
+                path="$.derivation_graph_alignment",
+                source_stage="export_validation",
+            ))
+        for entry in result["review_items"]:
+            review_items.append(ValidationEntry(
+                code=f"DERIVATION_GRAPH_ALIGNMENT_{_alignment_code(entry)}",
+                message=_alignment_message(entry),
+                artifact="component_assembly",
+                path="$.derivation_graph_alignment",
                 source_stage="export_validation",
             ))
 

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -14,6 +14,7 @@ from episteme_graph.agents.id_canonicalization import (
 
 from .cartridge_loader import CartridgeLoader
 from .component_refiner import ComponentRefiner
+from .derivation_graph_aligner import DerivationGraphAligner
 from .enrichment import enrich_component_assembly
 from .granularity_analyzer import ComponentGranularityAnalyzer
 from .input_builder import ComponentAssemblyInputBuilder
@@ -42,6 +43,7 @@ class ComponentAssemblyAgent:
         self._repairer = ComponentAssemblyRepairer(cleanup=self._cleanup)
         self._refiner = ComponentRefiner()
         self._granularity_analyzer = ComponentGranularityAnalyzer()
+        self._derivation_graph_aligner = DerivationGraphAligner()
 
     def run(
         self,
@@ -144,6 +146,16 @@ class ComponentAssemblyAgent:
             result.validation_issues = self._validator.validate(
                 result, cartridge, llm_input=llm_input
             )
+
+        # Step 4: align refined components with derivation chains, equation
+        # operations, the theory component graph, and the support map. Disabled
+        # by default so the upstream contract stays stable until opted in.
+        if (config or {}).get("enable_derivation_graph_aligner", False):
+            alignment = self._derivation_graph_aligner.align(
+                result, llm_input=llm_input, derivations=derivations
+            )
+            result.derivation_graph_alignment = alignment.to_dict()
+
         merged_diagnostics = dict(diagnostics)
         merged_diagnostics.update(result.diagnostics or {})
         result.diagnostics = merged_diagnostics

--- a/src/episteme_graph/agents/component_assembly/derivation_graph_aligner.py
+++ b/src/episteme_graph/agents/component_assembly/derivation_graph_aligner.py
@@ -1,0 +1,1057 @@
+"""Step 4: DerivationGraphAligner (issue #325).
+
+Aligns refined components (Step 3 output) with derivation chains, equation
+operations, the theory component graph, and a headline-claim support map.
+
+This stage is deterministic (non-LLM). It separates -- but connects -- five
+artifacts that previously tended to leak into one another:
+
+1. ``theory_component_graph``     -- high-level refined-component dependency graph
+2. ``equation_operation_graph``   -- low-level equation manipulation graph
+3. ``component_operation_links``  -- refined component <-> equation operation map
+4. ``aligned_derivation_chains``  -- component-attributed derivation steps
+5. ``support_map``                -- headline-claim-centered support layers
+
+It also emits ``graph_alignment_validation`` (structural self-check) and an
+``export_validation`` aggregation block (``derivation_graph_alignment``) so the
+ExportValidationGate can surface results without re-implementing alignment.
+
+Design principles (see issue #325 and CLAUDE.md):
+- The component graph never contains raw equation-operation nodes.
+- The equation-operation graph never contains theory-component nodes.
+- Low-confidence / blocked equations downgrade the derivation paths that use
+  them; final-result components that render blocked equations become
+  ``review_required``.
+- Old component IDs (pre Step-3 split) are resolved through the Step 3
+  ``component_id_mapping``; unresolved references are reported, never dropped.
+- Canonical edge types are preferred; generic ``RELATED_TO`` edges are kept but
+  reported as warnings.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+from .claim_centered_planner import infer_support_metadata
+from .responsibility import canonical_responsibility_type
+
+# ---------------------------------------------------------------------------
+# Canonical vocabularies
+# ---------------------------------------------------------------------------
+
+CANONICAL_EDGE_TYPES = {
+    "defines",
+    "feeds",
+    "enables",
+    "derives",
+    "constrains",
+    "applies",
+    "limits",
+    "depends_on",
+    "contrasts",
+    "refines",
+}
+
+GENERIC_EDGE_TYPE = "RELATED_TO"
+
+# refined component dependency_type -> canonical theory-graph edge type.
+DEPENDENCY_TO_EDGE = {
+    "requires": "depends_on",
+    "depends_on": "depends_on",
+    "refines": "refines",
+    "qualifies": "constrains",
+    "supports": "feeds",
+    "diagnoses": "applies",
+    "propagates_uncertainty_to": "limits",
+    "contrasts": "contrasts",
+    "contradicts": "contrasts",
+    "enables": "enables",
+    "feeds": "feeds",
+    "derives": "derives",
+    "constrains": "constrains",
+    "applies": "applies",
+    "limits": "limits",
+    "defines": "defines",
+}
+
+# equation-operation node vocabulary.
+OPERATION_TYPES = {
+    "define",
+    "transform",
+    "substitute",
+    "solve",
+    "eliminate",
+    "linearize",
+    "approximate",
+    "derive",
+}
+
+# support_role -> support-map layer id.
+SUPPORT_ROLE_TO_LAYER = {
+    "result": "result_layer",
+    "derivation_core": "derivation_core",
+    "observable_bridge": "observable_bridge",
+    "theory_base": "theory_base",
+    "application": "application_layer",
+    "limitation": "limitation_layer",
+}
+
+# Ordered standard layers (result first, down to prerequisites / caveats).
+STANDARD_SUPPORT_LAYERS = [
+    "result_layer",
+    "derivation_core",
+    "observable_bridge",
+    "theory_base",
+    "application_layer",
+    "limitation_layer",
+]
+
+SOURCE_BACKED = "source_backed"
+REVIEW_REQUIRED = "review_required"
+
+# responsibility types that act as "final" theory results.
+RESULT_RESPONSIBILITIES = {"constraint", "result"}
+DERIVATION_RESPONSIBILITIES = {"derivation"}
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DerivationGraphAlignmentResult:
+    theory_component_graph: dict = field(default_factory=dict)
+    equation_operation_graph: dict = field(default_factory=dict)
+    component_operation_links: list = field(default_factory=list)
+    aligned_derivation_chains: list = field(default_factory=list)
+    support_map: dict = field(default_factory=dict)
+    graph_alignment_validation: dict = field(default_factory=dict)
+    # Aggregated block for export_validation.derivation_graph_alignment.
+    export_validation: dict = field(default_factory=dict)
+    unresolved_component_refs: list = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Aligner
+# ---------------------------------------------------------------------------
+
+
+class DerivationGraphAligner:
+    """Build aligned theory / operation graphs from refined components."""
+
+    def align(
+        self,
+        result,
+        llm_input=None,
+        derivations=None,
+        headline_claim_id: str | None = None,
+    ) -> DerivationGraphAlignmentResult:
+        components = list(getattr(result, "components", []) or [])
+        component_by_id = {c.component_id: c for c in components}
+        component_ids = set(component_by_id)
+
+        remap = _build_remap(result)
+        eq_index = _equation_index(llm_input)
+        eq_ids_known = set(eq_index)
+        chains = list(getattr(derivations, "chains", []) or [])
+        headline_claim_id = headline_claim_id or _headline_claim_id(llm_input)
+
+        errors: list[dict] = []
+        warnings: list[dict] = []
+        review_items: list[dict] = []
+        unresolved_component_refs: list[dict] = []
+
+        # 1. Theory component graph (refined components only).
+        theory_graph, generic_edges, dangling_component_refs = self._theory_component_graph(
+            components,
+            component_ids,
+            remap,
+            eq_index,
+            unresolved_component_refs,
+        )
+
+        # 2. Equation operation graph (derivation-step operations only).
+        operation_graph, operation_nodes, dangling_equation_refs = self._equation_operation_graph(
+            chains, eq_index, eq_ids_known
+        )
+
+        # 3 + 4. Component-attributed derivation chains and operation links.
+        aligned_chains, step_owner, review_required_paths = self._aligned_chains(
+            chains, components, component_by_id, remap, eq_index, unresolved_component_refs
+        )
+        component_links = self._component_operation_links(
+            components, aligned_chains, eq_index
+        )
+
+        linked_operation_ids = {
+            op_id for link in component_links for op_id in link["operation_ids"]
+        }
+        unmapped_operations = [
+            node["operation_id"]
+            for node in operation_nodes
+            if node["operation_id"] not in linked_operation_ids
+        ]
+        unmapped_steps = [
+            step["step_id"]
+            for chain in aligned_chains
+            for step in chain["steps"]
+            if not step.get("component_id")
+        ]
+
+        # 5. Support map.
+        support_map, missing_support = self._support_map(
+            components, headline_claim_id
+        )
+
+        # ---- Alignment rule checks (warnings / review items) ----
+        self._check_derivation_components(components, component_links, warnings)
+        self._check_final_result_components(
+            components, component_by_id, remap, warnings
+        )
+        self._collect_review_paths(review_required_paths, review_items)
+
+        for entry in generic_edges:
+            warnings.append({
+                "code": "generic_edge",
+                "message": (
+                    f"generic '{GENERIC_EDGE_TYPE}' edge {entry['source']} -> "
+                    f"{entry['target']} (no canonical edge type)"
+                ),
+                "source": entry["source"],
+                "target": entry["target"],
+            })
+        for cid in missing_support:
+            warnings.append({
+                "code": "component_missing_from_support_map",
+                "message": f"component '{cid}' is not assigned to any support layer",
+                "component_id": cid,
+            })
+
+        # ---- Hard errors ----
+        for ref in unresolved_component_refs:
+            errors.append({
+                "code": "dangling_component_ref",
+                "message": (
+                    f"component reference '{ref['missing_ref']}' could not be "
+                    f"resolved to a refined component"
+                ),
+                **ref,
+            })
+        for ref in dangling_component_refs:
+            errors.append({
+                "code": "dangling_component_ref",
+                "message": (
+                    f"theory graph edge references missing component "
+                    f"'{ref['missing_ref']}'"
+                ),
+                **ref,
+            })
+        for ref in dangling_equation_refs:
+            errors.append({
+                "code": "dangling_equation_ref",
+                "message": (
+                    f"equation operation '{ref['operation_id']}' references "
+                    f"missing equation '{ref['missing_ref']}'"
+                ),
+                **ref,
+            })
+        operation_node_in_component_graph = _operation_nodes_in_component_graph(
+            theory_graph
+        )
+        for node_id in operation_node_in_component_graph:
+            errors.append({
+                "code": "component_graph_contains_operation_node",
+                "message": f"theory component graph contains operation node '{node_id}'",
+                "node_id": node_id,
+            })
+        support_missing_refs = _support_map_missing_components(support_map, component_ids)
+        for cid in support_missing_refs:
+            errors.append({
+                "code": "support_map_missing_component",
+                "message": f"support map references non-existent component '{cid}'",
+                "component_id": cid,
+            })
+
+        component_graph_clean = not operation_node_in_component_graph
+        operation_graph_clean = not dangling_equation_refs
+        support_map_renderable = not support_missing_refs and not missing_support
+        derivation_order_valid = self._derivation_order_valid(aligned_chains, eq_ids_known)
+
+        graph_alignment_validation = {
+            "component_graph_clean": component_graph_clean,
+            "operation_graph_clean": operation_graph_clean,
+            "derivation_order_valid": derivation_order_valid,
+            "support_map_renderable": support_map_renderable,
+            "dangling_component_refs": [r["missing_ref"] for r in dangling_component_refs]
+            + [r["missing_ref"] for r in unresolved_component_refs],
+            "dangling_equation_refs": [r["missing_ref"] for r in dangling_equation_refs],
+            "unmapped_operations": unmapped_operations,
+            "unmapped_derivation_steps": unmapped_steps,
+            "review_required_paths": [p["derivation_id"] for p in review_required_paths],
+            "generic_edges": generic_edges,
+            "missing_support_layers": missing_support,
+        }
+
+        export_validation = {
+            "errors": errors,
+            "warnings": warnings,
+            "review_items": review_items,
+            "component_graph_clean": component_graph_clean,
+            "operation_graph_clean": operation_graph_clean,
+            "support_map_renderable": support_map_renderable,
+        }
+
+        return DerivationGraphAlignmentResult(
+            theory_component_graph=theory_graph,
+            equation_operation_graph=operation_graph,
+            component_operation_links=component_links,
+            aligned_derivation_chains=aligned_chains,
+            support_map=support_map,
+            graph_alignment_validation=graph_alignment_validation,
+            export_validation=export_validation,
+            unresolved_component_refs=unresolved_component_refs,
+        )
+
+    # ------------------------------------------------------------------
+    # 1. Theory component graph
+    # ------------------------------------------------------------------
+
+    def _theory_component_graph(
+        self,
+        components,
+        component_ids,
+        remap,
+        eq_index,
+        unresolved_component_refs,
+    ):
+        nodes: list[dict] = []
+        for component in components:
+            nodes.append({
+                "component_id": component.component_id,
+                "component_type": _node_component_type(component),
+                "support_role": _support_role(component),
+                "concepts": list(component.concepts or []),
+                "review_status": _component_review_status(component, eq_index),
+            })
+
+        edges: list[dict] = []
+        generic_edges: list[dict] = []
+        dangling: list[dict] = []
+        seen: set[tuple] = set()
+        for component in components:
+            source = component.component_id
+            for dep in component.dependencies or []:
+                if not isinstance(dep, dict):
+                    continue
+                dep_type = str(dep.get("dependency_type") or "")
+                edge_type, is_generic = _edge_type_for_dependency(dep_type)
+                for raw_ref in dep.get("component_refs") or []:
+                    resolved = _resolve_ref(
+                        raw_ref, component_ids, remap, unresolved_component_refs, source
+                    )
+                    for target in resolved:
+                        if target == source:
+                            continue
+                        if target not in component_ids:
+                            dangling.append({
+                                "component_id": source,
+                                "missing_ref": target,
+                            })
+                            continue
+                        key = (source, target, edge_type)
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        edge = {
+                            "source": source,
+                            "target": target,
+                            "edge_type": edge_type,
+                            "evidence_refs": _shared_refs(
+                                component, _component_by_id(components, target),
+                                "linked_evidence_ids",
+                            ),
+                            "claim_refs": _shared_refs(
+                                component, _component_by_id(components, target),
+                                "linked_claim_ids",
+                            ),
+                            "derivation_refs": _shared_refs(
+                                component, _component_by_id(components, target),
+                                "linked_derivation_ids",
+                            ),
+                        }
+                        edges.append(edge)
+                        if is_generic:
+                            generic_edges.append({
+                                "source": source,
+                                "target": target,
+                            })
+
+        graph = {
+            "graph_type": "theory_component_graph",
+            "nodes": nodes,
+            "edges": edges,
+        }
+        return graph, generic_edges, dangling
+
+    # ------------------------------------------------------------------
+    # 2. Equation operation graph
+    # ------------------------------------------------------------------
+
+    def _equation_operation_graph(self, chains, eq_index, eq_ids_known):
+        nodes: list[dict] = []
+        dangling: list[dict] = []
+        op_by_id: dict[str, dict] = {}
+        producers: dict[str, list[str]] = {}
+        for chain in chains:
+            for step in getattr(chain, "steps", []) or []:
+                op_id = _operation_id(chain, step)
+                inputs = list(step.input_equation_ids or [])
+                outputs = list(step.output_equation_ids or [])
+                node = {
+                    "operation_id": op_id,
+                    "operation_type": _operation_type(step.operation),
+                    "input_equation_ids": inputs,
+                    "output_equation_ids": outputs,
+                    "source_evidence_ids": list(step.source_evidence_ids or []),
+                    "review_status": _step_review_status(step, eq_index),
+                }
+                nodes.append(node)
+                op_by_id[op_id] = node
+                for eq_id in outputs:
+                    producers.setdefault(eq_id, []).append(op_id)
+                if eq_ids_known:
+                    for eq_id in inputs + outputs:
+                        if eq_id and eq_id not in eq_ids_known:
+                            dangling.append({
+                                "operation_id": op_id,
+                                "missing_ref": eq_id,
+                            })
+
+        edges: list[dict] = []
+        seen: set[tuple] = set()
+        # Equation flow: producer output -> consumer input.
+        for node in nodes:
+            for eq_id in node["input_equation_ids"]:
+                for producer_id in producers.get(eq_id, []):
+                    if producer_id == node["operation_id"]:
+                        continue
+                    key = (producer_id, node["operation_id"], "produces_input_for")
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    edges.append({
+                        "source": producer_id,
+                        "target": node["operation_id"],
+                        "edge_type": "produces_input_for",
+                    })
+        # Sequential dependency within a chain.
+        for chain in chains:
+            steps = getattr(chain, "steps", []) or []
+            for prev, curr in zip(steps, steps[1:]):
+                src = _operation_id(chain, prev)
+                dst = _operation_id(chain, curr)
+                key = (dst, src, "operation_depends_on")
+                if key in seen:
+                    continue
+                seen.add(key)
+                edges.append({
+                    "source": dst,
+                    "target": src,
+                    "edge_type": "operation_depends_on",
+                })
+
+        graph = {
+            "graph_type": "equation_operation_graph",
+            "nodes": nodes,
+            "edges": edges,
+        }
+        return graph, nodes, dangling
+
+    # ------------------------------------------------------------------
+    # 4. Aligned derivation chains
+    # ------------------------------------------------------------------
+
+    def _aligned_chains(
+        self,
+        chains,
+        components,
+        component_by_id,
+        remap,
+        eq_index,
+        unresolved_component_refs,
+    ):
+        aligned: list[dict] = []
+        step_owner: dict[str, str] = {}
+        review_paths: list[dict] = []
+        for chain in chains:
+            candidates = self._chain_component_candidates(
+                chain, components, component_by_id, remap, unresolved_component_refs
+            )
+            steps_out: list[dict] = []
+            chain_review = _norm_status(getattr(chain, "review_status", ""))
+            for step in getattr(chain, "steps", []) or []:
+                owner = _assign_step_owner(step, candidates, component_by_id)
+                op_id = _operation_id(chain, step)
+                status = _step_review_status(step, eq_index)
+                if status == REVIEW_REQUIRED:
+                    chain_review = REVIEW_REQUIRED
+                if owner:
+                    step_owner[op_id] = owner
+                steps_out.append({
+                    "step_id": step.step_id,
+                    "component_id": owner,
+                    "operation_id": op_id,
+                    "operation": _operation_type(step.operation),
+                    "input_equation_ids": list(step.input_equation_ids or []),
+                    "output_equation_ids": list(step.output_equation_ids or []),
+                    "source_evidence_ids": list(step.source_evidence_ids or []),
+                    "linked_claim_ids": _ordered_unique(
+                        list(step.required_claim_ids or [])
+                        + list(step.input_claim_ids or [])
+                        + list(step.output_claim_ids or [])
+                    ),
+                    "review_status": status,
+                })
+            entry = {
+                "derivation_id": chain.derivation_id,
+                "name": getattr(chain, "teaching_takeaway", "") or chain.derivation_id,
+                "linked_component_ids": candidates,
+                "steps": steps_out,
+                "review_status": chain_review,
+            }
+            aligned.append(entry)
+            if chain_review == REVIEW_REQUIRED:
+                review_paths.append({
+                    "derivation_id": chain.derivation_id,
+                    "review_required_step_ids": [
+                        s["step_id"] for s in steps_out
+                        if s["review_status"] == REVIEW_REQUIRED
+                    ],
+                })
+        return aligned, step_owner, review_paths
+
+    def _chain_component_candidates(
+        self, chain, components, component_by_id, remap, unresolved_component_refs
+    ):
+        candidates: list[str] = []
+        for raw in getattr(chain, "linked_component_ids", []) or []:
+            for resolved in _resolve_ref(
+                raw, set(component_by_id), remap, unresolved_component_refs,
+                f"derivation:{chain.derivation_id}",
+            ):
+                if resolved in component_by_id and resolved not in candidates:
+                    candidates.append(resolved)
+        # Components that explicitly link this derivation.
+        for component in components:
+            if chain.derivation_id in (component.linked_derivation_ids or []):
+                if component.component_id not in candidates:
+                    candidates.append(component.component_id)
+        return candidates
+
+    # ------------------------------------------------------------------
+    # 3. Component operation links
+    # ------------------------------------------------------------------
+
+    def _component_operation_links(self, components, aligned_chains, eq_index):
+        ops_by_component: dict[str, list[str]] = {}
+        for chain in aligned_chains:
+            for step in chain["steps"]:
+                cid = step.get("component_id")
+                if not cid:
+                    continue
+                ops_by_component.setdefault(cid, [])
+                if step["operation_id"] not in ops_by_component[cid]:
+                    ops_by_component[cid].append(step["operation_id"])
+
+        links: list[dict] = []
+        for component in components:
+            operation_ids = ops_by_component.get(component.component_id, [])
+            if not operation_ids:
+                continue
+            inputs = list(component.input_equation_ids or [])
+            outputs = list(component.output_equation_ids or [])
+            if not inputs or not outputs:
+                # Aggregate from owned operations when the component fields are bare.
+                op_inputs, op_outputs = _operation_io(
+                    component.component_id, aligned_chains
+                )
+                inputs = inputs or op_inputs
+                outputs = outputs or op_outputs
+            links.append({
+                "component_id": component.component_id,
+                "operation_ids": operation_ids,
+                "role": _link_role(component),
+                "input_equation_ids": _ordered_unique(inputs),
+                "output_equation_ids": _ordered_unique(outputs),
+                "review_status": _component_review_status(component, eq_index),
+            })
+        return links
+
+    # ------------------------------------------------------------------
+    # 5. Support map
+    # ------------------------------------------------------------------
+
+    def _support_map(self, components, headline_claim_id):
+        layer_members: dict[str, list[str]] = {
+            layer: [] for layer in STANDARD_SUPPORT_LAYERS
+        }
+        assigned: set[str] = set()
+        primary: list[str] = []
+        secondary: list[str] = []
+        review_required: list[str] = []
+        edges: list[dict] = []
+        for component in components:
+            role = _support_role(component)
+            layer = SUPPORT_ROLE_TO_LAYER.get(role)
+            if not layer:
+                # Generate a layer id from the (non-standard) support role.
+                layer = f"{role}_layer"
+                layer_members.setdefault(layer, [])
+            layer_members[layer].append(component.component_id)
+            assigned.add(component.component_id)
+
+            status = _component_review_status(component, None)
+            if status == REVIEW_REQUIRED:
+                review_required.append(component.component_id)
+            elif role == "result":
+                primary.append(component.component_id)
+            else:
+                secondary.append(component.component_id)
+
+            if headline_claim_id:
+                edges.append({
+                    "source": component.component_id,
+                    "target": headline_claim_id,
+                    "support_kind": _support_kind(component),
+                })
+
+        layers = [
+            {"layer_id": layer_id, "component_ids": layer_members[layer_id]}
+            for layer_id in _layer_order(layer_members)
+        ]
+        support_map = {
+            "headline_claim_id": headline_claim_id or "",
+            "layers": layers,
+            "edges": edges,
+            "emphasis": {
+                "primary_novelty_component_ids": primary,
+                "secondary_support_component_ids": secondary,
+                "review_required_component_ids": review_required,
+            },
+        }
+        missing = [c.component_id for c in components if c.component_id not in assigned]
+        return support_map, missing
+
+    # ------------------------------------------------------------------
+    # Alignment rule checks
+    # ------------------------------------------------------------------
+
+    def _check_derivation_components(self, components, component_links, warnings):
+        link_by_component = {link["component_id"]: link for link in component_links}
+        for component in components:
+            if _responsibility(component) not in DERIVATION_RESPONSIBILITIES:
+                continue
+            link = link_by_component.get(component.component_id)
+            inputs = list(component.input_equation_ids or [])
+            outputs = list(component.output_equation_ids or [])
+            if link:
+                inputs = inputs or link["input_equation_ids"]
+                outputs = outputs or link["output_equation_ids"]
+            if not inputs or not outputs:
+                warnings.append({
+                    "code": "derivation_component_missing_io_equations",
+                    "message": (
+                        f"derivation component '{component.component_id}' is missing "
+                        f"{'input' if not inputs else 'output'} equations"
+                    ),
+                    "component_id": component.component_id,
+                })
+
+    def _check_final_result_components(
+        self, components, component_by_id, remap, warnings
+    ):
+        for component in components:
+            if not _is_final_result(component):
+                continue
+            if not _has_upstream_derivation(
+                component, component_by_id, remap
+            ):
+                warnings.append({
+                    "code": "final_result_missing_upstream_derivation",
+                    "message": (
+                        f"final result/constraint component "
+                        f"'{component.component_id}' has no upstream derivation "
+                        f"component"
+                    ),
+                    "component_id": component.component_id,
+                })
+
+    def _collect_review_paths(self, review_required_paths, review_items):
+        for path in review_required_paths:
+            review_items.append({
+                "code": "review_required_derivation_path",
+                "message": (
+                    f"derivation '{path['derivation_id']}' contains review-required "
+                    f"steps due to low-confidence equations"
+                ),
+                "derivation_id": path["derivation_id"],
+                "step_ids": path["review_required_step_ids"],
+            })
+
+    def _derivation_order_valid(self, aligned_chains, eq_ids_known) -> bool:
+        """Order is invalid when a step consumes an equation that is only
+        produced by a *later* step in the same chain (a backward dependency)."""
+        for chain in aligned_chains:
+            produced_anywhere: set[str] = set()
+            for step in chain["steps"]:
+                produced_anywhere.update(step["output_equation_ids"])
+            produced_so_far: set[str] = set()
+            for step in chain["steps"]:
+                for eq_id in step["input_equation_ids"]:
+                    if eq_id in produced_anywhere and eq_id not in produced_so_far:
+                        return False
+                produced_so_far.update(step["output_equation_ids"])
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_remap(result) -> dict[str, list[str]]:
+    """old component id -> [new component ids] from Step 3 id mapping."""
+    refinement = getattr(result, "component_refinement", {}) or {}
+    remap: dict[str, list[str]] = {}
+    for entry in refinement.get("component_id_mapping") or []:
+        if not isinstance(entry, dict):
+            continue
+        old_id = str(entry.get("original_component_id") or "")
+        new_ids = [str(v) for v in entry.get("new_component_ids") or [] if str(v)]
+        if old_id:
+            remap[old_id] = new_ids
+    return remap
+
+
+def _resolve_ref(raw_ref, component_ids, remap, unresolved, source) -> list[str]:
+    ref = str(raw_ref or "")
+    if not ref:
+        return []
+    if ref in component_ids:
+        return [ref]
+    if ref in remap:
+        resolved = [r for r in remap[ref] if r in component_ids]
+        if resolved:
+            return resolved
+    unresolved.append({"component_id": source, "missing_ref": ref})
+    return []
+
+
+def _equation_index(llm_input) -> dict[str, dict]:
+    index: dict[str, dict] = {}
+    if not llm_input:
+        return index
+    pools = list(getattr(llm_input, "equations", []) or []) + list(
+        getattr(llm_input, "available_equations", []) or []
+    )
+    for eq in pools:
+        eq_id = str(eq.get("equation_id") or "")
+        if not eq_id:
+            continue
+        merged = dict(index.get(eq_id, {}))
+        merged.update(eq)
+        index[eq_id] = merged
+    return index
+
+
+def _headline_claim_id(llm_input) -> str:
+    if not llm_input:
+        return ""
+    plan = getattr(llm_input, "claim_centered_plan", {}) or {}
+    ids = plan.get("headline_claim_ids") or []
+    if ids:
+        return str(ids[0])
+    return ""
+
+
+def _node_component_type(component) -> str:
+    responsibility = _responsibility(component)
+    if responsibility:
+        return responsibility
+    return str(getattr(component, "component_type", "") or "")
+
+
+def _responsibility(component) -> str:
+    raw = getattr(component, "responsibility_type", "") or getattr(
+        component, "operation", ""
+    )
+    return canonical_responsibility_type(raw)
+
+
+def _support_role(component) -> str:
+    role = str(getattr(component, "support_role", "") or "")
+    if role:
+        return role
+    metadata = infer_support_metadata(component, None)
+    return metadata["support_role"]
+
+
+def _support_kind(component) -> str:
+    kind = str(getattr(component, "support_kind", "") or "")
+    if kind:
+        return kind
+    metadata = infer_support_metadata(component, None)
+    return metadata["support_kind"]
+
+
+def _norm_status(value) -> str:
+    raw = str(value or "")
+    if raw in {SOURCE_BACKED, "auto_accepted"}:
+        return SOURCE_BACKED
+    return REVIEW_REQUIRED
+
+
+def _component_review_status(component, eq_index) -> str:
+    if _norm_status(getattr(component, "review_status", "")) == REVIEW_REQUIRED:
+        return REVIEW_REQUIRED
+    if getattr(component, "review_required_equation_ids", None):
+        return REVIEW_REQUIRED
+    gate = getattr(component, "confidence_gate", {}) or {}
+    if gate.get("blocked_by_equation_ids"):
+        return REVIEW_REQUIRED
+    # Final-result components rendering blocked equations are review_required.
+    if eq_index and _is_final_result(component):
+        for eq_id in _final_equation_ids(component):
+            if _cannot_render_final(eq_index.get(eq_id)):
+                return REVIEW_REQUIRED
+    return SOURCE_BACKED
+
+
+def _step_review_status(step, eq_index) -> str:
+    if _norm_status(getattr(step, "review_status", "")) == REVIEW_REQUIRED:
+        return REVIEW_REQUIRED
+    gate = getattr(step, "confidence_gate", {}) or {}
+    if gate.get("blocked_by_equation_ids"):
+        return REVIEW_REQUIRED
+    if eq_index:
+        for eq_id in list(step.input_equation_ids or []) + list(
+            step.output_equation_ids or []
+        ):
+            if _blocked_in_derivation(eq_index.get(eq_id)):
+                return REVIEW_REQUIRED
+    return SOURCE_BACKED
+
+
+def _eq_policy(eq) -> dict:
+    if not isinstance(eq, dict):
+        return {}
+    policy = eq.get("confidence_policy")
+    return policy if isinstance(policy, dict) else {}
+
+
+def _blocked_in_derivation(eq) -> bool:
+    policy = _eq_policy(eq)
+    if not policy:
+        return False
+    if str(policy.get("allowed_downstream_use") or "") == "blocked":
+        return True
+    return policy.get("can_be_used_in_derivation") is False
+
+
+def _cannot_render_final(eq) -> bool:
+    policy = _eq_policy(eq)
+    if not policy:
+        return False
+    if str(policy.get("allowed_downstream_use") or "") == "blocked":
+        return True
+    return policy.get("can_be_rendered_as_final_formula") is False
+
+
+def _edge_type_for_dependency(dep_type: str) -> tuple[str, bool]:
+    mapped = DEPENDENCY_TO_EDGE.get(dep_type)
+    if mapped in CANONICAL_EDGE_TYPES:
+        return mapped, False
+    return GENERIC_EDGE_TYPE, True
+
+
+def _operation_type(operation: str) -> str:
+    op = str(operation or "").lower()
+    if "substitut" in op:
+        return "substitute"
+    if "eliminat" in op:
+        return "eliminate"
+    if "lineariz" in op:
+        return "linearize"
+    if "approxim" in op:
+        return "approximate"
+    if "solve" in op:
+        return "solve"
+    if "deriv" in op:
+        return "derive"
+    if "define" in op or "definition" in op:
+        return "define"
+    if "transform" in op:
+        return "transform"
+    return "transform"
+
+
+def _operation_id(chain, step) -> str:
+    step_id = str(getattr(step, "step_id", "") or "")
+    if step_id:
+        return step_id
+    return f"{chain.derivation_id}:op"
+
+
+def _link_role(component) -> str:
+    responsibility = _responsibility(component)
+    if responsibility in {"definition", "model", "observation_model", "observable_basis"}:
+        return "defines"
+    if responsibility == "derivation":
+        return "derives"
+    if responsibility == "constraint":
+        return "constrains"
+    if responsibility in {"application", "limitation"}:
+        return "validates"
+    return "uses"
+
+
+def _is_final_result(component) -> bool:
+    if _responsibility(component) in RESULT_RESPONSIBILITIES:
+        return True
+    return _support_role(component) == "result"
+
+
+def _final_equation_ids(component) -> list[str]:
+    ids = list(component.output_equation_ids or []) + list(
+        component.constraint_equation_ids or []
+    )
+    return _ordered_unique(ids)
+
+
+def _has_upstream_derivation(component, component_by_id, remap) -> bool:
+    for dep in component.dependencies or []:
+        if not isinstance(dep, dict):
+            continue
+        for raw_ref in dep.get("component_refs") or []:
+            for target in _resolve_to_existing(raw_ref, component_by_id, remap):
+                upstream = component_by_id.get(target)
+                if upstream and _responsibility(upstream) in DERIVATION_RESPONSIBILITIES:
+                    return True
+    return False
+
+
+def _resolve_to_existing(raw_ref, component_by_id, remap) -> list[str]:
+    ref = str(raw_ref or "")
+    if ref in component_by_id:
+        return [ref]
+    if ref in remap:
+        return [r for r in remap[ref] if r in component_by_id]
+    return []
+
+
+def _assign_step_owner(step, candidates, component_by_id) -> str:
+    if not candidates:
+        return ""
+    if len(candidates) == 1:
+        return candidates[0]
+    step_eqs = set(step.input_equation_ids or []) | set(step.output_equation_ids or [])
+    best = ""
+    best_overlap = 0
+    for cid in candidates:
+        component = component_by_id.get(cid)
+        if not component:
+            continue
+        overlap = len(step_eqs & set(_component_equation_ids(component)))
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best = cid
+    return best or candidates[0]
+
+
+def _component_equation_ids(component) -> list[str]:
+    ids: list[str] = []
+    for field_name in (
+        "linked_equation_ids",
+        "input_equation_ids",
+        "intermediate_equation_ids",
+        "output_equation_ids",
+        "constraint_equation_ids",
+        "definition_equation_ids",
+        "review_required_equation_ids",
+    ):
+        ids.extend(getattr(component, field_name, []) or [])
+    refs = getattr(component, "evidence_refs", {}) or {}
+    ids.extend(refs.get("equation_ids") or [])
+    return _ordered_unique(ids)
+
+
+def _operation_io(component_id, aligned_chains) -> tuple[list[str], list[str]]:
+    inputs: list[str] = []
+    outputs: list[str] = []
+    for chain in aligned_chains:
+        for step in chain["steps"]:
+            if step.get("component_id") == component_id:
+                inputs.extend(step["input_equation_ids"])
+                outputs.extend(step["output_equation_ids"])
+    return _ordered_unique(inputs), _ordered_unique(outputs)
+
+
+def _shared_refs(source_component, target_component, field_name) -> list[str]:
+    source_refs = set(getattr(source_component, field_name, []) or [])
+    if target_component is None:
+        return _ordered_unique(getattr(source_component, field_name, []) or [])
+    target_refs = set(getattr(target_component, field_name, []) or [])
+    return _ordered_unique(source_refs & target_refs)
+
+
+def _component_by_id(components, component_id):
+    for component in components:
+        if component.component_id == component_id:
+            return component
+    return None
+
+
+def _layer_order(layer_members) -> list[str]:
+    order = [layer for layer in STANDARD_SUPPORT_LAYERS]
+    for layer in layer_members:
+        if layer not in order:
+            order.append(layer)
+    return order
+
+
+def _operation_nodes_in_component_graph(theory_graph) -> list[str]:
+    bad: list[str] = []
+    for node in theory_graph.get("nodes", []):
+        if "operation_id" in node or "operation_type" in node:
+            bad.append(node.get("operation_id") or node.get("component_id") or "")
+    return bad
+
+
+def _support_map_missing_components(support_map, component_ids) -> list[str]:
+    missing: list[str] = []
+    for layer in support_map.get("layers", []):
+        for cid in layer.get("component_ids", []):
+            if cid not in component_ids and cid not in missing:
+                missing.append(cid)
+    emphasis = support_map.get("emphasis", {}) or {}
+    for key in (
+        "primary_novelty_component_ids",
+        "secondary_support_component_ids",
+        "review_required_component_ids",
+    ):
+        for cid in emphasis.get(key, []) or []:
+            if cid not in component_ids and cid not in missing:
+                missing.append(cid)
+    return missing
+
+
+def _ordered_unique(values) -> list[str]:
+    result: list[str] = []
+    for value in values or []:
+        text = str(value or "")
+        if text and text not in result:
+            result.append(text)
+    return result

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -217,6 +217,11 @@ class ComponentAssemblyResult:
     # {refined_components, component_refinement_records, component_id_mapping,
     #  component_graph_updates, refinement_validation}.
     component_refinement: dict = field(default_factory=dict)
+    # DerivationGraphAligner Step 4 output contract (issue #325):
+    # {theory_component_graph, equation_operation_graph, component_operation_links,
+    #  aligned_derivation_chains, support_map, graph_alignment_validation,
+    #  export_validation}.
+    derivation_graph_alignment: dict = field(default_factory=dict)
     diagnostics: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -304,6 +309,7 @@ class ComponentAssemblyResult:
             validation_issues=issues,
             refinement_report=d.get("refinement_report") or {},
             component_refinement=d.get("component_refinement") or {},
+            derivation_graph_alignment=d.get("derivation_graph_alignment") or {},
             diagnostics=d.get("diagnostics") or {},
         )
 

--- a/src/tests/agents/component_assembly/test_derivation_graph_aligner.py
+++ b/src/tests/agents/component_assembly/test_derivation_graph_aligner.py
@@ -1,0 +1,519 @@
+"""Step 4 DerivationGraphAligner tests (issue #325).
+
+Covers clean graph separation, derivation alignment, final-result dependency,
+low-confidence equation propagation, old-id remapping, support map generation,
+operation reference checks, generic edge warnings, and missing support layers.
+"""
+from episteme_graph.agents.component_assembly.derivation_graph_aligner import (
+    DerivationGraphAligner,
+)
+from episteme_graph.agents.component_assembly.schema import (
+    COMPONENTS_VERSION,
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+
+ALIGNER = DerivationGraphAligner()
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _component(**kwargs):
+    defaults = dict(
+        component_id="comp",
+        component_type="RelationComponent",
+        label="Component",
+        summary="summary",
+        inputs=[],
+        outputs=[],
+        preconditions=[],
+        cautions=[],
+        dependencies=[],
+        evidence_refs={},
+        reason="",
+        confidence=0.8,
+        review_notes=[],
+        review_status="auto_accepted",
+    )
+    defaults.update(kwargs)
+    return ComponentRecord(**defaults)
+
+
+def _result(components, component_refinement=None):
+    return ComponentAssemblyResult(
+        document_id="doc",
+        components_version=COMPONENTS_VERSION,
+        cartridge_id=None,
+        components=components,
+        assembly_hints=[],
+        review_notes=[],
+        confidence=0.8,
+        component_refinement=component_refinement or {},
+    )
+
+
+def _step(step_id, op, inputs, outputs, **kwargs):
+    return DerivationStep(
+        step_id=step_id,
+        input_equation_ids=inputs,
+        operation=op,
+        output_equation_ids=outputs,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+
+
+def _chain(derivation_id, steps, **kwargs):
+    return DerivationChainRecord(
+        derivation_id=derivation_id,
+        document_id="doc",
+        source_section_ids=[],
+        steps=steps,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+
+
+def _derivations(*chains):
+    return DerivationChainResult(document_id="doc", cartridge_id=None, chains=list(chains))
+
+
+class _LLMInput:
+    def __init__(self, equations=None, claim_centered_plan=None):
+        self.equations = equations or []
+        self.available_equations = []
+        self.claim_centered_plan = claim_centered_plan or {}
+
+
+def _eq(equation_id, *, can_derivation=True, can_final=True, allowed="unrestricted"):
+    return {
+        "equation_id": equation_id,
+        "plain_text": equation_id,
+        "confidence_policy": {
+            "can_support_claim": can_derivation,
+            "can_be_used_in_derivation": can_derivation,
+            "can_be_rendered_as_final_formula": can_final,
+            "allowed_downstream_use": allowed,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Clean separation
+# ---------------------------------------------------------------------------
+
+
+def test_clean_separation_of_component_and_operation_graphs():
+    comp = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_b"],
+    )
+    chain = _chain("d1", [_step("s1", "derive", ["eq_a"], ["eq_b"])])
+    alignment = ALIGNER.align(
+        _result([comp]),
+        llm_input=_LLMInput(equations=[_eq("eq_a"), _eq("eq_b")]),
+        derivations=_derivations(chain),
+    )
+
+    tcg = alignment.theory_component_graph
+    eog = alignment.equation_operation_graph
+    assert tcg["graph_type"] == "theory_component_graph"
+    assert [n["component_id"] for n in tcg["nodes"]] == ["c_der"]
+    # No operation fields leak into component nodes.
+    for node in tcg["nodes"]:
+        assert "operation_id" not in node and "operation_type" not in node
+    assert eog["graph_type"] == "equation_operation_graph"
+    assert [n["operation_id"] for n in eog["nodes"]] == ["s1"]
+    # No component nodes in the operation graph.
+    for node in eog["nodes"]:
+        assert "component_id" not in node
+    # The connection lives in component_operation_links.
+    links = alignment.component_operation_links
+    assert links == [
+        {
+            "component_id": "c_der",
+            "operation_ids": ["s1"],
+            "role": "derives",
+            "input_equation_ids": ["eq_a"],
+            "output_equation_ids": ["eq_b"],
+            "review_status": "source_backed",
+        }
+    ]
+    assert alignment.graph_alignment_validation["component_graph_clean"] is True
+    assert alignment.graph_alignment_validation["operation_graph_clean"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Derivation alignment
+# ---------------------------------------------------------------------------
+
+
+def test_derivation_chain_aligned_to_component():
+    comp = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_c"],
+    )
+    chain = _chain(
+        "d1",
+        [
+            _step("s1", "substitute", ["eq_a"], ["eq_b"]),
+            _step("s2", "solve", ["eq_b"], ["eq_c"]),
+        ],
+        teaching_takeaway="Eliminate the bias parameter",
+    )
+    alignment = ALIGNER.align(
+        _result([comp]),
+        llm_input=_LLMInput(equations=[_eq("eq_a"), _eq("eq_b"), _eq("eq_c")]),
+        derivations=_derivations(chain),
+    )
+
+    aligned = alignment.aligned_derivation_chains
+    assert len(aligned) == 1
+    entry = aligned[0]
+    assert entry["derivation_id"] == "d1"
+    assert entry["name"] == "Eliminate the bias parameter"
+    assert entry["linked_component_ids"] == ["c_der"]
+    assert [s["operation_id"] for s in entry["steps"]] == ["s1", "s2"]
+    assert all(s["component_id"] == "c_der" for s in entry["steps"])
+    assert entry["steps"][0]["input_equation_ids"] == ["eq_a"]
+    assert entry["steps"][1]["output_equation_ids"] == ["eq_c"]
+    assert entry["review_status"] == "source_backed"
+    # Operation flow edge produced inside the operation graph.
+    edges = alignment.equation_operation_graph["edges"]
+    assert {"source": "s1", "target": "s2", "edge_type": "produces_input_for"} in edges
+
+
+# ---------------------------------------------------------------------------
+# 3. Final result dependency
+# ---------------------------------------------------------------------------
+
+
+def test_final_result_with_upstream_derivation_no_warning():
+    derivation = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_b"],
+    )
+    constraint = _component(
+        component_id="c_res",
+        responsibility_type="constraint",
+        dependencies=[{"dependency_type": "depends_on", "component_refs": ["c_der"], "reason": ""}],
+        output_equation_ids=["eq_b"],
+    )
+    chain = _chain("d1", [_step("s1", "derive", ["eq_a"], ["eq_b"])])
+    alignment = ALIGNER.align(
+        _result([derivation, constraint]),
+        llm_input=_LLMInput(equations=[_eq("eq_a"), _eq("eq_b")]),
+        derivations=_derivations(chain),
+    )
+
+    warnings = alignment.export_validation["warnings"]
+    assert not any(
+        w["code"] == "final_result_missing_upstream_derivation" for w in warnings
+    )
+    # The component graph has a depends_on edge from result to derivation.
+    edges = alignment.theory_component_graph["edges"]
+    assert any(
+        e["source"] == "c_res" and e["target"] == "c_der" and e["edge_type"] == "depends_on"
+        for e in edges
+    )
+
+
+def test_final_result_without_upstream_derivation_warns():
+    constraint = _component(
+        component_id="c_res",
+        responsibility_type="constraint",
+        output_equation_ids=["eq_b"],
+    )
+    alignment = ALIGNER.align(
+        _result([constraint]),
+        llm_input=_LLMInput(equations=[_eq("eq_b")]),
+        derivations=_derivations(),
+    )
+    warnings = alignment.export_validation["warnings"]
+    assert any(
+        w["code"] == "final_result_missing_upstream_derivation"
+        and w["component_id"] == "c_res"
+        for w in warnings
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Low-confidence equation path
+# ---------------------------------------------------------------------------
+
+
+def test_low_confidence_equation_downgrades_derivation_path():
+    comp = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+        input_equation_ids=["eq_bad"],
+        output_equation_ids=["eq_out"],
+    )
+    chain = _chain("d1", [_step("s1", "derive", ["eq_bad"], ["eq_out"])])
+    alignment = ALIGNER.align(
+        _result([comp]),
+        llm_input=_LLMInput(
+            equations=[
+                _eq("eq_bad", can_derivation=False, allowed="blocked"),
+                _eq("eq_out"),
+            ]
+        ),
+        derivations=_derivations(chain),
+    )
+
+    aligned = alignment.aligned_derivation_chains[0]
+    assert aligned["steps"][0]["review_status"] == "review_required"
+    assert aligned["review_status"] == "review_required"
+    review_items = alignment.export_validation["review_items"]
+    assert any(
+        item["code"] == "review_required_derivation_path" and item["derivation_id"] == "d1"
+        for item in review_items
+    )
+    assert "d1" in alignment.graph_alignment_validation["review_required_paths"]
+
+
+def test_blocked_final_equation_makes_result_review_required():
+    constraint = _component(
+        component_id="c_res",
+        responsibility_type="constraint",
+        dependencies=[{"dependency_type": "depends_on", "component_refs": ["c_der"], "reason": ""}],
+        output_equation_ids=["eq_final"],
+    )
+    derivation = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_final"],
+    )
+    alignment = ALIGNER.align(
+        _result([constraint, derivation]),
+        llm_input=_LLMInput(
+            equations=[_eq("eq_final", can_final=False), _eq("eq_a")]
+        ),
+        derivations=_derivations(),
+    )
+    node = next(
+        n for n in alignment.theory_component_graph["nodes"] if n["component_id"] == "c_res"
+    )
+    assert node["review_status"] == "review_required"
+
+
+# ---------------------------------------------------------------------------
+# 5. Old ID remapping
+# ---------------------------------------------------------------------------
+
+
+def test_old_component_id_resolved_through_step3_mapping():
+    # comp_new_a depends on the *old* id "comp_old"; Step 3 split it into two.
+    comp_a = _component(
+        component_id="comp_new_a",
+        responsibility_type="derivation",
+        dependencies=[{"dependency_type": "depends_on", "component_refs": ["comp_old"], "reason": ""}],
+    )
+    comp_b = _component(component_id="comp_new_b", responsibility_type="definition")
+    refinement = {
+        "component_id_mapping": [
+            {
+                "original_component_id": "comp_old",
+                "new_component_ids": ["comp_new_b"],
+                "mapping_type": "one_to_one",
+            }
+        ]
+    }
+    alignment = ALIGNER.align(
+        _result([comp_a, comp_b], component_refinement=refinement),
+        llm_input=_LLMInput(),
+        derivations=_derivations(),
+    )
+    edges = alignment.theory_component_graph["edges"]
+    assert any(
+        e["source"] == "comp_new_a" and e["target"] == "comp_new_b" for e in edges
+    )
+    assert alignment.unresolved_component_refs == []
+    assert alignment.graph_alignment_validation["dangling_component_refs"] == []
+
+
+def test_unresolved_component_ref_reported():
+    comp = _component(
+        component_id="comp_a",
+        dependencies=[{"dependency_type": "depends_on", "component_refs": ["ghost"], "reason": ""}],
+    )
+    alignment = ALIGNER.align(
+        _result([comp]), llm_input=_LLMInput(), derivations=_derivations()
+    )
+    assert any(r["missing_ref"] == "ghost" for r in alignment.unresolved_component_refs)
+    assert "ghost" in alignment.graph_alignment_validation["dangling_component_refs"]
+    assert any(
+        e["code"] == "dangling_component_ref"
+        for e in alignment.export_validation["errors"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Support map
+# ---------------------------------------------------------------------------
+
+
+def test_support_map_assigns_components_to_layers():
+    comps = [
+        _component(component_id="c_theory", responsibility_type="model", support_role="theory_base"),
+        _component(component_id="c_bridge", responsibility_type="observation_model", support_role="observable_bridge"),
+        _component(component_id="c_der", responsibility_type="derivation", support_role="derivation_core"),
+        _component(component_id="c_res", responsibility_type="constraint", support_role="result"),
+    ]
+    alignment = ALIGNER.align(
+        _result(comps),
+        llm_input=_LLMInput(claim_centered_plan={"headline_claim_ids": ["claim_head"]}),
+        derivations=_derivations(),
+    )
+    support = alignment.support_map
+    assert support["headline_claim_id"] == "claim_head"
+    layer_map = {l["layer_id"]: l["component_ids"] for l in support["layers"]}
+    assert layer_map["theory_base"] == ["c_theory"]
+    assert layer_map["observable_bridge"] == ["c_bridge"]
+    assert layer_map["derivation_core"] == ["c_der"]
+    assert layer_map["result_layer"] == ["c_res"]
+    assert support["emphasis"]["primary_novelty_component_ids"] == ["c_res"]
+    assert alignment.graph_alignment_validation["support_map_renderable"] is True
+    # All support edges reference existing components.
+    for edge in support["edges"]:
+        assert edge["target"] == "claim_head"
+        assert edge["support_kind"]
+
+
+# ---------------------------------------------------------------------------
+# 7. Operation graph references missing equation
+# ---------------------------------------------------------------------------
+
+
+def test_operation_referencing_missing_equation_is_error():
+    comp = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_ghost"],
+    )
+    chain = _chain("d1", [_step("s1", "derive", ["eq_a"], ["eq_ghost"])])
+    alignment = ALIGNER.align(
+        _result([comp]),
+        llm_input=_LLMInput(equations=[_eq("eq_a")]),  # eq_ghost is missing
+        derivations=_derivations(chain),
+    )
+    assert "eq_ghost" in alignment.graph_alignment_validation["dangling_equation_refs"]
+    assert alignment.graph_alignment_validation["operation_graph_clean"] is False
+    assert any(
+        e["code"] == "dangling_equation_ref" and e["missing_ref"] == "eq_ghost"
+        for e in alignment.export_validation["errors"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Generic edge warning
+# ---------------------------------------------------------------------------
+
+
+def test_generic_edge_warns_but_graph_still_built():
+    comp_a = _component(
+        component_id="c_a",
+        dependencies=[{"dependency_type": "mysterious_relation", "component_refs": ["c_b"], "reason": ""}],
+    )
+    comp_b = _component(component_id="c_b")
+    alignment = ALIGNER.align(
+        _result([comp_a, comp_b]), llm_input=_LLMInput(), derivations=_derivations()
+    )
+    edges = alignment.theory_component_graph["edges"]
+    related = [e for e in edges if e["edge_type"] == "RELATED_TO"]
+    assert len(related) == 1
+    assert any(
+        w["code"] == "generic_edge" for w in alignment.export_validation["warnings"]
+    )
+    assert alignment.graph_alignment_validation["generic_edges"] == [
+        {"source": "c_a", "target": "c_b"}
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 9. Missing support layer / component
+# ---------------------------------------------------------------------------
+
+
+def test_component_missing_from_support_map_warns():
+    # A component whose support role maps cleanly should appear; we force a
+    # component with no support data to verify it still lands in a layer (no
+    # component should silently disappear) -- and a genuinely excluded one warns.
+    comp = _component(component_id="c_known", responsibility_type="model", support_role="theory_base")
+    alignment = ALIGNER.align(
+        _result([comp]), llm_input=_LLMInput(), derivations=_derivations()
+    )
+    # Every component must be placed; none missing.
+    assert alignment.graph_alignment_validation["missing_support_layers"] == []
+    layer_components = {
+        cid for layer in alignment.support_map["layers"] for cid in layer["component_ids"]
+    }
+    assert "c_known" in layer_components
+
+
+def test_derivation_order_validation():
+    comp = _component(
+        component_id="c_der", responsibility_type="derivation", linked_derivation_ids=["d1"]
+    )
+    good = _chain(
+        "d1",
+        [
+            _step("s1", "substitute", ["eq_a"], ["eq_b"]),
+            _step("s2", "solve", ["eq_b"], ["eq_c"]),
+        ],
+    )
+    ok = ALIGNER.align(
+        _result([comp]), llm_input=_LLMInput(), derivations=_derivations(good)
+    )
+    assert ok.graph_alignment_validation["derivation_order_valid"] is True
+
+    # s1 consumes eq_b which is only produced later by s2 -> backward dependency.
+    bad = _chain(
+        "d1",
+        [
+            _step("s1", "solve", ["eq_b"], ["eq_c"]),
+            _step("s2", "substitute", ["eq_a"], ["eq_b"]),
+        ],
+    )
+    broken = ALIGNER.align(
+        _result([comp]), llm_input=_LLMInput(), derivations=_derivations(bad)
+    )
+    assert broken.graph_alignment_validation["derivation_order_valid"] is False
+
+
+def test_derivation_component_missing_io_equations_warns():
+    comp = _component(
+        component_id="c_der",
+        responsibility_type="derivation",
+        linked_derivation_ids=["d1"],
+    )
+    chain = _chain("d1", [_step("s1", "derive", [], [])])
+    alignment = ALIGNER.align(
+        _result([comp]), llm_input=_LLMInput(), derivations=_derivations(chain)
+    )
+    assert any(
+        w["code"] == "derivation_component_missing_io_equations"
+        and w["component_id"] == "c_der"
+        for w in alignment.export_validation["warnings"]
+    )

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -323,6 +323,57 @@ def test_summary_only_component_cross_validation():
     assert "SUMMARY_ONLY_COMPONENT" in codes
 
 
+class _ComponentResultWithAlignment:
+    def __init__(self, components, derivation_graph_alignment):
+        self.components = components
+        self.derivation_graph_alignment = derivation_graph_alignment
+
+
+def test_derivation_graph_alignment_aggregated_into_export(monkeypatch=None):
+    """issue #325: Step 4 alignment results are aggregated into export buckets."""
+    alignment = {
+        "export_validation": {
+            "errors": [
+                {"code": "dangling_equation_ref", "message": "op references missing eq"}
+            ],
+            "warnings": [
+                {"code": "generic_edge", "message": "RELATED_TO edge"}
+            ],
+            "review_items": [
+                {"code": "review_required_derivation_path", "message": "low confidence eq"}
+            ],
+            "component_graph_clean": True,
+            "operation_graph_clean": False,
+            "support_map_renderable": True,
+        }
+    }
+    comp = _ComponentRecord("comp_001")
+    result = _run_gate(
+        component_result=_ComponentResultWithAlignment([comp], alignment)
+    )
+    error_codes = [e.code for e in result.errors]
+    warning_codes = [w.code for w in result.warnings]
+    review_codes = [r.code for r in result.review_items]
+    assert "DERIVATION_GRAPH_ALIGNMENT_DANGLING_EQUATION_REF" in error_codes
+    assert "DERIVATION_GRAPH_ALIGNMENT_GENERIC_EDGE" in warning_codes
+    assert "DERIVATION_GRAPH_ALIGNMENT_REVIEW_REQUIRED_DERIVATION_PATH" in review_codes
+    assert result.derivation_graph_alignment["operation_graph_clean"] is False
+    assert result.status == "failed_validation"
+
+
+def test_derivation_graph_alignment_absent_is_clean_default():
+    comp = _ComponentRecord("comp_001")
+    result = _run_gate(component_result=_ComponentResult([comp]))
+    assert result.derivation_graph_alignment == {
+        "errors": [],
+        "warnings": [],
+        "review_items": [],
+        "component_graph_clean": True,
+        "operation_graph_clean": True,
+        "support_map_renderable": True,
+    }
+
+
 def test_relation_component_without_internal_flow_blocks_export():
     comp = _ComponentRecord("comp_001", component_type="RelationComponent", internal_flow=[])
     result = _run_gate(component_result=_ComponentResult([comp]))


### PR DESCRIPTION
## Summary

Implements Step 4 of the PDF analysis pipeline (#325): the `DerivationGraphAligner` deterministically separates refined components (Step 3 output) into five distinct, connected artifacts:

1. **theory_component_graph** – high-level refined-component dependency graph
2. **equation_operation_graph** – low-level equation manipulation graph  
3. **component_operation_links** – refined component ↔ equation operation map
4. **aligned_derivation_chains** – component-attributed derivation steps
5. **support_map** – headline-claim-centered support layers

This stage enforces strict separation: the component graph never contains operation nodes, and the operation graph never contains theory-component nodes. Low-confidence / blocked equations downgrade derivation paths; final-result components that render blocked equations become `review_required`.

## Key Changes

- **New module:** `src/episteme_graph/agents/component_assembly/derivation_graph_aligner.py` (1057 lines)
  - `DerivationGraphAligner` class with `align()` method
  - Canonical edge-type vocabulary and support-layer mappings
  - Graph construction, validation, and alignment rule checks
  - Helper functions for ID remapping, equation indexing, and support metadata inference

- **New test suite:** `src/tests/agents/component_assembly/test_derivation_graph_aligner.py` (519 lines)
  - Clean separation of component and operation graphs
  - Derivation chain alignment to components
  - Final-result dependency validation
  - Low-confidence equation path propagation
  - Old component ID remapping through Step 3 `component_id_mapping`
  - Support map layer assignment
  - Operation graph equation reference checks
  - Generic edge warnings and missing support layer detection

- **Integration into export validation gate:**
  - `backend/core/document_pipeline/export_validation_gate.py`: Added `_empty_derivation_graph_alignment()` template and `_check_derivation_graph_alignment()` aggregation method
  - `ExportValidationResult` now includes `derivation_graph_alignment` field
  - Alignment errors/warnings/review items are surfaced without re-running alignment

- **Schema updates:**
  - `src/episteme_graph/agents/component_assembly/schema.py`: Added `derivation_graph_alignment` field to `ComponentAssemblyResult`
  - `src/episteme_graph/agents/component_assembly/agent.py`: Integrated `DerivationGraphAligner` into the assembly pipeline

- **Test updates:**
  - `src/tests/agents/test_export_validation_gate.py`: Added test for alignment aggregation into export buckets

## Implementation Details

- **Deterministic (non-LLM):** All graph construction and validation is rule-based; no LLM calls
- **Unresolved references are reported, never dropped:** Old component IDs are resolved through Step 3 `component_id_mapping`; dangling references are collected and surfaced as errors
- **Canonical edge types preferred:** Generic `RELATED_TO` edges are kept but reported as warnings
- **Equation confidence propagation:** Steps consuming low-confidence equations are marked `review_required`; derivation chains containing such steps are downgraded; final-result components rendering blocked equations become `review_required`
- **Support map generation:** Components are assigned to standard layers (result, derivation_core, observable_bridge, theory_base, application, limitation) based on `support_role`; missing assignments are reported as warnings

https://claude.ai/code/session_019AXkNcwFXR2pFq7FPKurHQ