### PR TITLE
Step 5: TheoryBundleBuilder + TeachingOutputMapper (issue #326)

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -94,6 +94,29 @@ def _empty_derivation_graph_alignment() -> dict:
     }
 
 
+def _empty_theory_bundle_validation() -> dict:
+    return {
+        "errors": [],
+        "warnings": [],
+        "review_items": [],
+        "bundle_created": False,
+        "headline_claim_linked": False,
+        "component_refs_valid": True,
+        "support_map_linked": False,
+    }
+
+
+def _empty_teaching_output_validation() -> dict:
+    return {
+        "errors": [],
+        "warnings": [],
+        "review_items": [],
+        "course_topics_link_components": True,
+        "blueprint_refs_valid": True,
+        "blackbox_policy_respects_confidence": True,
+    }
+
+
 @dataclass
 class ExportValidationResult:
     status: str                          # one of EXPORT_STATUSES
@@ -110,6 +133,10 @@ class ExportValidationResult:
     component_refinement_validation: dict = field(default_factory=_empty_refinement_validation)
     # DerivationGraphAligner Step 4 reporting (issue #325).
     derivation_graph_alignment: dict = field(default_factory=_empty_derivation_graph_alignment)
+    # TheoryBundleBuilder Step 5 reporting (issue #326).
+    theory_bundle_validation: dict = field(default_factory=_empty_theory_bundle_validation)
+    # TeachingOutputMapper Step 5 reporting (issue #326).
+    teaching_output_validation: dict = field(default_factory=_empty_teaching_output_validation)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -170,6 +197,18 @@ def _ordered_unique(values) -> list:
             seen.add(text)
             result.append(text)
     return result
+
+
+def _component_low_confidence_equation_ids(component) -> list:
+    """Low-confidence equation ids a component carries (Step 3 fields, #326).
+
+    Used by the teaching-output check to verify a topic's blackbox_policy covers
+    every low-confidence equation of its linked components.
+    """
+    ids = list(getattr(component, "review_required_equation_ids", []) or [])
+    gate = getattr(component, "confidence_gate", {}) or {}
+    ids.extend(gate.get("blocked_by_equation_ids") or [])
+    return _ordered_unique(ids)
 
 
 def _alignment_code(entry) -> str:
@@ -362,6 +401,17 @@ class ExportValidationGate:
             component_result, errors, warnings, review_items
         )
 
+        # 7f. theory bundle + teaching output reporting (#326): Step 5 represents
+        # the whole paper as a TheoryBundle and maps refined components into a
+        # teaching output. The gate re-validates the bundle / topic / blueprint
+        # references against the refined components so dangling refs surface here.
+        theory_bundle_validation = self._check_theory_bundle(
+            component_result, errors, warnings, review_items
+        )
+        teaching_output_validation = self._check_teaching_output(
+            component_result, errors, warnings, review_items
+        )
+
         # 6. Determine status
         summary = ValidationSummary(
             error_count=len(errors),
@@ -398,6 +448,8 @@ class ExportValidationGate:
             concept_validation=concept_validation,
             component_refinement_validation=component_refinement_validation,
             derivation_graph_alignment=derivation_graph_alignment,
+            theory_bundle_validation=theory_bundle_validation,
+            teaching_output_validation=teaching_output_validation,
         )
 
     # ------------------------------------------------------------------
@@ -930,6 +982,191 @@ class ExportValidationGate:
                 source_stage="export_validation",
             ))
 
+        return result
+
+    def _check_theory_bundle(
+        self,
+        component_result,
+        errors: list,
+        warnings: list,
+        review_items: list,
+    ) -> dict:
+        """Validate the TheoryBundle Step 5 container (issue #326).
+
+        Reads ``component_result.theory_bundle.theory_bundle`` and re-validates
+        its component references against the refined components so dangling refs
+        surface here regardless of what the stage pre-computed. Aggregates the
+        stage's own errors/warnings/review items as well.
+        """
+        bundle_block = getattr(component_result, "theory_bundle", {}) or {}
+        if not isinstance(bundle_block, dict) or not bundle_block:
+            return _empty_theory_bundle_validation()
+        bundle = bundle_block.get("theory_bundle")
+        if not isinstance(bundle, dict) or not bundle:
+            return _empty_theory_bundle_validation()
+
+        known_ids = {
+            c.component_id for c in (getattr(component_result, "components", []) or [])
+        }
+
+        result = _empty_theory_bundle_validation()
+        stage_block = bundle_block.get("theory_bundle_validation")
+        if isinstance(stage_block, dict):
+            for key in ("bundle_created", "headline_claim_linked", "support_map_linked"):
+                if key in stage_block:
+                    result[key] = stage_block[key]
+
+        # Authoritative ref re-validation (independent of stage booleans).
+        dangling = [
+            cid for cid in bundle.get("component_ids", []) or [] if cid not in known_ids
+        ]
+        result["component_refs_valid"] = not dangling
+        for cid in dangling:
+            errors.append(ValidationEntry(
+                code="THEORY_BUNDLE_DANGLING_COMPONENT_REF",
+                message=f"theory bundle references missing component {cid!r}",
+                artifact="component_assembly",
+                path="$.theory_bundle.theory_bundle.component_ids",
+                source_stage="export_validation",
+            ))
+
+        if not result["headline_claim_linked"]:
+            warnings.append(ValidationEntry(
+                code="THEORY_BUNDLE_HEADLINE_CLAIM_MISSING",
+                message="theory bundle is not linked to a headline claim",
+                artifact="component_assembly",
+                path="$.theory_bundle.theory_bundle.headline_claim_id",
+                source_stage="export_validation",
+            ))
+        if not result["support_map_linked"]:
+            warnings.append(ValidationEntry(
+                code="THEORY_BUNDLE_SUPPORT_MAP_MISSING",
+                message="theory bundle is not linked to a renderable support map",
+                artifact="component_assembly",
+                path="$.theory_bundle.theory_bundle.support_map_id",
+                source_stage="export_validation",
+            ))
+        if str(bundle.get("review_status")) == "review_required":
+            review_items.append(ValidationEntry(
+                code="THEORY_BUNDLE_REVIEW_REQUIRED",
+                message="theory bundle requires review before publish-ready export",
+                artifact="component_assembly",
+                path="$.theory_bundle.theory_bundle.review_status",
+                source_stage="export_validation",
+            ))
+        return result
+
+    def _check_teaching_output(
+        self,
+        component_result,
+        errors: list,
+        warnings: list,
+        review_items: list,
+    ) -> dict:
+        """Validate the TeachingOutput Step 5 mapping (issue #326).
+
+        Re-validates course topic / blueprint component references against the
+        refined components and verifies each topic's ``blackbox_policy`` covers
+        the low-confidence equations of its linked components (equation
+        confidence must be respected before teaching).
+        """
+        bundle_block = getattr(component_result, "theory_bundle", {}) or {}
+        if not isinstance(bundle_block, dict) or not bundle_block:
+            return _empty_teaching_output_validation()
+        teaching = bundle_block.get("course_mapping")
+        blueprint = bundle_block.get("blueprint_updates") or {}
+        if not isinstance(teaching, dict) or not teaching:
+            return _empty_teaching_output_validation()
+
+        components = getattr(component_result, "components", []) or []
+        known_ids = {c.component_id for c in components}
+        component_by_id = {c.component_id: c for c in components}
+
+        result = _empty_teaching_output_validation()
+        topics_link = True
+        blackbox_ok = True
+
+        for topic in teaching.get("topics", []) or []:
+            if not isinstance(topic, dict):
+                continue
+            topic_id = topic.get("topic_id")
+            linked = topic.get("linked_component_ids") or []
+            resolved = [cid for cid in linked if cid in known_ids]
+            if not resolved:
+                topics_link = False
+                errors.append(ValidationEntry(
+                    code="TEACHING_OUTPUT_TOPIC_LINKS_NO_COMPONENT",
+                    message=f"course topic {topic_id!r} links no refined component",
+                    artifact="course_mapping",
+                    path="$.theory_bundle.course_mapping.topics",
+                    source_stage="export_validation",
+                ))
+            for cid in linked:
+                if cid not in known_ids:
+                    topics_link = False
+                    errors.append(ValidationEntry(
+                        code="TEACHING_OUTPUT_DANGLING_COMPONENT_REF",
+                        message=(
+                            f"course topic {topic_id!r} references missing component {cid!r}"
+                        ),
+                        artifact="course_mapping",
+                        path="$.theory_bundle.course_mapping.topics",
+                        source_stage="export_validation",
+                    ))
+
+            policy_eq_ids = {
+                str(p.get("equation_id"))
+                for p in topic.get("blackbox_policy") or []
+                if isinstance(p, dict) and p.get("equation_id")
+            }
+            for cid in resolved:
+                for eq_id in _component_low_confidence_equation_ids(component_by_id[cid]):
+                    if eq_id not in policy_eq_ids:
+                        blackbox_ok = False
+                        errors.append(ValidationEntry(
+                            code="TEACHING_OUTPUT_BLACKBOX_POLICY_IGNORES_CONFIDENCE",
+                            message=(
+                                f"course topic {topic_id!r} does not blackbox "
+                                f"low-confidence equation {eq_id!r}"
+                            ),
+                            artifact="course_mapping",
+                            path="$.theory_bundle.course_mapping.topics",
+                            source_stage="export_validation",
+                        ))
+
+            if str(topic.get("review_status")) == "review_required":
+                review_items.append(ValidationEntry(
+                    code="TEACHING_OUTPUT_TOPIC_REVIEW_REQUIRED",
+                    message=f"course topic {topic_id!r} contains a review_required component",
+                    artifact="course_mapping",
+                    path="$.theory_bundle.course_mapping.topics",
+                    source_stage="export_validation",
+                ))
+
+        blueprint_refs_valid = True
+        for cid in blueprint.get("linked_component_ids", []) or []:
+            if cid not in known_ids:
+                blueprint_refs_valid = False
+                errors.append(ValidationEntry(
+                    code="TEACHING_OUTPUT_BLUEPRINT_DANGLING_REF",
+                    message=f"blueprint references missing component {cid!r}",
+                    artifact="blueprint",
+                    path="$.theory_bundle.blueprint_updates.linked_component_ids",
+                    source_stage="export_validation",
+                ))
+
+        # Combine the gate's own (component-field) checks with the stage's
+        # equation-policy-aware booleans: a property holds only if both agree.
+        stage_block = bundle_block.get("teaching_output_validation") or {}
+        result["course_topics_link_components"] = topics_link and bool(
+            stage_block.get("course_topics_link_components", True)
+        )
+        result["blackbox_policy_respects_confidence"] = blackbox_ok and bool(
+            stage_block.get("blackbox_policy_respects_confidence", True)
+        )
+        result["blueprint_refs_valid"] = blueprint_refs_valid and bool(
+            stage_block.get("blueprint_refs_valid", True)
+        )
         return result
 
     def _cross_validate_course_mapping(

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -23,6 +23,7 @@ from .overlap_cleanup import ComponentOverlapCleanup
 from .prompt import ComponentAssemblyPromptFactory
 from .repair import ComponentAssemblyRepairer, _parse_raw, make_deterministic_fallback
 from .schema import CartridgeContext, ComponentAssemblyLLMInput, ComponentAssemblyResult, ValidationIssue
+from .theory_bundle import TheoryBundleStage
 from .validator import ComponentAssemblyValidator
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,7 @@ class ComponentAssemblyAgent:
         self._refiner = ComponentRefiner()
         self._granularity_analyzer = ComponentGranularityAnalyzer()
         self._derivation_graph_aligner = DerivationGraphAligner()
+        self._theory_bundle_stage = TheoryBundleStage()
 
     def run(
         self,
@@ -155,6 +157,16 @@ class ComponentAssemblyAgent:
                 result, llm_input=llm_input, derivations=derivations
             )
             result.derivation_graph_alignment = alignment.to_dict()
+
+        # Step 5: represent the whole paper as a TheoryBundle and map refined
+        # components into a teaching output (course topics + minimal blueprint
+        # reflection). Disabled by default; depends on Step 3/4 output being
+        # present, so it stays additive until opted in.
+        if (config or {}).get("enable_theory_bundle_builder", False):
+            bundle = self._theory_bundle_stage.run(
+                result, llm_input=llm_input, derivations=derivations
+            )
+            result.theory_bundle = bundle.to_dict()
 
         merged_diagnostics = dict(diagnostics)
         merged_diagnostics.update(result.diagnostics or {})

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -222,6 +222,10 @@ class ComponentAssemblyResult:
     #  aligned_derivation_chains, support_map, graph_alignment_validation,
     #  export_validation}.
     derivation_graph_alignment: dict = field(default_factory=dict)
+    # TheoryBundleBuilder + TeachingOutputMapper Step 5 output contract (issue #326):
+    # {theory_bundle, course_mapping, blueprint_updates, theory_bundle_validation,
+    #  teaching_output_validation}.
+    theory_bundle: dict = field(default_factory=dict)
     diagnostics: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -310,6 +314,7 @@ class ComponentAssemblyResult:
             refinement_report=d.get("refinement_report") or {},
             component_refinement=d.get("component_refinement") or {},
             derivation_graph_alignment=d.get("derivation_graph_alignment") or {},
+            theory_bundle=d.get("theory_bundle") or {},
             diagnostics=d.get("diagnostics") or {},
         )
 

