### PR TITLE
Support claim-only derivation chains in component graph (#334)

### DIFF
--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -137,6 +137,8 @@ class ComponentGraphNormalizer:
             for rec in records
         ]
         main_edges = _main_edges_from_groups(groups)
+        if not main_edges and len(groups) >= 2:
+            main_edges = _fallback_sequential_edges(groups)
         detail_edges = _detail_edges_from_records(records, claim_index)
         return main_nodes, detail_nodes, main_edges + detail_edges
 
@@ -174,6 +176,11 @@ class ComponentGraphNormalizer:
                     "is_generic": is_generic,
                     "inputs": _ordered_unique(getattr(step, "input_equation_ids", []) or []),
                     "outputs": _ordered_unique(getattr(step, "output_equation_ids", []) or []),
+                    "input_claims": _ordered_unique(
+                        list(getattr(step, "input_claim_ids", []) or [])
+                        + list(getattr(step, "required_claim_ids", []) or [])
+                    ),
+                    "output_claims": _ordered_unique(getattr(step, "output_claim_ids", []) or []),
                 })
         return records
 
@@ -420,11 +427,19 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
 
 
 def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
-    """High-level theory flow: group output equation feeds another group's input."""
+    """High-level theory flow: group output feeds another group's input.
+
+    Edges are created from equation overlap (output equations matching input
+    equations) or, when no equation overlap exists, from claim overlap (output
+    claims matching input/required claims).  This ensures claim-only derivation
+    chains still produce a connected graph (issue #334).
+    """
     summaries = []
     for group in groups:
         outputs = {eq for rec in group["records"] for eq in rec["outputs"]}
         inputs = {eq for rec in group["records"] for eq in rec["inputs"]}