--- a/src/episteme_graph/agents/component_assembly/theory_bundle.py
+++ b/src/episteme_graph/agents/component_assembly/theory_bundle.py
@@ -1,0 +1,594 @@
+"""Step 5: TheoryBundleBuilder + TeachingOutputMapper (issue #326).
+
+Represents the whole paper as a ``theory_bundle`` (a container that *references*
+the refined components, theory component graph and support map) instead of one
+giant component, and maps the refined components into a teaching output
+(course topics + minimal blueprint reflection).
+
+This stage is deterministic (non-LLM) and additive. It runs after Step 4
+(DerivationGraphAligner) and reads:
+
+- ``result.components``                 -- refined components (Step 3 output)
+- ``result.component_refinement``       -- Step 3 id mapping (old -> refined)
+- ``result.derivation_graph_alignment`` -- Step 4 theory graph + support map
+- ``llm_input``                         -- equations + claim-centered plan
+
+It emits a single ``theory_bundle`` artifact dict on the ComponentAssemblyResult:
+
+    {
+      "theory_bundle":  {...},          # paper-level container (refs only)
+      "course_mapping": {"topics": []}, # teaching output (refined-component topics)
+      "blueprint_updates": {...},       # minimal blueprint reflection
+      "theory_bundle_validation":  {...},
+      "teaching_output_validation": {...},
+    }
+
+Design principles (issue #326 / CLAUDE.md):
+- The paper-level / headline claim attaches to the bundle, not a giant component.
+- Reusable theory parts remain components; the bundle only references their IDs.
+- Course topics link refined component IDs (never pre-split / old IDs).
+- low-confidence / blocked equations are surfaced in each topic's
+  ``blackbox_policy`` and in ``blueprint_updates.review_required_items``.
+- review_required components propagate to the teaching output and bundle status.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+SOURCE_BACKED = "source_backed"
+REVIEW_REQUIRED = "review_required"
+
+BUNDLE_KIND = "theory_bundle"
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TheoryBundleResult:
+    theory_bundle: dict = field(default_factory=dict)
+    course_mapping: dict = field(default_factory=dict)
+    blueprint_updates: dict = field(default_factory=dict)
+    theory_bundle_validation: dict = field(default_factory=dict)
+    teaching_output_validation: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Stage orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TheoryBundleStage:
+    """Run TheoryBundleBuilder then TeachingOutputMapper and self-validate."""
+
+    def __init__(self) -> None:
+        self._bundle_builder = TheoryBundleBuilder()
+        self._teaching_mapper = TeachingOutputMapper()
+
+    def run(self, result, llm_input=None, derivations=None) -> TheoryBundleResult:
+        components = list(getattr(result, "components", []) or [])
+        eq_index = _equation_index(llm_input)
+        document_id = str(getattr(result, "document_id", "") or "")
+        headline_claim_id, headline_claim = _headline_claim(llm_input)
+        alignment = getattr(result, "derivation_graph_alignment", {}) or {}
+        # Step 4 owns the can_be_rendered_as_final_formula / blocked-path downgrade;
+        # Step 5 consumes the resulting per-component review status from the theory
+        # component graph so the bundle / teaching output stay consistent with it.
+        review_override = _alignment_review_status(alignment)
+
+        bundle = self._bundle_builder.build(
+            document_id=document_id,
+            components=components,
+            eq_index=eq_index,
+            headline_claim_id=headline_claim_id,
+            headline_claim=headline_claim,
+            alignment=alignment,
+            review_override=review_override,
+        )
+        teaching = self._teaching_mapper.map(
+            components=components,
+            eq_index=eq_index,
+            headline_claim=headline_claim,
+            review_override=review_override,
+        )
+        blueprint_updates = self._teaching_mapper.blueprint_updates(
+            components=components, eq_index=eq_index, review_override=review_override
+        )
+
+        bundle_validation = _validate_bundle(bundle, components, alignment)
+        teaching_validation = _validate_teaching_output(
+            teaching, blueprint_updates, components, eq_index
+        )
+
+        return TheoryBundleResult(
+            theory_bundle=bundle,
+            course_mapping=teaching,
+            blueprint_updates=blueprint_updates,
+            theory_bundle_validation=bundle_validation,
+            teaching_output_validation=teaching_validation,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TheoryBundleBuilder
+# ---------------------------------------------------------------------------
+
+
+class TheoryBundleBuilder:
+    """Build the paper-level theory bundle container (references only)."""
+
+    def build(
+        self,
+        *,
+        document_id: str,
+        components: list,
+        eq_index: dict,
+        headline_claim_id: str,
+        headline_claim: str,
+        alignment: dict,
+        review_override: dict | None = None,
+    ) -> dict:
+        component_ids = [c.component_id for c in components]
+        review_reasons: list[str] = []
+        status = SOURCE_BACKED
+        for component in components:
+            if _component_review_status(component, review_override) == REVIEW_REQUIRED:
+                status = REVIEW_REQUIRED
+                _add(review_reasons, f"component {component.component_id} requires review")
+            for eq_id in _component_low_confidence_equations(component, eq_index):
+                status = REVIEW_REQUIRED
+                _add(review_reasons, f"low-confidence equation {eq_id} in bundle")
+
+        support_map = alignment.get("support_map") if isinstance(alignment, dict) else None
+        theory_graph = (
+            alignment.get("theory_component_graph") if isinstance(alignment, dict) else None
+        )
+
+        return {
+            "bundle_id": f"{document_id}:{BUNDLE_KIND}",
+            "paper_id": document_id,
+            "kind": BUNDLE_KIND,
+            "title": headline_claim or f"Theory bundle for {document_id}",
+            "central_question": headline_claim,
+            "headline_claim_id": headline_claim_id,
+            "headline_claim": headline_claim,
+            "component_ids": component_ids,
+            # References to the Step 4 artifacts. The graph/support-map payloads
+            # live on result.derivation_graph_alignment; these IDs are the
+            # deterministic handles for them.
+            "component_graph_id": f"{document_id}:theory_component_graph"
+            if theory_graph
+            else "",
+            "support_map_id": f"{document_id}:support_map" if support_map else "",
+            # Registry handles: payloads are reachable from the upstream
+            # EvidenceRegistry / EquationSemantics / DerivationChain artifacts
+            # (keyed by document_id).
+            "evidence_registry_id": f"{document_id}:evidence_registry",
+            "equation_registry_id": f"{document_id}:equation_registry",
+            "derivation_registry_id": f"{document_id}:derivation_registry",
+            "review_status": status,
+            "review_reasons": review_reasons,
+        }
+
+
+# ---------------------------------------------------------------------------
+# TeachingOutputMapper
+# ---------------------------------------------------------------------------
+
+
+class TeachingOutputMapper:
+    """Map refined components into course topics + minimal blueprint reflection."""
+
+    def map(
+        self,
+        *,
+        components: list,
+        eq_index: dict,
+        headline_claim: str,
+        review_override: dict | None = None,
+    ) -> dict:
+        topics: list[dict] = []
+        for component in components:
+            topics.append(
+                self._topic_for_component(
+                    component, eq_index, headline_claim, review_override
+                )
+            )
+        return {"topics": topics}
+
+    def _topic_for_component(
+        self, component, eq_index, headline_claim, review_override=None
+    ) -> dict:
+        cid = component.component_id
+        label = str(getattr(component, "label", "") or cid)
+        takeaway = str(getattr(component, "teaching_takeaway", "") or "").strip()
+        review_status = _component_review_status(component, review_override)
+
+        learning_objectives: list[str] = []
+        if takeaway:
+            learning_objectives.append(takeaway)
+        learning_objectives.append(f"Understand {label}.")
+
+        blackbox_policy = _blackbox_policy_for_component(component, eq_index)
+        granularity = dict(getattr(component, "teaching_granularity", {}) or {})
+
+        return {
+            "topic_id": f"topic:{cid}",
+            "title": label,
+            "description": str(getattr(component, "summary", "") or ""),
+            "linked_component_ids": [cid],
+            "learning_objectives": _ordered_unique(learning_objectives),
+            "prerequisite_concepts": list(getattr(component, "prerequisite_concepts", []) or []),
+            "introduced_concepts": list(getattr(component, "introduced_concepts", []) or []),
+            "blackbox_policy": blackbox_policy,
+            "assessment_prompts": [f"Explain {label} and its role in the paper's argument."],
+            "expected_misconceptions": _expected_misconceptions(component),
+            "visualization_plan": _visualization_plan(component),
+            "review_status": review_status,
+            "teaching_granularity": granularity,
+        }
+
+    def blueprint_updates(
+        self, *, components: list, eq_index: dict, review_override: dict | None = None
+    ) -> dict:
+        linked_component_ids = [c.component_id for c in components]
+        review_required_items: list[dict] = []
+        for component in components:
+            if _component_review_status(component, review_override) == REVIEW_REQUIRED:
+                review_required_items.append({
+                    "type": "component",
+                    "id": component.component_id,
+                    "reason": "component is review_required",
+                })
+            for eq_id in _component_low_confidence_equations(component, eq_index):
+                review_required_items.append({
+                    "type": "equation",
+                    "id": eq_id,
+                    "reason": "low-confidence equation must be blackboxed or warned",
+                })
+        return {
+            "linked_component_ids": linked_component_ids,
+            "review_required_items": review_required_items,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Validation (stage self-check; gate re-validates refs independently)
+# ---------------------------------------------------------------------------
+
+
+def _validate_bundle(bundle: dict, components: list, alignment: dict) -> dict:
+    component_ids = {c.component_id for c in components}
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    review_items: list[dict] = []
+
+    bundle_created = bool(bundle.get("component_ids"))
+    if not bundle_created:
+        warnings.append({
+            "code": "theory_bundle_empty",
+            "message": "theory bundle has no component references",
+        })
+
+    headline_claim_linked = bool(bundle.get("headline_claim_id"))
+    if not headline_claim_linked:
+        warnings.append({
+            "code": "bundle_headline_claim_missing",
+            "message": "theory bundle has no headline claim id",
+        })
+
+    dangling = [cid for cid in bundle.get("component_ids", []) if cid not in component_ids]
+    for cid in dangling:
+        errors.append({
+            "code": "bundle_dangling_component_ref",
+            "message": f"theory bundle references non-existent component '{cid}'",
+            "component_id": cid,
+        })
+    component_refs_valid = not dangling
+
+    support_map = alignment.get("support_map") if isinstance(alignment, dict) else None
+    support_map_linked = bool(bundle.get("support_map_id")) and bool(
+        (support_map or {}).get("layers")
+    )
+    if not support_map_linked:
+        warnings.append({
+            "code": "bundle_support_map_missing",
+            "message": "theory bundle is not linked to a renderable support map",
+        })
+
+    if bundle.get("review_status") == REVIEW_REQUIRED:
+        review_items.append({
+            "code": "bundle_review_required",
+            "message": "theory bundle requires review before publish-ready export",
+            "reasons": list(bundle.get("review_reasons") or []),
+        })
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "review_items": review_items,
+        "bundle_created": bundle_created,
+        "headline_claim_linked": headline_claim_linked,
+        "component_refs_valid": component_refs_valid,
+        "support_map_linked": support_map_linked,
+    }
+
+
+def _validate_teaching_output(
+    teaching: dict, blueprint_updates: dict, components: list, eq_index: dict
+) -> dict:
+    component_ids = {c.component_id for c in components}
+    component_by_id = {c.component_id: c for c in components}
+    errors: list[dict] = []
+    warnings: list[dict] = []
+    review_items: list[dict] = []
+
+    topics = teaching.get("topics", []) or []
+    course_topics_link_components = True
+    blackbox_ok = True
+
+    for topic in topics:
+        linked = topic.get("linked_component_ids") or []
+        resolved = [cid for cid in linked if cid in component_ids]
+        if not resolved:
+            course_topics_link_components = False
+            errors.append({
+                "code": "topic_links_no_component",
+                "message": f"course topic '{topic.get('topic_id')}' links no refined component",
+                "topic_id": topic.get("topic_id"),
+            })
+        for cid in linked:
+            if cid not in component_ids:
+                course_topics_link_components = False
+                errors.append({
+                    "code": "topic_dangling_component_ref",
+                    "message": (
+                        f"course topic '{topic.get('topic_id')}' references "
+                        f"non-existent component '{cid}'"
+                    ),
+                    "topic_id": topic.get("topic_id"),
+                    "component_id": cid,
+                })
+
+        # blackbox policy must cover every low-confidence equation of its components.
+        policy_eq_ids = {
+            str(p.get("equation_id"))
+            for p in topic.get("blackbox_policy") or []
+            if isinstance(p, dict) and p.get("equation_id")
+        }
+        for cid in resolved:
+            for eq_id in _component_low_confidence_equations(component_by_id[cid], eq_index):
+                if eq_id not in policy_eq_ids:
+                    blackbox_ok = False
+                    errors.append({
+                        "code": "blackbox_policy_missing_low_confidence_equation",
+                        "message": (
+                            f"course topic '{topic.get('topic_id')}' does not blackbox "
+                            f"low-confidence equation '{eq_id}'"
+                        ),
+                        "topic_id": topic.get("topic_id"),
+                        "equation_id": eq_id,
+                    })
+
+        if topic.get("review_status") == REVIEW_REQUIRED:
+            review_items.append({
+                "code": "topic_review_required",
+                "message": (
+                    f"course topic '{topic.get('topic_id')}' contains a review_required "
+                    f"component"
+                ),
+                "topic_id": topic.get("topic_id"),
+            })
+
+        granularity = topic.get("teaching_granularity") or {}
+        if granularity.get("teachable_as_single_unit") is False or granularity.get(
+            "split_if_too_dense"
+        ):
+            warnings.append({
+                "code": "topic_too_dense",
+                "message": (
+                    f"course topic '{topic.get('topic_id')}' is too dense to teach as a "
+                    f"single unit"
+                ),
+                "topic_id": topic.get("topic_id"),
+            })
+
+    blueprint_refs_valid = True
+    for cid in blueprint_updates.get("linked_component_ids", []) or []:
+        if cid not in component_ids:
+            blueprint_refs_valid = False
+            errors.append({
+                "code": "blueprint_dangling_component_ref",
+                "message": f"blueprint references non-existent component '{cid}'",
+                "component_id": cid,
+            })
+
+    return {
+        "errors": errors,
+        "warnings": warnings,
+        "review_items": review_items,
+        "course_topics_link_components": course_topics_link_components,
+        "blueprint_refs_valid": blueprint_refs_valid,
+        "blackbox_policy_respects_confidence": blackbox_ok,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _equation_index(llm_input) -> dict:
+    index: dict[str, dict] = {}
+    if not llm_input:
+        return index
+    pools = list(getattr(llm_input, "equations", []) or []) + list(
+        getattr(llm_input, "available_equations", []) or []
+    )
+    for eq in pools:
+        eq_id = str(eq.get("equation_id") or "")
+        if not eq_id:
+            continue
+        merged = dict(index.get(eq_id, {}))
+        merged.update(eq)
+        index[eq_id] = merged
+    return index
+
+
+def _headline_claim(llm_input) -> tuple[str, str]:
+    if not llm_input:
+        return "", ""
+    plan = getattr(llm_input, "claim_centered_plan", {}) or {}
+    ids = plan.get("headline_claim_ids") or []
+    claim_id = str(ids[0]) if ids else ""
+    return claim_id, str(plan.get("headline_claim") or "")
+
+
+def _alignment_review_status(alignment: dict) -> dict:
+    """component_id -> review_status from the Step 4 theory component graph."""
+    override: dict[str, str] = {}
+    if not isinstance(alignment, dict):
+        return override
+    graph = alignment.get("theory_component_graph") or {}
+    for node in graph.get("nodes", []) or []:
+        cid = node.get("component_id")
+        status = node.get("review_status")
+        if cid and status:
+            override[str(cid)] = str(status)
+    return override
+
+
+def _component_review_status(component, review_override: dict | None = None) -> str:
+    cid = getattr(component, "component_id", "")
+    if review_override and str(review_override.get(cid, "")) == REVIEW_REQUIRED:
+        return REVIEW_REQUIRED
+    raw = str(getattr(component, "review_status", "") or "")
+    if raw in {SOURCE_BACKED, "auto_accepted"}:
+        # An otherwise-accepted component is still review_required if its own
+        # gate / review-equation fields say so.
+        if getattr(component, "review_required_equation_ids", None):
+            return REVIEW_REQUIRED
+        gate = getattr(component, "confidence_gate", {}) or {}
+        if gate.get("blocked_by_equation_ids"):
+            return REVIEW_REQUIRED
+        return SOURCE_BACKED
+    return REVIEW_REQUIRED
+
+
+def _equation_is_low_confidence(eq: dict) -> bool:
+    """True when an equation's confidence policy makes it unsafe to render as-is.
+
+    Mirrors the Step 0 / Step 4 gates: blocked downstream use, cannot support a
+    claim, cannot be used in a derivation, or cannot be rendered as a final
+    formula. The last one is the can_be_rendered_as_final_formula concern that
+    Step 4 owns; Step 5 surfaces it in the teaching blackbox policy.
+    """
+    if not isinstance(eq, dict):
+        return False
+    policy = eq.get("confidence_policy")
+    if not isinstance(policy, dict):
+        return False
+    if str(policy.get("allowed_downstream_use") or "") == "blocked":
+        return True
+    return (
+        policy.get("can_support_claim") is False
+        or policy.get("can_be_used_in_derivation") is False
+        or policy.get("can_be_rendered_as_final_formula") is False
+    )
+
+
+def _component_low_confidence_equations(component, eq_index: dict | None = None) -> list[str]:
+    # Step 3 component fields (already-decided low-confidence equations).
+    ids: list[str] = list(getattr(component, "review_required_equation_ids", []) or [])
+    gate = getattr(component, "confidence_gate", {}) or {}
+    ids.extend(gate.get("blocked_by_equation_ids") or [])
+    # Plus any linked equation whose confidence policy says it must not be
+    # rendered as-is (covers can_be_rendered_as_final_formula=false, #326).
+    if eq_index:
+        for eq_id in _component_equation_ids(component):
+            if _equation_is_low_confidence(eq_index.get(eq_id, {})):
+                ids.append(eq_id)
+    return _ordered_unique(ids)
+
+
+def _component_equation_ids(component) -> list[str]:
+    ids: list[str] = []
+    for field_name in (
+        "linked_equation_ids",
+        "input_equation_ids",
+        "intermediate_equation_ids",
+        "output_equation_ids",
+        "constraint_equation_ids",
+        "definition_equation_ids",
+        "review_required_equation_ids",
+    ):
+        ids.extend(getattr(component, field_name, []) or [])
+    refs = getattr(component, "evidence_refs", {}) or {}
+    ids.extend(refs.get("equation_ids") or [])
+    return _ordered_unique(ids)
+
+
+def _blackbox_policy_for_component(component, eq_index) -> list[dict]:
+    policy: list[dict] = []
+    for eq_id in _component_low_confidence_equations(component, eq_index):
+        eq = eq_index.get(eq_id, {}) if isinstance(eq_index, dict) else {}
+        eq_policy = eq.get("confidence_policy") if isinstance(eq, dict) else {}
+        eq_policy = eq_policy if isinstance(eq_policy, dict) else {}
+        allowed = str(eq_policy.get("allowed_downstream_use") or "")
+        if allowed not in {"blocked", "semantic_hint_only"}:
+            allowed = "semantic_hint_only"
+        policy.append({
+            "equation_id": eq_id,
+            "allowed_downstream_use": allowed,
+            "reason": "low-confidence equation must not be rendered as a final formula",
+        })
+    return policy
+
+
+def _expected_misconceptions(component) -> list[str]:
+    items: list[str] = []
+    for caution in getattr(component, "cautions", []) or []:
+        if isinstance(caution, dict):
+            text = str(caution.get("text") or caution.get("name") or "").strip()
+        else:
+            text = str(caution or "").strip()
+        if text:
+            items.append(text)
+    for cond in getattr(component, "invalid_conditions", []) or []:
+        text = str(cond or "").strip()
+        if text:
+            items.append(f"Assuming validity when: {text}")
+    return _ordered_unique(items)
+
+
+def _visualization_plan(component) -> list[dict]:
+    plan: list[dict] = []
+    plan.append({"kind": "component", "ref": component.component_id})
+    for eq_id in _ordered_unique(
+        list(getattr(component, "linked_equation_ids", []) or [])
+    ):
+        plan.append({"kind": "equation", "ref": eq_id})
+    for der_id in _ordered_unique(
+        list(getattr(component, "linked_derivation_ids", []) or [])
+    ):
+        plan.append({"kind": "derivation", "ref": der_id})
+    return plan
+
+
+def _add(items: list[str], value: str) -> None:
+    if value and value not in items:
+        items.append(value)
+
+
+def _ordered_unique(values) -> list[str]:
+    result: list[str] = []
+    for value in values or []:
+        text = str(value or "")
+        if text and text not in result:
+            result.append(text)
+    return result

--- a/src/tests/agents/component_assembly/test_component_refinement_stage.py
+++ b/src/tests/agents/component_assembly/test_component_refinement_stage.py
@@ -138,6 +138,14 @@ def test_basic_split_into_two_single_responsibility_children():
     assert set(graph["added_nodes"]) == {"comp_mix__r1", "comp_mix__r2"}
     assert graph["unresolved_edges"] == []
 
+    # split_method / split_reason / candidate mapping provenance are recorded.
+    assert record["split_method"] == "rule_based"
+    assert record["split_reason"]  # non-empty: carries the Step 1 reasons
+    candidate_names = {
+        m["new_component_id"] for m in record["split_candidate_mapping"]
+    }
+    assert candidate_names == {"comp_mix__r1", "comp_mix__r2"}
+
 
 # ---------------------------------------------------------------------------
 # 3. Link redistribution
@@ -182,6 +190,63 @@ def test_links_redistributed_not_duplicated_and_unassigned_reported():
 
     unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
     assert any(u["link_id"] == "eq_orphan" and u["link_type"] == "equation" for u in unassigned)
+
+
+# ---------------------------------------------------------------------------
+# 3b. Derivation link redistribution (#324 rule 4)
+# ---------------------------------------------------------------------------
+
+def test_derivation_links_redistributed_to_derivational_child():
+    component = _component(
+        component_id="comp_derlinks",
+        linked_equation_ids=["eq_def", "eq_der"],
+        linked_derivation_ids=["d_a", "d_b"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Derivation", "derivation"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_der", "role": "transformation"},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
+    # Derivation links go to the derivational child only, not copied to both.
+    assert derivation.linked_derivation_ids == ["d_a", "d_b"]
+    assert definition.linked_derivation_ids == []
+
+
+def test_unassigned_derivation_link_reported_not_dropped():
+    # definition + application: the split happens (both children carry equations),
+    # but neither child is derivational, so the derivation link has no home and
+    # must be reported instead of silently dropped.
+    component = _component(
+        component_id="comp_unassign_der",
+        linked_equation_ids=["eq_def", "eq_app"],
+        linked_derivation_ids=["d_orphan"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Application", "application"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_app", "role": "result"},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    # The split still produced two single-responsibility children.
+    assert [c.responsibility_type for c in refined.components] == ["definition", "application"]
+    # The derivation link was not assigned to any child.
+    for child in refined.components:
+        assert "d_orphan" not in child.linked_derivation_ids
+    unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
+    assert any(
+        u["link_id"] == "d_orphan" and u["link_type"] == "derivation" for u in unassigned
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +358,68 @@ def test_concepts_recomputed_per_child_not_copied_wholesale():
     assert derivation.introduced_concepts == ["beta"]
     # prerequisite recomputed: alpha is a parent prerequisite present in the definition child.
     assert definition.prerequisite_concepts == ["alpha"]
+
+
+def test_concepts_recomputed_from_equation_symbols():
+    # No claims at all: child concepts must be derived from the equations'
+    # defined/used symbols, redistributed per responsibility.
+    component = _component(
+        component_id="comp_eqsym",
+        linked_equation_ids=["eq_def", "eq_der"],
+        concepts=["broad_parent_concept"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Derivation", "derivation"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition", "defined_symbols": [{"symbol": "sigma"}]},
+        {"equation_id": "eq_der", "role": "transformation", "defined_symbols": [{"symbol": "b_2"}],
+         "used_symbols": ["delta"]},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
+    assert definition.concepts == ["sigma"]
+    assert set(derivation.concepts) == {"b_2", "delta"}
+    # The broad parent-only concept is not copied onto either child.
+    assert "broad_parent_concept" not in definition.concepts + derivation.concepts
+
+
+def test_non_atomic_claim_concepts_not_treated_as_confirmed():
+    # A composite (non-atomic) claim's concepts must NOT become a child's
+    # confirmed concepts; only atomic-claim and equation-symbol concepts do.
+    component = _component(
+        component_id="comp_lowconf_concept",
+        linked_equation_ids=["eq_def", "eq_der"],
+        linked_claim_ids=["claim_atomic", "claim_composite"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Derivation", "derivation"),
+        ),
+    )
+    llm_input = _LLMInput(
+        equations=[
+            {"equation_id": "eq_def", "role": "definition"},
+            {"equation_id": "eq_der", "role": "transformation"},
+        ],
+        claims=[
+            {"claim_id": "claim_atomic", "is_atomic": True, "atomicity": "atomic",
+             "equation_ids": ["eq_def"], "concepts": ["confirmed_concept"]},
+            {"claim_id": "claim_composite", "is_atomic": False, "atomicity": "split_pending",
+             "equation_ids": ["eq_der"], "concepts": ["unconfirmed_concept"]},
+        ],
+    )
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
+    assert "confirmed_concept" in definition.concepts
+    # The composite claim was assigned to the derivation child, but its concept
+    # is not promoted to a confirmed concept there.
+    assert "claim_composite" in derivation.linked_claim_ids
+    assert "unconfirmed_concept" not in derivation.concepts
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/agents/component_assembly/test_derivation_graph_aligner.py
+++ b/src/tests/agents/component_assembly/test_derivation_graph_aligner.py
@@ -502,6 +502,112 @@ def test_derivation_order_validation():
     assert broken.graph_alignment_validation["derivation_order_valid"] is False
 
 
+def test_unmapped_operations_and_steps_reported():
+    # A derivation chain that is not linked to any component (and whose equations
+    # match no component) leaves its operation/step unattributed. These must be
+    # surfaced, not silently dropped.
+    comp = _component(component_id="c_unrelated", responsibility_type="definition")
+    chain = _chain("d_floating", [_step("s1", "derive", ["eq_a"], ["eq_b"])])
+    alignment = ALIGNER.align(
+        _result([comp]),
+        llm_input=_LLMInput(equations=[_eq("eq_a"), _eq("eq_b")]),
+        derivations=_derivations(chain),
+    )
+    gv = alignment.graph_alignment_validation
+    assert gv["unmapped_operations"] == ["s1"]
+    assert gv["unmapped_derivation_steps"] == ["s1"]
+    # The unattributed step carries an empty component_id rather than a wrong one.
+    assert alignment.aligned_derivation_chains[0]["steps"][0]["component_id"] == ""
+
+
+def test_chain_linked_component_ids_remapped_through_step3_mapping():
+    # A derivation chain still references the pre-split (old) component id; Step 4
+    # must resolve it to the refined id via the Step 3 mapping.
+    comp = _component(
+        component_id="c_new",
+        responsibility_type="derivation",
+        linked_derivation_ids=[],
+        input_equation_ids=["eq_a"],
+        output_equation_ids=["eq_b"],
+    )
+    chain = _chain(
+        "d1",
+        [_step("s1", "derive", ["eq_a"], ["eq_b"])],
+        linked_component_ids=["c_old"],
+    )
+    refinement = {
+        "component_id_mapping": [
+            {
+                "original_component_id": "c_old",
+                "new_component_ids": ["c_new"],
+                "mapping_type": "one_to_one",
+            }
+        ]
+    }
+    alignment = ALIGNER.align(
+        _result([comp], component_refinement=refinement),
+        llm_input=_LLMInput(equations=[_eq("eq_a"), _eq("eq_b")]),
+        derivations=_derivations(chain),
+    )
+    aligned = alignment.aligned_derivation_chains[0]
+    assert aligned["linked_component_ids"] == ["c_new"]
+    assert all(s["component_id"] == "c_new" for s in aligned["steps"])
+    assert alignment.unresolved_component_refs == []
+
+
+def test_review_required_component_in_support_emphasis_and_role_layers():
+    comps = [
+        _component(
+            component_id="c_rev",
+            responsibility_type="model",
+            support_role="theory_base",
+            review_status="review_required",
+        ),
+        _component(component_id="c_app", responsibility_type="application", support_role="application"),
+        _component(component_id="c_lim", responsibility_type="limitation", support_role="limitation"),
+    ]
+    alignment = ALIGNER.align(
+        _result(comps),
+        llm_input=_LLMInput(claim_centered_plan={"headline_claim_ids": ["claim_head"]}),
+        derivations=_derivations(),
+    )
+    support = alignment.support_map
+    layer_map = {l["layer_id"]: l["component_ids"] for l in support["layers"]}
+    # support_role drives both standard and generated layer ids.
+    assert layer_map["theory_base"] == ["c_rev"]
+    assert layer_map["application_layer"] == ["c_app"]
+    assert layer_map["limitation_layer"] == ["c_lim"]
+    # A review_required component lands in the review emphasis bucket, not primary.
+    assert support["emphasis"]["review_required_component_ids"] == ["c_rev"]
+    assert "c_rev" not in support["emphasis"]["primary_novelty_component_ids"]
+
+
+def test_theory_edge_carries_claim_evidence_and_derivation_refs():
+    comp_a = _component(
+        component_id="c_a",
+        responsibility_type="derivation",
+        linked_claim_ids=["claim_x"],
+        linked_evidence_ids=["ev_x"],
+        linked_derivation_ids=["der_x"],
+        dependencies=[{"dependency_type": "depends_on", "component_refs": ["c_b"], "reason": ""}],
+    )
+    comp_b = _component(
+        component_id="c_b",
+        responsibility_type="definition",
+        linked_claim_ids=["claim_x"],
+        linked_evidence_ids=["ev_x"],
+        linked_derivation_ids=["der_x"],
+    )
+    alignment = ALIGNER.align(
+        _result([comp_a, comp_b]), llm_input=_LLMInput(), derivations=_derivations()
+    )
+    edge = next(e for e in alignment.theory_component_graph["edges"] if e["source"] == "c_a")
+    assert edge["edge_type"] == "depends_on"
+    assert edge["claim_refs"] == ["claim_x"]
+    assert edge["evidence_refs"] == ["ev_x"]
+    assert edge["derivation_refs"] == ["der_x"]
+
+
 def test_derivation_component_missing_io_equations_warns():
     comp = _component(
         component_id="c_der",

--- a/src/tests/agents/component_assembly/test_step3_step4_integration.py
+++ b/src/tests/agents/component_assembly/test_step3_step4_integration.py
@@ -235,3 +235,58 @@ def test_low_confidence_equation_propagates_refiner_to_aligner_path():
         if n["component_id"] == derivation_child.component_id
     )
     assert der_node["review_status"] == "review_required"
+
+
+def test_cannot_render_as_final_formula_downgrades_in_step4_not_step3():
+    """Agreed contract (amends #324 rule 6).
+
+    ``can_be_rendered_as_final_formula: false`` is about whether an equation may
+    be shown/used as the final formula -- a display/result concern. Step 3
+    (component split) only *preserves and propagates* the flag (it keeps the
+    equation linked) and does NOT downgrade a child on this flag alone. The
+    downgrade of a final result/constraint component belongs to Step 4, where
+    derivation / result alignment happens.
+    """
+    cx = _component(
+        component_id="cx",
+        linked_equation_ids=["eq_def", "eq_final"],
+        split_recommendation=_split_rec(
+            ("Definition", "definition"),
+            ("Result", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {
+            "equation_id": "eq_final",
+            "role": "result",
+            "confidence_policy": {
+                # otherwise healthy: only the final-formula flag is false.
+                "can_support_claim": True,
+                "can_be_used_in_derivation": True,
+                "can_be_rendered_as_final_formula": False,
+                "allowed_downstream_use": "display_with_warning",
+            },
+        },
+    ])
+
+    # --- Step 3: preserve + propagate, but do NOT downgrade on this flag alone ---
+    refined = REFINER.refine(_result([cx]), llm_input=llm_input, derivations=None)
+    result_child = next(
+        c for c in refined.components if c.responsibility_type == "constraint"
+    )
+    assert result_child.review_status == "source_backed"
+    # The equation (and therefore its policy) is propagated, not dropped, so Step 4
+    # can re-evaluate it.
+    assert "eq_final" in result_child.linked_equation_ids
+    # The flag alone did not put eq_final into the Step 3 review list.
+    assert "eq_final" not in result_child.review_required_equation_ids
+
+    # --- Step 4: final result rendering a non-final-formula equation -> review ---
+    alignment = ALIGNER.align(refined, llm_input=llm_input, derivations=_derivations())
+    result_node = next(
+        n
+        for n in alignment.theory_component_graph["nodes"]
+        if n["component_id"] == result_child.component_id
+    )
+    assert result_node["review_status"] == "review_required"

--- a/src/tests/agents/component_assembly/test_step3_step4_integration.py
+++ b/src/tests/agents/component_assembly/test_step3_step4_integration.py
@@ -1,0 +1,237 @@
+"""Step 3 -> Step 4 integration / cross-stage wiring tests (#324 / #325).
+
+The dedicated unit tests in ``test_component_refinement_stage.py`` and
+``test_derivation_graph_aligner.py`` exercise each stage in isolation; the
+aligner unit tests hand-build the ``component_id_mapping``. These tests instead
+run the *real* ComponentRefiner output into the DerivationGraphAligner so the
+non-LLM contract between the two stages is exercised end to end:
+
+- Step 3 splits a coarse component and emits ``component_id_mapping``.
+- Step 4 consumes that mapping to resolve old (pre-split) component references in
+  dependencies and derivation chains to the refined IDs.
+- No dangling references / errors survive a clean happy path.
+- A low-confidence equation propagates from the refined component all the way to
+  the aligned derivation path's review status and export review items.
+"""
+from episteme_graph.agents.component_assembly.component_refiner import ComponentRefiner
+from episteme_graph.agents.component_assembly.derivation_graph_aligner import (
+    DerivationGraphAligner,
+)
+from episteme_graph.agents.component_assembly.schema import (
+    COMPONENTS_VERSION,
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+
+REFINER = ComponentRefiner()
+ALIGNER = DerivationGraphAligner()
+
+
+def _component(**kwargs):
+    defaults = dict(
+        component_id="comp",
+        component_type="RelationComponent",
+        label="Coarse theory component",
+        summary="A coarse bundle of distinct responsibilities.",
+        inputs=[{"name": "input"}],
+        outputs=[{"name": "output"}],
+        preconditions=[],
+        cautions=[],
+        dependencies=[],
+        evidence_refs={},
+        reason="coarse",
+        confidence=0.8,
+        review_notes=[],
+        review_status="auto_accepted",
+        source_scope={"section_ids": ["s1"]},
+    )
+    defaults.update(kwargs)
+    return ComponentRecord(**defaults)
+
+
+def _result(components, component_refinement=None):
+    return ComponentAssemblyResult(
+        document_id="doc",
+        components_version=COMPONENTS_VERSION,
+        cartridge_id=None,
+        components=components,
+        assembly_hints=[],
+        review_notes=[],
+        confidence=0.8,
+        component_refinement=component_refinement or {},
+    )
+
+
+class _LLMInput:
+    def __init__(self, equations=None, claims=None, claim_centered_plan=None):
+        self.equations = equations or []
+        self.available_equations = []
+        self.available_claims = claims or []
+        self.accepted_claims = []
+        self.claim_centered_plan = claim_centered_plan or {}
+
+
+def _step(step_id, op, inputs, outputs, **kwargs):
+    return DerivationStep(
+        step_id=step_id,
+        input_equation_ids=inputs,
+        operation=op,
+        output_equation_ids=outputs,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+
+
+def _chain(derivation_id, steps, linked_component_ids=None, **kwargs):
+    chain = DerivationChainRecord(
+        derivation_id=derivation_id,
+        document_id="doc",
+        source_section_ids=[],
+        steps=steps,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+    if linked_component_ids is not None:
+        chain.linked_component_ids = linked_component_ids
+    return chain
+
+
+def _derivations(*chains):
+    return DerivationChainResult(document_id="doc", cartridge_id=None, chains=list(chains))
+
+
+def _split_rec(*suggested):
+    return {
+        "required": True,
+        "reasons": ["responsibility type has more than one primary value"],
+        "suggested_components": [
+            {"name": name, "responsibility_type": resp} for name, resp in suggested
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path: refiner split -> aligner consumes mapping, resolves old refs.
+# ---------------------------------------------------------------------------
+
+
+def test_refiner_split_then_aligner_uses_refined_ids_no_dangling():
+    # cx is oversized (definition + derivation) and gets split. cb depends on the
+    # *old* id cx; a derivation chain is also linked to the old id cx.
+    cx = _component(
+        component_id="cx",
+        linked_equation_ids=["eq_def", "eq_der"],
+        linked_derivation_ids=["d1"],
+        split_recommendation=_split_rec(
+            ("Definition of foo", "definition"),
+            ("Derivation of bar", "derivation"),
+        ),
+    )
+    cb = _component(
+        component_id="cb",
+        component_type="ClaimBundleComponent",
+        split_recommendation={"required": False, "suggested_components": []},
+        dependencies=[
+            {"dependency_type": "depends_on", "component_refs": ["cx"], "reason": "uses cx"}
+        ],
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition", "plain_text": "def"},
+        {"equation_id": "eq_der", "role": "transformation", "plain_text": "der"},
+    ])
+
+    # --- Step 3 ---
+    refined = REFINER.refine(_result([cx, cb]), llm_input=llm_input, derivations=None)
+    refined_ids = [c.component_id for c in refined.components]
+    assert "cx" not in refined_ids
+    assert {"cx__r1", "cx__r2", "cb"} == set(refined_ids)
+    # Step 3 already rewired the in-graph dependency to the first child.
+    cb_refined = next(c for c in refined.components if c.component_id == "cb")
+    assert cb_refined.dependencies[0]["component_refs"] == ["cx__r1"]
+
+    # --- Step 4 (consumes Step 3 output, not a hand-built mapping) ---
+    chain = _chain(
+        "d1",
+        [_step("s1", "derive", ["eq_def"], ["eq_der"])],
+        linked_component_ids=["cx"],  # still the OLD id
+    )
+    alignment = ALIGNER.align(refined, llm_input=llm_input, derivations=_derivations(chain))
+
+    # Theory graph contains only refined component nodes.
+    node_ids = [n["component_id"] for n in alignment.theory_component_graph["nodes"]]
+    assert set(node_ids) == {"cx__r1", "cx__r2", "cb"}
+    # The chain's old "cx" reference is resolved to BOTH refined children.
+    assert alignment.aligned_derivation_chains[0]["linked_component_ids"] == [
+        "cx__r1",
+        "cx__r2",
+    ]
+    # No unresolved / dangling references remain on a clean happy path.
+    assert alignment.unresolved_component_refs == []
+    assert alignment.graph_alignment_validation["dangling_component_refs"] == []
+    assert alignment.export_validation["errors"] == []
+    assert alignment.graph_alignment_validation["component_graph_clean"] is True
+
+
+# ---------------------------------------------------------------------------
+# Low-confidence path: blocked equation propagates Step 3 -> Step 4.
+# ---------------------------------------------------------------------------
+
+
+def test_low_confidence_equation_propagates_refiner_to_aligner_path():
+    cx = _component(
+        component_id="cx",
+        linked_equation_ids=["eq_def", "eq_blocked"],
+        linked_derivation_ids=["d1"],
+        split_recommendation=_split_rec(
+            ("Definition", "definition"),
+            ("Derivation", "derivation"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {
+            "equation_id": "eq_blocked",
+            "role": "transformation",
+            "confidence_policy": {
+                "can_support_claim": False,
+                "can_be_used_in_derivation": False,
+                "allowed_downstream_use": "blocked",
+            },
+        },
+    ])
+
+    refined = REFINER.refine(_result([cx]), llm_input=llm_input, derivations=None)
+    derivation_child = next(
+        c for c in refined.components if c.responsibility_type == "derivation"
+    )
+    # Step 3 already downgraded the child that owns the blocked equation.
+    assert derivation_child.review_status == "review_required"
+
+    chain = _chain(
+        "d1",
+        [_step("s1", "derive", ["eq_def"], ["eq_blocked"])],
+        linked_component_ids=["cx"],
+    )
+    alignment = ALIGNER.align(refined, llm_input=llm_input, derivations=_derivations(chain))
+
+    aligned = alignment.aligned_derivation_chains[0]
+    # The step using the blocked equation, and the whole chain, are review_required.
+    assert aligned["steps"][0]["review_status"] == "review_required"
+    assert aligned["review_status"] == "review_required"
+    assert "d1" in alignment.graph_alignment_validation["review_required_paths"]
+    assert any(
+        item["code"] == "review_required_derivation_path" and item["derivation_id"] == "d1"
+        for item in alignment.export_validation["review_items"]
+    )
+    # The refined derivation component node also reflects review_required status.
+    der_node = next(
+        n
+        for n in alignment.theory_component_graph["nodes"]
+        if n["component_id"] == derivation_child.component_id
+    )
+    assert der_node["review_status"] == "review_required"

--- a/src/tests/agents/component_assembly/test_theory_bundle.py
+++ b/src/tests/agents/component_assembly/test_theory_bundle.py
@@ -1,0 +1,405 @@
+"""Step 5 TheoryBundleBuilder + TeachingOutputMapper tests (issue #326).
+
+Non-LLM 疎通 coverage for the TheoryBundle container and the teaching output
+mapping: bundle creation + references, bundle/component separation, course-topic
+linkage to refined component IDs, blackbox policy reflecting equation confidence,
+review_required propagation, and the Step 5 validation blocks. Also includes a
+Step 3 -> 4 -> 5 integration path that feeds real refiner/aligner output into the
+bundle stage.
+"""
+from episteme_graph.agents.component_assembly.component_refiner import ComponentRefiner
+from episteme_graph.agents.component_assembly.derivation_graph_aligner import (
+    DerivationGraphAligner,
+)
+from episteme_graph.agents.component_assembly.theory_bundle import (
+    TheoryBundleStage,
+    TheoryBundleBuilder,
+    TeachingOutputMapper,
+)
+from episteme_graph.agents.component_assembly.schema import (
+    COMPONENTS_VERSION,
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+
+STAGE = TheoryBundleStage()
+
+
+def _component(**kwargs):
+    defaults = dict(
+        component_id="comp",
+        component_type="RelationComponent",
+        label="A reusable theory unit",
+        summary="summary",
+        inputs=[{"name": "input"}],
+        outputs=[{"name": "output"}],
+        preconditions=[],
+        cautions=[],
+        dependencies=[],
+        evidence_refs={},
+        reason="",
+        confidence=0.8,
+        review_notes=[],
+        review_status="source_backed",
+        source_scope={},
+    )
+    defaults.update(kwargs)
+    return ComponentRecord(**defaults)
+
+
+def _result(components, derivation_graph_alignment=None, document_id="doc1"):
+    return ComponentAssemblyResult(
+        document_id=document_id,
+        components_version=COMPONENTS_VERSION,
+        cartridge_id=None,
+        components=components,
+        assembly_hints=[],
+        review_notes=[],
+        confidence=0.8,
+        derivation_graph_alignment=derivation_graph_alignment or {},
+    )
+
+
+class _LLMInput:
+    def __init__(self, equations=None, claim_centered_plan=None):
+        self.equations = equations or []
+        self.available_equations = []
+        self.claim_centered_plan = claim_centered_plan or {}
+
+
+def _plan(headline_id="claim_head", headline="The central claim of the paper."):
+    return {"headline_claim_ids": [headline_id], "headline_claim": headline}
+
+
+def _eq(equation_id, **policy):
+    return {
+        "equation_id": equation_id,
+        "plain_text": equation_id,
+        "confidence_policy": {
+            "can_support_claim": policy.get("can_support_claim", True),
+            "can_be_used_in_derivation": policy.get("can_be_used_in_derivation", True),
+            "can_be_rendered_as_final_formula": policy.get("can_final", True),
+            "allowed_downstream_use": policy.get("allowed", "unrestricted"),
+        },
+    }
+
+
+def _step(step_id, op, inputs, outputs, **kwargs):
+    return DerivationStep(
+        step_id=step_id,
+        input_equation_ids=inputs,
+        operation=op,
+        output_equation_ids=outputs,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+
+
+def _chain(derivation_id, steps, linked_component_ids=None, **kwargs):
+    chain = DerivationChainRecord(
+        derivation_id=derivation_id,
+        document_id="doc1",
+        source_section_ids=[],
+        steps=steps,
+        review_status=kwargs.pop("review_status", "auto_accepted"),
+        **kwargs,
+    )
+    if linked_component_ids is not None:
+        chain.linked_component_ids = linked_component_ids
+    return chain
+
+
+def _derivations(*chains):
+    return DerivationChainResult(document_id="doc1", cartridge_id=None, chains=list(chains))
+
+
+# ---------------------------------------------------------------------------
+# 1. TheoryBundle creation
+# ---------------------------------------------------------------------------
+
+
+def test_theory_bundle_created_with_refs_and_headline():
+    comps = [
+        _component(component_id="c1", responsibility_type="model", support_role="theory_base",
+                   concepts=["alpha"]),
+        _component(component_id="c2", responsibility_type="constraint", support_role="result",
+                   concepts=["beta"]),
+    ]
+    alignment = {
+        "theory_component_graph": {"nodes": [
+            {"component_id": "c1", "review_status": "source_backed"},
+            {"component_id": "c2", "review_status": "source_backed"},
+        ], "edges": []},
+        "support_map": {"layers": [{"layer_id": "result_layer", "component_ids": ["c2"]}]},
+    }
+    out = STAGE.run(
+        _result(comps, alignment),
+        llm_input=_LLMInput(claim_centered_plan=_plan()),
+        derivations=_derivations(),
+    )
+    bundle = out.theory_bundle
+    assert bundle["kind"] == "theory_bundle"
+    assert bundle["paper_id"] == "doc1"
+    assert bundle["bundle_id"] == "doc1:theory_bundle"
+    # headline claim attached to the bundle.
+    assert bundle["headline_claim_id"] == "claim_head"
+    assert bundle["headline_claim"] == "The central claim of the paper."
+    # refined components are bundle children (by id reference).
+    assert bundle["component_ids"] == ["c1", "c2"]
+    # graph / support map / registries reachable by reference handle.
+    assert bundle["component_graph_id"] == "doc1:theory_component_graph"
+    assert bundle["support_map_id"] == "doc1:support_map"
+    assert bundle["evidence_registry_id"] == "doc1:evidence_registry"
+    assert bundle["equation_registry_id"] == "doc1:equation_registry"
+    assert bundle["derivation_registry_id"] == "doc1:derivation_registry"
+    assert bundle["review_status"] == "source_backed"
+
+    v = out.theory_bundle_validation
+    assert v["bundle_created"] is True
+    assert v["headline_claim_linked"] is True
+    assert v["component_refs_valid"] is True
+    assert v["support_map_linked"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Bundle vs component separation
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_references_components_and_is_not_a_giant_component():
+    comps = [
+        _component(component_id="c1", responsibility_type="model"),
+        _component(component_id="c2", responsibility_type="derivation"),
+        _component(component_id="c3", responsibility_type="constraint"),
+    ]
+    out = STAGE.run(
+        _result(comps),
+        llm_input=_LLMInput(claim_centered_plan=_plan()),
+        derivations=_derivations(),
+    )
+    bundle = out.theory_bundle
+    # The bundle is a container that references component IDs; the reusable parts
+    # remain as separate components (no giant component swallowing the paper).
+    assert bundle["component_ids"] == ["c1", "c2", "c3"]
+    assert "inputs" not in bundle and "internal_flow" not in bundle
+    # The paper-level headline claim lives on the bundle, not duplicated as a
+    # component field.
+    assert bundle["headline_claim_id"] == "claim_head"
+
+
+# ---------------------------------------------------------------------------
+# 3. Course mapping linkage (teaching output)
+# ---------------------------------------------------------------------------
+
+
+def test_course_topics_link_refined_components_with_concepts():
+    comps = [
+        _component(
+            component_id="c_def",
+            responsibility_type="definition",
+            prerequisite_concepts=["alpha"],
+            introduced_concepts=["sigma"],
+            teaching_takeaway="Sigma is the smoothed moment.",
+        ),
+    ]
+    out = STAGE.run(
+        _result(comps),
+        llm_input=_LLMInput(claim_centered_plan=_plan()),
+        derivations=_derivations(),
+    )
+    topics = out.course_mapping["topics"]
+    assert len(topics) == 1
+    topic = topics[0]
+    assert topic["topic_id"] == "topic:c_def"
+    assert topic["linked_component_ids"] == ["c_def"]
+    assert topic["prerequisite_concepts"] == ["alpha"]
+    assert topic["introduced_concepts"] == ["sigma"]
+    assert "Sigma is the smoothed moment." in topic["learning_objectives"]
+    assert topic["assessment_prompts"]
+    # visualization plan references the actual component.
+    assert {"kind": "component", "ref": "c_def"} in topic["visualization_plan"]
+    assert out.teaching_output_validation["course_topics_link_components"] is True
+    assert out.teaching_output_validation["blueprint_refs_valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Low-confidence equation -> blackbox policy
+# ---------------------------------------------------------------------------
+
+
+def test_low_confidence_equation_reflected_in_blackbox_policy_and_review():
+    comp = _component(
+        component_id="c_res",
+        responsibility_type="constraint",
+        support_role="result",
+        linked_equation_ids=["eq_final"],
+        output_equation_ids=["eq_final"],
+    )
+    # eq_final must not be rendered as a final formula.
+    llm_input = _LLMInput(
+        equations=[_eq("eq_final", can_final=False, allowed="display_with_warning")],
+        claim_centered_plan=_plan(),
+    )
+    out = STAGE.run(_result([comp]), llm_input=llm_input, derivations=_derivations())
+
+    topic = out.course_mapping["topics"][0]
+    policy_eqs = [p["equation_id"] for p in topic["blackbox_policy"]]
+    assert "eq_final" in policy_eqs
+    # the bundle is downgraded because it carries a low-confidence equation.
+    assert out.theory_bundle["review_status"] == "review_required"
+    assert any("eq_final" in r for r in out.theory_bundle["review_reasons"])
+    # blackbox policy is self-consistent with the low-confidence equation set.
+    assert out.teaching_output_validation["blackbox_policy_respects_confidence"] is True
+    # equation also surfaced for the blueprint as a review-required item.
+    bp_items = out.blueprint_updates["review_required_items"]
+    assert any(i["type"] == "equation" and i["id"] == "eq_final" for i in bp_items)
+
+
+# ---------------------------------------------------------------------------
+# 5. review_required component -> teaching output
+# ---------------------------------------------------------------------------
+
+
+def test_review_required_component_propagates_to_topic_and_blueprint():
+    comp = _component(component_id="c_rev", responsibility_type="model",
+                      review_status="review_required")
+    out = STAGE.run(
+        _result([comp]),
+        llm_input=_LLMInput(claim_centered_plan=_plan()),
+        derivations=_derivations(),
+    )
+    topic = out.course_mapping["topics"][0]
+    assert topic["review_status"] == "review_required"
+    assert any(
+        r["code"] == "topic_review_required" for r in out.teaching_output_validation["review_items"]
+    )
+    assert any(
+        i["type"] == "component" and i["id"] == "c_rev"
+        for i in out.blueprint_updates["review_required_items"]
+    )
+    assert out.theory_bundle["review_status"] == "review_required"
+
+
+# ---------------------------------------------------------------------------
+# 6. Missing headline / support map -> warnings (still creates bundle)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_headline_and_support_map_warn_but_bundle_created():
+    comp = _component(component_id="c1", responsibility_type="model")
+    out = STAGE.run(
+        _result([comp]),  # no alignment -> no support map
+        llm_input=_LLMInput(claim_centered_plan={}),  # no headline
+        derivations=_derivations(),
+    )
+    v = out.theory_bundle_validation
+    assert v["bundle_created"] is True
+    assert v["headline_claim_linked"] is False
+    assert v["support_map_linked"] is False
+    assert any(w["code"] == "bundle_headline_claim_missing" for w in v["warnings"])
+    assert any(w["code"] == "bundle_support_map_missing" for w in v["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# 7. Builder/mapper unit-level: dangling detection in validation
+# ---------------------------------------------------------------------------
+
+
+def test_validation_flags_dangling_topic_component_ref():
+    # A teaching output that references a component not in the refined set must be
+    # reported (defensive check via the stage validator).
+    from episteme_graph.agents.component_assembly.theory_bundle import (
+        _validate_teaching_output,
+    )
+    comp = _component(component_id="c1", responsibility_type="model")
+    teaching = {"topics": [{
+        "topic_id": "topic:ghost",
+        "linked_component_ids": ["ghost"],
+        "blackbox_policy": [],
+    }]}
+    blueprint = {"linked_component_ids": ["c1"], "review_required_items": []}
+    validation = _validate_teaching_output(teaching, blueprint, [comp], {})
+    assert validation["course_topics_link_components"] is False
+    assert any(e["code"] == "topic_dangling_component_ref" for e in validation["errors"])
+
+
+# ---------------------------------------------------------------------------
+# 8. Integration: Step 3 -> 4 -> 5 end to end
+# ---------------------------------------------------------------------------
+
+
+def test_step3_4_5_integration_bundle_separation_and_refined_ids():
+    cx = _component(
+        component_id="cx",
+        label="Coarse bundle",
+        linked_equation_ids=["eq_def", "eq_final"],
+        linked_claim_ids=["claim_head"],
+        linked_derivation_ids=["d1"],
+        teaching_takeaway="The bias-free consistency relation removes b2.",
+        review_status="auto_accepted",
+        split_recommendation={
+            "required": True,
+            "reasons": ["mix"],
+            "suggested_components": [
+                {"name": "Definition of moments", "responsibility_type": "definition"},
+                {"name": "Consistency relation", "responsibility_type": "constraint"},
+            ],
+        },
+    )
+    llm_input = _LLMInput(
+        equations=[
+            {"equation_id": "eq_def", "role": "definition"},
+            {
+                "equation_id": "eq_final",
+                "role": "result",
+                "confidence_policy": {
+                    "can_support_claim": True,
+                    "can_be_used_in_derivation": True,
+                    "can_be_rendered_as_final_formula": False,
+                    "allowed_downstream_use": "display_with_warning",
+                },
+            },
+        ],
+        claim_centered_plan=_plan(headline="Bias-free consistency relation holds"),
+    )
+
+    result = _result([cx])
+    # Step 3
+    result = ComponentRefiner().refine(result, llm_input=llm_input, derivations=None)
+    refined_ids = [c.component_id for c in result.components]
+    assert "cx" not in refined_ids  # split happened
+    # Step 4 (chain references the OLD id "cx")
+    chain = _chain("d1", [_step("s1", "derive", ["eq_def"], ["eq_final"])],
+                   linked_component_ids=["cx"])
+    alignment = DerivationGraphAligner().align(
+        result, llm_input=llm_input, derivations=_derivations(chain)
+    )
+    result.derivation_graph_alignment = alignment.to_dict()
+    # Step 5
+    out = STAGE.run(result, llm_input=llm_input, derivations=_derivations(chain))
+
+    bundle = out.theory_bundle
+    # Bundle references the REFINED component IDs, never the old "cx".
+    assert bundle["component_ids"] == refined_ids
+    assert "cx" not in bundle["component_ids"]
+    # Headline claim is on the bundle; reusable parts remain as components.
+    assert bundle["headline_claim_id"] == "claim_head"
+    # Every course topic links a refined component id (and no old id).
+    topic_links = [
+        cid for t in out.course_mapping["topics"] for cid in t["linked_component_ids"]
+    ]
+    assert set(topic_links) == set(refined_ids)
+    assert "cx" not in topic_links
+    # The constraint child renders eq_final (can_be_rendered_as_final_formula=false):
+    # Step 4 marked it review_required and Step 5 reflects it.
+    constraint_topic = next(
+        t for t in out.course_mapping["topics"]
+        if any("eq_final" in p["equation_id"] for p in t["blackbox_policy"])
+    )
+    assert constraint_topic["review_status"] == "review_required"
+    assert bundle["review_status"] == "review_required"

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1058,3 +1058,149 @@ def test_component_refinement_review_required_and_teaching_warning():
     result = _run_gate(component_result=comp_result)
     assert any(r.code == "COMPONENT_REFINEMENT_REVIEW_REQUIRED" for r in result.review_items)
     assert any(w.code == "COMPONENT_REFINEMENT_TEACHING_GRANULARITY" for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Step 5: theory bundle + teaching output (issue #326)
+# ---------------------------------------------------------------------------
+
+
+class _BundleComponentResult:
+    """component_result carrying a Step 5 theory_bundle artifact block."""
+
+    def __init__(self, components, theory_bundle):
+        self.components = components
+        self.theory_bundle = theory_bundle
+
+
+def _bundle_block(*, bundle=None, course_mapping=None, blueprint_updates=None,
+                  theory_bundle_validation=None, teaching_output_validation=None):
+    return {
+        "theory_bundle": bundle or {},
+        "course_mapping": course_mapping or {"topics": []},
+        "blueprint_updates": blueprint_updates or {"linked_component_ids": [], "review_required_items": []},
+        "theory_bundle_validation": theory_bundle_validation or {},
+        "teaching_output_validation": teaching_output_validation or {},
+    }
+
+
+def test_theory_bundle_absent_is_empty_default():
+    result = _run_gate(component_result=_ComponentResult([]))
+    assert result.theory_bundle_validation["bundle_created"] is False
+    assert result.teaching_output_validation["course_topics_link_components"] is True
+
+
+def test_theory_bundle_clean_passes_and_reports_booleans():
+    comp = _ComponentRecord("c1", review_status="source_backed")
+    block = _bundle_block(
+        bundle={
+            "component_ids": ["c1"],
+            "headline_claim_id": "claim_head",
+            "support_map_id": "doc:support_map",
+            "review_status": "source_backed",
+        },
+        course_mapping={"topics": [{
+            "topic_id": "topic:c1",
+            "linked_component_ids": ["c1"],
+            "blackbox_policy": [],
+            "review_status": "source_backed",
+        }]},
+        blueprint_updates={"linked_component_ids": ["c1"], "review_required_items": []},
+        theory_bundle_validation={
+            "bundle_created": True, "headline_claim_linked": True, "support_map_linked": True,
+        },
+        teaching_output_validation={
+            "course_topics_link_components": True, "blueprint_refs_valid": True,
+            "blackbox_policy_respects_confidence": True,
+        },
+    )
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.theory_bundle_validation["component_refs_valid"] is True
+    assert result.theory_bundle_validation["headline_claim_linked"] is True
+    assert result.theory_bundle_validation["support_map_linked"] is True
+    assert result.teaching_output_validation["course_topics_link_components"] is True
+    assert result.teaching_output_validation["blackbox_policy_respects_confidence"] is True
+    assert not any(e.code.startswith("THEORY_BUNDLE") for e in result.errors)
+
+
+def test_theory_bundle_dangling_component_ref_is_hard_error():
+    comp = _ComponentRecord("c1")
+    block = _bundle_block(bundle={
+        "component_ids": ["c1", "ghost"],
+        "headline_claim_id": "claim_head",
+        "support_map_id": "doc:support_map",
+        "review_status": "source_backed",
+    })
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.status == "failed_validation"
+    assert result.theory_bundle_validation["component_refs_valid"] is False
+    assert any(e.code == "THEORY_BUNDLE_DANGLING_COMPONENT_REF" for e in result.errors)
+
+
+def test_teaching_output_dangling_topic_ref_is_hard_error():
+    comp = _ComponentRecord("c1")
+    block = _bundle_block(
+        bundle={"component_ids": ["c1"], "headline_claim_id": "h",
+                "support_map_id": "s", "review_status": "source_backed"},
+        course_mapping={"topics": [{
+            "topic_id": "topic:ghost",
+            "linked_component_ids": ["ghost"],
+            "blackbox_policy": [],
+        }]},
+    )
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.status == "failed_validation"
+    assert result.teaching_output_validation["course_topics_link_components"] is False
+    assert any(e.code == "TEACHING_OUTPUT_DANGLING_COMPONENT_REF" for e in result.errors)
+
+
+def test_teaching_output_blackbox_policy_must_respect_equation_confidence():
+    # c1 carries a low-confidence equation but the topic does not blackbox it.
+    comp = _ComponentRecord("c1", review_required_equation_ids=["eq_bad"])
+    block = _bundle_block(
+        bundle={"component_ids": ["c1"], "headline_claim_id": "h",
+                "support_map_id": "s", "review_status": "review_required"},
+        course_mapping={"topics": [{
+            "topic_id": "topic:c1",
+            "linked_component_ids": ["c1"],
+            "blackbox_policy": [],  # missing eq_bad
+            "review_status": "review_required",
+        }]},
+        teaching_output_validation={"blackbox_policy_respects_confidence": True},
+    )
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.teaching_output_validation["blackbox_policy_respects_confidence"] is False
+    assert any(
+        e.code == "TEACHING_OUTPUT_BLACKBOX_POLICY_IGNORES_CONFIDENCE" for e in result.errors
+    )
+
+
+def test_theory_bundle_review_required_blocks_publish_ready():
+    comp = _ComponentRecord("c1")
+    block = _bundle_block(
+        bundle={"component_ids": ["c1"], "headline_claim_id": "h",
+                "support_map_id": "s", "review_status": "review_required"},
+        course_mapping={"topics": [{
+            "topic_id": "topic:c1", "linked_component_ids": ["c1"],
+            "blackbox_policy": [], "review_status": "review_required",
+        }]},
+    )
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.publish_ready is False
+    assert any(r.code == "THEORY_BUNDLE_REVIEW_REQUIRED" for r in result.review_items)
+    assert any(r.code == "TEACHING_OUTPUT_TOPIC_REVIEW_REQUIRED" for r in result.review_items)
+
+
+def test_teaching_output_blueprint_dangling_ref_is_hard_error():
+    comp = _ComponentRecord("c1")
+    block = _bundle_block(
+        bundle={"component_ids": ["c1"], "headline_claim_id": "h",
+                "support_map_id": "s", "review_status": "source_backed"},
+        course_mapping={"topics": [{
+            "topic_id": "topic:c1", "linked_component_ids": ["c1"], "blackbox_policy": [],
+        }]},
+        blueprint_updates={"linked_component_ids": ["ghost"], "review_required_items": []},
+    )
+    result = _run_gate(component_result=_BundleComponentResult([comp], block))
+    assert result.teaching_output_validation["blueprint_refs_valid"] is False
+    assert any(e.code == "TEACHING_OUTPUT_BLUEPRINT_DANGLING_REF" for e in result.errors)


### PR DESCRIPTION
## Summary

Implements Step 5 of the component assembly pipeline: a deterministic (non-LLM) stage that represents the whole paper as a `theory_bundle` container and maps refined components into teaching output (course topics + blueprint reflection).

The theory bundle is a paper-level artifact that references refined components, the theory component graph, and support map from Step 4—rather than creating a giant monolithic component. This design separates concerns: reusable theory parts remain as individual components, while the bundle serves as the headline-claim-bearing container for the entire paper.

## Key Changes

### New Files

- **`src/episteme_graph/agents/component_assembly/theory_bundle.py`** (594 lines)
  - `TheoryBundleStage`: Orchestrator that runs `TheoryBundleBuilder` and `TeachingOutputMapper` in sequence
  - `TheoryBundleBuilder`: Creates the paper-level bundle container with references to components, graph, and support map
  - `TeachingOutputMapper`: Maps refined components into course topics with learning objectives, blackbox policies, and assessment prompts
  - Validation functions (`_validate_bundle`, `_validate_teaching_output`) that check reference integrity and policy consistency
  - Helper functions for extracting headline claims, equation indices, review status, and low-confidence equations

- **`src/tests/agents/component_assembly/test_theory_bundle.py`** (405 lines)
  - Comprehensive unit tests for bundle creation, component separation, course topic linkage, and low-confidence equation handling
  - Tests for review_required propagation and validation blocks
  - Integration tests verifying the bundle/teaching output contract

- **`src/tests/agents/component_assembly/test_step3_step4_integration.py`** (292 lines)
  - End-to-end integration tests for Step 3 (ComponentRefiner) → Step 4 (DerivationGraphAligner) → Step 5 (TheoryBundleStage)
  - Validates that component splits are properly resolved through the pipeline
  - Tests low-confidence equation propagation across stages

### Modified Files

- **`backend/core/document_pipeline/export_validation_gate.py`**
  - Added `_empty_theory_bundle_validation()` and `_empty_teaching_output_validation()` helper functions
  - Added `_component_low_confidence_equation_ids()` to extract blocked/review-required equations from components
  - Implemented `_check_theory_bundle()` method: re-validates bundle component references against refined components (gate-level authoritative check)
  - Implemented `_check_teaching_output()` method: validates course topic linkage and blackbox policy coverage
  - Extended `ExportValidationResult` dataclass with `theory_bundle_validation` and `teaching_output_validation` fields

- **`src/episteme_graph/agents/component_assembly/schema.py`**
  - Added `theory_bundle` field to `ComponentAssemblyResult` to hold Step 5 output

- **`src/episteme_graph/agents/component_assembly/agent.py`**
  - Integrated `TheoryBundleStage` into the component assembly pipeline (runs after Step 4)

- **`src/tests/agents/component_assembly/test_component_refinement_stage.py`**
  - Added tests for split method/reason provenance tracking
  - Added tests for derivation link redistribution to derivational children (#324 rule 4)
  - Added tests for unassigned derivation link reporting

- **`src/tests/agents/component_assembly/test_derivation_graph_aligner.py`**
  - Added tests for unmapped operations/steps reporting
  - Added tests for chain linked_component_ids remapping through Step 3 mapping
  - Added tests for review_required component propagation in support/emphasis/role layers

- **`src/tests/agents/test_export_validation_gate.py`**
  - Added comprehensive tests for theory bundle validation (clean bundles, dangling refs, missing headline claims)
  - Added tests for teaching output validation (topic linkage, blackbox policy coverage)
  - Added tests for blueprint updates

https://claude.ai/code/session_01Aio3PyHjYh9k8LLycfmmhc