+        output_claims = {cid for rec in group["records"] for cid in rec.get("output_claims", [])}
+        input_claims = {cid for rec in group["records"] for cid in rec.get("input_claims", [])}
         step_ids = [rec["step_id"] for rec in group["records"]]
         claim_ids = _ordered_unique(
             [cid for rec in group["records"] for cid in _step_claim_ids(rec["step"])]
@@ -437,6 +452,8 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
             "group": group,
             "outputs": outputs,
             "inputs": inputs,
+            "output_claims": output_claims,
+            "input_claims": input_claims,
             "step_ids": step_ids,
             "claim_ids": claim_ids,
             "evidence_ids": evidence_ids,
@@ -445,13 +462,16 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
     edges: list[ComponentGraphEdge] = []
     seen: set[tuple[str, str, str]] = set()
     for tgt in summaries:
-        if not tgt["inputs"]:
+        if not tgt["inputs"] and not tgt["input_claims"]:
             continue
         for src in summaries:
             if src["group"]["node_id"] == tgt["group"]["node_id"]:
                 continue
-            overlap = _ordered_unique([eq for eq in src["outputs"] if eq in tgt["inputs"]])
-            if not overlap:
+            eq_overlap = _ordered_unique([eq for eq in src["outputs"] if eq in tgt["inputs"]])
+            claim_overlap = _ordered_unique(
+                [cid for cid in src["output_claims"] if cid in tgt["input_claims"]]
+            )
+            if not eq_overlap and not claim_overlap:
                 continue
             edge_type = tgt["group"]["edge_type"]
             key = (src["group"]["node_id"], tgt["group"]["node_id"], edge_type)
@@ -460,11 +480,21 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
             seen.add(key)
             evidence_derivation_ids = _ordered_unique(src["step_ids"] + tgt["step_ids"])
             source_backing_status, review_status, review_reasons = _edge_backing(
-                evidence_equation_ids=overlap,
+                evidence_equation_ids=eq_overlap,
                 is_generic=False,
                 evidence_claims=tgt["claim_ids"],
                 evidence_derivation_ids=evidence_derivation_ids,
             )
+            if eq_overlap:
+                reasoning = (
+                    f"Theory flow: {theory_stage_label(src['group']['stage'])} output feeds "
+                    f"{theory_stage_label(tgt['group']['stage'])} ({', '.join(eq_overlap)})."
+                )
+            else:
+                reasoning = (
+                    f"Claim flow: {theory_stage_label(src['group']['stage'])} output feeds "
+                    f"{theory_stage_label(tgt['group']['stage'])} ({', '.join(claim_overlap[:3])})."
+                )
             edges.append(ComponentGraphEdge(
                 edge_id=f"theory_edge_{len(edges) + 1:04d}",
                 source=src["group"]["node_id"],
@@ -472,19 +502,61 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
                 edge_type=edge_type,
                 support_status="derivation_linked",
                 evidence_claims=[],
-                reasoning=(
-                    f"Theory flow: {theory_stage_label(src['group']['stage'])} output feeds "
-                    f"{theory_stage_label(tgt['group']['stage'])} ({', '.join(overlap)})."
-                ),
+                reasoning=reasoning,
                 confidence=0.9,
-                evidence_equation_ids=overlap,
+                evidence_equation_ids=eq_overlap,
                 source_backing_status=source_backing_status,
                 review_status=review_status,
                 evidence_derivation_ids=evidence_derivation_ids,
-                evidence_claim_ids=tgt["claim_ids"],
+                evidence_claim_ids=_ordered_unique(claim_overlap + tgt["claim_ids"]),
                 source_evidence_ids=tgt["evidence_ids"],
                 review_reasons=review_reasons,
             ))
+    return edges
+
+
+def _fallback_sequential_edges(groups: list[dict]) -> list[ComponentGraphEdge]:
+    """Sequential stage edges when neither equation nor claim flow produces edges.
+
+    Connects consecutive main nodes in stage order.  Marked ``review_required``
+    because the connection is inferred from ordering, not from data overlap.
+    """
+    edges: list[ComponentGraphEdge] = []
+    for i in range(len(groups) - 1):
+        src = groups[i]
+        tgt = groups[i + 1]
+        edge_type = tgt["edge_type"]
+        evidence_derivation_ids = _ordered_unique(
+            [rec["step_id"] for rec in src["records"]]
+            + [rec["step_id"] for rec in tgt["records"]]
+        )
+        claim_ids = _ordered_unique(
+            [cid for rec in tgt["records"] for cid in _step_claim_ids(rec["step"])]
+        )
+        evidence_ids = _ordered_unique(
+            [eid for rec in tgt["records"]
+             for eid in (getattr(rec["step"], "source_evidence_ids", []) or [])]
+        )
+        edges.append(ComponentGraphEdge(
+            edge_id=f"theory_edge_{len(edges) + 1:04d}",
+            source=src["node_id"],
+            target=tgt["node_id"],
+            edge_type=edge_type,
+            support_status="derivation_linked",
+            evidence_claims=[],
+            reasoning=(
+                f"Sequential stage flow: {theory_stage_label(src['stage'])} → "
+                f"{theory_stage_label(tgt['stage'])}."
+            ),
+            confidence=0.7,
+            evidence_equation_ids=[],
+            source_backing_status="review_required",
+            review_status="review_required",
+            evidence_derivation_ids=evidence_derivation_ids,
+            evidence_claim_ids=claim_ids,
+            source_evidence_ids=evidence_ids,
+            review_reasons=["edge_not_source_backed"],
+        ))
     return edges
 
 
@@ -566,11 +638,16 @@ def _detail_edges_from_records(
     seen: set[tuple[str, str, str]] = set()
     for j, target in enumerate(records):
         target_inputs = set(target["inputs"])
-        if not target_inputs:
+        target_input_claims = set(target.get("input_claims", []))
+        if not target_inputs and not target_input_claims:
             continue
         for source in records[:j]:
-            overlap = [eq for eq in source["outputs"] if eq in target_inputs]
-            if not overlap:
+            eq_overlap = [eq for eq in source["outputs"] if eq in target_inputs]
+            claim_overlap = [
+                cid for cid in source.get("output_claims", [])
+                if cid in target_input_claims
+            ]
+            if not eq_overlap and not claim_overlap:
                 continue
             edge_type = target["edge_type"]
             key = (source["detail_id"], target["detail_id"], edge_type)
@@ -579,10 +656,20 @@ def _detail_edges_from_records(
             seen.add(key)
             step = target["step"]
             source_backing_status, review_status, review_reasons = _edge_backing(
-                evidence_equation_ids=overlap,
+                evidence_equation_ids=eq_overlap,
                 is_generic=target["is_generic"],
                 evidence_derivation_ids=[source["step_id"], target["step_id"]],
             )
+            if eq_overlap:
+                reasoning = (
+                    f"Derivation data flow: {source['operation'] or 'step'} output "
+                    f"feeds {target['operation'] or 'step'} ({', '.join(eq_overlap)})."
+                )
+            else:
+                reasoning = (
+                    f"Claim flow: {source['operation'] or 'step'} output "
+                    f"feeds {target['operation'] or 'step'} ({', '.join(claim_overlap[:3])})."
+                )
             edges.append(ComponentGraphEdge(
                 edge_id=f"eq_edge_{len(edges) + 1:04d}",
                 source=source["detail_id"],
@@ -590,18 +677,15 @@ def _detail_edges_from_records(
                 edge_type=edge_type,
                 support_status="derivation_linked",
                 evidence_claims=[],
-                reasoning=(
-                    f"Derivation data flow: {source['operation'] or 'step'} output "
-                    f"feeds {target['operation'] or 'step'} ({', '.join(overlap)})."
-                ),
+                reasoning=reasoning,
                 confidence=0.9,
-                evidence_equation_ids=_ordered_unique(overlap),
+                evidence_equation_ids=_ordered_unique(eq_overlap),
                 source_backing_status=source_backing_status,
                 review_status=review_status,
                 evidence_derivation_ids=_ordered_unique([
                     source["step_id"], target["step_id"]
                 ]),
-                evidence_claim_ids=_ordered_unique(_step_claim_ids(step)),
+                evidence_claim_ids=_ordered_unique(claim_overlap + _step_claim_ids(step)),
                 source_evidence_ids=_ordered_unique(
                     getattr(step, "source_evidence_ids", []) or []
                 ),

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -181,12 +181,20 @@ class ComponentGraphValidator:
                 f"nodes[{cid}].source_backing_status",
             ))
 
-        # Hard error: result/constraint/derive nodes must expose equation links.
+        # Result/constraint/derive nodes should expose equation links.  For
+        # claim-only derivation chains the node may legitimately have no
+        # equations; downgrade to warning when claims or evidence back it
+        # (issue #334).
         if operation and edge_type in _OUTPUT_BEARING_EDGE_TYPES and is_main:
             if not getattr(node, "linked_equation_ids", []):
+                has_claim_backing = bool(
+                    getattr(node, "linked_claim_ids", [])
+                    or getattr(node, "linked_evidence_ids", [])
+                )
+                severity = "warning" if has_claim_backing else "error"
                 issues.append(ValidationIssue(
                     "output_node_missing_linked_equations",
-                    "error",
+                    severity,
                     f"{edge_type} node {cid!r} has no linked_equation_ids",
                     f"nodes[{cid}].linked_equation_ids",
                 ))

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -535,3 +535,133 @@ def test_normalizer_reflects_single_step_derivation_chain():
     main_nodes = _layer(result, "main")
     assert len(main_nodes) == 1
     assert main_nodes[0].operation == "derive_consistency_relation"
+
+
+# --- claim-only derivation chains (issue #334) --------------------------------
+
+
+def _claim_step(operation, input_claims, output_claims, **kwargs):
+    """DerivationStep with claim flow but no equation I/O."""
+    return DerivationStep(
+        step_id=f"step_{operation}",
+        input_equation_ids=[],
+        output_equation_ids=[],
+        operation=operation,
+        input_claim_ids=input_claims,
+        output_claim_ids=output_claims,
+        review_status="teacher_review_required",
+        **kwargs,
+    )
+
+
+def _claim_only_derivations():
+    return DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[DerivationChainRecord(
+            derivation_id="deriv_claim",
+            document_id="doc",
+            source_section_ids=[],
+            steps=[
+                _claim_step("define_framework", [], ["claim_a"],
+                            required_claim_ids=[]),
+                _claim_step("linearize_model", ["claim_a"], ["claim_b"],
+                            required_claim_ids=["claim_a"]),
+                _claim_step("derive_result", ["claim_b"], ["claim_c"],
+                            required_claim_ids=["claim_b"],
+                            source_evidence_ids=["ev_1"]),
+            ],
+        )],
+    )
+
+
+def test_claim_only_chain_produces_main_edges():
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    main_nodes = _layer(result, "main")
+    main_ids = {n.component_id for n in main_nodes}
+    main_edges = [e for e in result.edges if e.source in main_ids and e.target in main_ids]
+    assert len(main_nodes) >= 2
+    assert len(main_edges) >= 1, "claim-only chain must produce at least one main edge"
+
+
+def test_claim_only_chain_produces_detail_edges():
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    detail_ids = {n.component_id for n in _layer(result, "equation_detail")}
+    detail_edges = [e for e in result.edges if e.source in detail_ids and e.target in detail_ids]
+    assert len(detail_edges) >= 1, "claim-only chain must produce detail edges"
+
+
+def test_claim_only_chain_edges_carry_evidence():
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    main_ids = {n.component_id for n in _layer(result, "main")}
+    main_edges = [e for e in result.edges if e.source in main_ids and e.target in main_ids]
+    for edge in main_edges:
+        assert edge.evidence_derivation_ids, f"{edge.edge_id} missing derivation evidence"
+        assert edge.evidence_claim_ids, f"{edge.edge_id} missing claim evidence"
+
+
+def test_claim_only_chain_nodes_have_linked_claims():
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    for node in _layer(result, "main"):
+        assert node.linked_claim_ids, f"{node.component_id} missing linked_claim_ids"
+        assert node.linked_derivation_ids, f"{node.component_id} missing linked_derivation_ids"
+
+
+def test_claim_only_chain_node_not_review_required():
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    for node in _layer(result, "main"):
+        assert node.source_backing_status != "review_required", (
+            f"claim-only node {node.component_id} should be partially_source_backed "
+            f"(has derivation_ids), not review_required"
+        )
+
+
+def test_fallback_sequential_edges_when_no_overlap():
+    steps = [
+        _claim_step("define_framework", [], ["claim_x"]),
+        _claim_step("derive_result", ["claim_y"], ["claim_z"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_ids = {n.component_id for n in _layer(result, "main")}
+    main_edges = [e for e in result.edges if e.source in main_ids and e.target in main_ids]
+    assert len(main_edges) >= 1, "fallback sequential edges should connect main nodes"
+    for edge in main_edges:
+        assert edge.review_status == "review_required"
+        assert edge.review_reasons
+
+
+def test_mixed_equation_and_claim_chain_prefers_equations():
+    steps = [
+        _step("define", ["eq_a"], ["eq_b"]),
+        DerivationStep(
+            step_id="step_derive",
+            input_equation_ids=["eq_b"],
+            output_equation_ids=["eq_c"],
+            operation="derive_result",
+            input_claim_ids=["claim_a"],
+            output_claim_ids=["claim_b"],
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_ids = {n.component_id for n in _layer(result, "main")}
+    main_edges = [e for e in result.edges if e.source in main_ids and e.target in main_ids]
+    assert len(main_edges) >= 1
+    for edge in main_edges:
+        assert edge.evidence_equation_ids, "equation evidence should be preferred when available"

--- a/src/tests/agents/component_graph/test_validator.py
+++ b/src/tests/agents/component_graph/test_validator.py
@@ -331,3 +331,37 @@ class TestSourceBackingRules:
         )
         issues = self.validator.validate(_result(nodes, [edge]))
         assert [i for i in issues if i.severity == "error"] == []
+
+    # --- issue #334: claim-only nodes relax equation checks --------------------
+
+    def test_claim_only_derive_node_missing_equations_is_warning(self):
+        """A derives node backed by claims should produce a warning, not error."""
+        node = _theory_node(
+            "c1",
+            operation="derive_result",
+            linked_equation_ids=[],
+            linked_claim_ids=["claim_1"],
+            linked_evidence_ids=["ev_1"],
+            source_backing_status="partially_source_backed",
+            review_reasons=["missing_equation_link"],
+        )
+        issues = self.validator.validate(_result([node], []))
+        eq_issues = [i for i in issues if i.rule_id == "output_node_missing_linked_equations"]
+        assert len(eq_issues) == 1
+        assert eq_issues[0].severity == "warning"
+
+    def test_claim_only_derive_node_without_claims_is_error(self):
+        """A derives node with no equations AND no claims stays an error."""
+        node = _theory_node(
+            "c1",
+            operation="derive_result",
+            linked_equation_ids=[],
+            linked_claim_ids=[],
+            linked_evidence_ids=[],
+            source_backing_status="review_required",
+            review_reasons=["missing_equation_link", "missing_atomic_claim"],
+        )
+        issues = self.validator.validate(_result([node], []))
+        eq_issues = [i for i in issues if i.rule_id == "output_node_missing_linked_equations"]
+        assert len(eq_issues) == 1
+        assert eq_issues[0].severity == "error"


### PR DESCRIPTION
## Summary

Extends the component graph normalizer to handle derivation chains that flow through claims rather than equations. This enables proper graph connectivity and validation for claim-only derivations, which previously produced disconnected or invalid graphs.

## Key Changes

### Normalizer (`src/episteme_graph/agents/component_graph/normalizer.py`)

- **Claim tracking in step records**: Added `input_claims` and `output_claims` fields to derivation step records, combining `input_claim_ids`, `output_claim_ids`, and `required_claim_ids` from steps.

- **Claim-based edge detection**: Modified `_main_edges_from_groups()` to create edges based on claim overlap when equation overlap is unavailable. Edges now check both equation and claim flow, with distinct reasoning messages for each type.

- **Fallback sequential edges**: Introduced `_fallback_sequential_edges()` function that connects consecutive main nodes by stage order when neither equation nor claim overlap produces edges. These edges are marked `review_required` with lower confidence (0.7) since the connection is inferred from ordering rather than data overlap.

- **Detail layer claim support**: Updated `_detail_edges_from_records()` to similarly support claim-based edges at the equation-detail layer, with appropriate reasoning messages distinguishing equation vs. claim flow.

- **Evidence propagation**: Ensured claim-based edges carry both `evidence_claim_ids` and `evidence_derivation_ids` to maintain full traceability.

### Validator (`src/episteme_graph/agents/component_graph/validator.py`)

- **Relaxed equation requirement for claim-backed nodes**: Modified `_check_node_source_backing()` to downgrade missing equation links from error to warning when a node has claim or evidence backing. Nodes with neither equations nor claims still produce errors (issue #334).

### Tests (`src/tests/agents/component_graph/test_normalizer.py` and `test_validator.py`)

- Added comprehensive test suite for claim-only derivation chains:
  - `test_claim_only_chain_produces_main_edges()`: Verifies main layer connectivity
  - `test_claim_only_chain_produces_detail_edges()`: Verifies detail layer connectivity
  - `test_claim_only_chain_edges_carry_evidence()`: Validates evidence propagation
  - `test_claim_only_chain_nodes_have_linked_claims()`: Confirms claim/derivation linking
  - `test_claim_only_chain_node_not_review_required()`: Ensures proper backing status
  - `test_fallback_sequential_edges_when_no_overlap()`: Tests fallback mechanism
  - `test_mixed_equation_and_claim_chain_prefers_equations()`: Confirms equation preference when both available

- Added validator tests for claim-only nodes:
  - `test_claim_only_derive_node_missing_equations_is_warning()`: Validates warning-level severity
  - `test_claim_only_derive_node_without_claims_is_error()`: Confirms error when fully unsupported

## Implementation Details

- Claim overlap detection mirrors equation overlap logic, enabling symmetric treatment of both data types
- Edge reasoning messages distinguish between "Theory flow" (equations) and "Claim flow" (claims) for clarity
- Fallback sequential edges use lower confidence (0.7 vs 0.9) and explicit `review_required` status to signal inferred rather than data-driven connections
- All claim-based edges properly populate `evidence_claim_ids` alongside `evidence_derivation_ids` for complete traceability

https://claude.ai/code/session_011RztfNkyZ7aCmTFPdFNLVW