### PR TITLE
Refactor component graph detail panel and edge relation labels

### DIFF
--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -2011,6 +2011,10 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "review_reasons": node_reasons,
             "parent_component_id": str(node.get("parent_component_id") or ""),
             "member_component_ids": node.get("member_component_ids") if isinstance(node.get("member_component_ids"), list) else [],
+            "visual_label": str(node.get("visual_label") or ""),
+            "input_claim_ids": node.get("input_claim_ids") if isinstance(node.get("input_claim_ids"), list) else [],
+            "output_claim_ids": node.get("output_claim_ids") if isinstance(node.get("output_claim_ids"), list) else [],
+            "review_reason": str(node.get("review_reason") or ""),
         })
         seen_nodes.add(component_id)
     normalized_edges = []

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -2014,6 +2014,7 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
             "visual_label": str(node.get("visual_label") or ""),
             "input_claim_ids": node.get("input_claim_ids") if isinstance(node.get("input_claim_ids"), list) else [],
             "output_claim_ids": node.get("output_claim_ids") if isinstance(node.get("output_claim_ids"), list) else [],
+            "required_claim_ids": node.get("required_claim_ids") if isinstance(node.get("required_claim_ids"), list) else [],
             "review_reason": str(node.get("review_reason") or ""),
         })
         seen_nodes.add(component_id)

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -883,6 +883,13 @@ class ComponentGraphNode(BaseModel):
     # Layer linkage between main TheoryOperationNode and equation_detail nodes (issue #306).
     parent_component_id: str = ""
     member_component_ids: list[str] = Field(default_factory=list)
+    # Short graph-display label (issue #337).
+    visual_label: str = ""
+    # Claim I/O from derivation step (issue #337).
+    input_claim_ids: list[str] = Field(default_factory=list)
+    output_claim_ids: list[str] = Field(default_factory=list)
+    # Extraction/review note text (issue #337).
+    review_reason: str = ""
 
 
 class ComponentGraphEdge(BaseModel):

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -888,6 +888,8 @@ class ComponentGraphNode(BaseModel):
     # Claim I/O from derivation step (issue #337).
     input_claim_ids: list[str] = Field(default_factory=list)
     output_claim_ids: list[str] = Field(default_factory=list)
+    # Precondition claims required but not consumed (issue #337).
+    required_claim_ids: list[str] = Field(default_factory=list)
     # Extraction/review note text (issue #337).
     review_reason: str = ""
 

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -3658,6 +3658,12 @@ body {
   color: var(--color-text-primary);
   font-weight: 700;
 }
+.ls-graph-detail-memo {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  line-height: 1.5;
+}
 .ls-graph-detail-edge-reason {
   margin-top: 4px;
   padding-top: 4px;

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -3658,6 +3658,25 @@ body {
   color: var(--color-text-primary);
   font-weight: 700;
 }
+.ls-graph-detail-edge-reason {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--color-border-tertiary);
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+.ls-graph-detail-system {
+  margin-top: 8px;
+}
+.ls-graph-detail-system summary {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+.ls-graph-detail-system details[open] summary {
+  margin-bottom: 6px;
+}
 
 /* Source-backing status & review reasons (issue #302) */
 .ls-graph-backing {

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5338,7 +5338,7 @@
     }
     options.push({
       value: "all",
-      label: "すべて",
+      label: "すべて（デバッグ）",
       count: counts.main + counts.equation_detail + counts.debug + counts.other,
     });
     return options;
@@ -5528,43 +5528,49 @@
     var detail = document.getElementById("ls-component-graph-detail");
     if (!detail) return;
     var nodeId = lsGraphNodeId(node);
+    var nodeById = {};
+    (graph.nodes || []).forEach(function (n) {
+      var id = lsGraphNodeId(n);
+      if (id) nodeById[id] = n;
+    });
     var connected = (graph.edges || []).filter(function (edge) {
       var source = edge.source_component_id || edge.source || edge.from;
       var target = edge.target_component_id || edge.target || edge.to;
       return source === nodeId || target === nodeId;
     });
     var backing = String(node.source_backing_status || "").toLowerCase();
+
+    // Header: badge + title
     var html =
-      '<div class="ls-graph-detail-badge ' + escHtml(lsGraphNodeGroup(node)) + '">' + escHtml(node.component_type_text || node.component_type || node.typeName || "component") + '</div>' +
-      '<h4>' + escHtml(lsGraphFullDisplayLabel(node) || nodeId || "無題") + '</h4>' +
-      '<p class="ls-graph-detail-meta">' + escHtml(lsGraphLayerLabel(node.graph_layer)) + ' ・ ' + escHtml(node.review_status || node.origin || "paper") + '</p>';
-    var linkage = lsGraphLayerLinkageHtml(node);
-    if (linkage) {
-      html += '<div class="ls-graph-detail-section"><b>グラフ層</b>' + linkage + '</div>';
-    }
-    if (backing) {
-      html += '<div class="ls-graph-detail-section"><b>出典の裏付け</b>' +
-        '<p class="ls-graph-backing ls-graph-backing-' + escHtml(backing) + '">' +
-        escHtml(lsGraphSourceBackingLabel(backing)) + '</p></div>';
-    }
-    if ((node.review_reasons || []).length) {
-      html += '<div class="ls-graph-detail-section"><b>要確認の理由</b><ul class="ls-graph-detail-reasons">';
-      node.review_reasons.forEach(function (reason) {
-        html += '<li>' + escHtml(lsGraphReviewReasonLabel(reason)) + '</li>';
-      });
-      html += '</ul></div>';
-    }
+      '<div class="ls-graph-detail-badge ' + escHtml(lsGraphNodeGroup(node)) + '">' +
+      escHtml(node.component_type_text || node.component_type || node.typeName || "component") + '</div>' +
+      '<h4>' + escHtml(lsGraphFullDisplayLabel(node) || nodeId || "無題") + '</h4>';
+
+    // 1. このノードの意味
     if (node.description) {
-      html += '<div class="ls-graph-detail-section"><b>説明</b><p>' + escHtml(node.description) + '</p></div>';
+      html += '<div class="ls-graph-detail-section"><b>このノードの意味</b><p>' + escHtml(node.description) + '</p></div>';
     }
-    var links = lsGraphSourceLinksHtml(node);
-    if (links) {
-      html += '<div class="ls-graph-detail-section"><b>出典リンク</b>' + links + '</div>';
+
+    // 2. 入力
+    var inputParts = "";
+    if ((node.input_equation_ids || []).length) {
+      inputParts += '<div class="ls-graph-detail-link"><span>式</span> ' + escHtml((node.input_equation_ids).join(", ")) + '</div>';
     }
-    if (node.summary) {
-      html += '<div class="ls-graph-detail-section"><b>Summary</b><p>' + escHtml(node.summary) + '</p></div>';
+    if (inputParts) {
+      html += '<div class="ls-graph-detail-section"><b>入力</b>' + inputParts + '</div>';
     }
-    html += '<div class="ls-graph-detail-section"><b>Connections</b>';
+
+    // 3. 出力
+    var outputParts = "";
+    if ((node.output_equation_ids || []).length) {
+      outputParts += '<div class="ls-graph-detail-link"><span>式</span> ' + escHtml((node.output_equation_ids).join(", ")) + '</div>';
+    }
+    if (outputParts) {
+      html += '<div class="ls-graph-detail-section"><b>出力</b>' + outputParts + '</div>';
+    }
+
+    // 4. 接続（接続先ノードのラベルと接続理由を表示）
+    html += '<div class="ls-graph-detail-section"><b>接続</b>';
     if (!connected.length) {
       html += '<p class="ls-theory-muted">接続エッジはありません。</p>';
     } else {
@@ -5572,12 +5578,58 @@
       connected.forEach(function (edge) {
         var source = edge.source_component_id || edge.source || edge.from;
         var target = edge.target_component_id || edge.target || edge.to;
-        var direction = source === nodeId ? "→ " + target : "← " + source;
-        html += '<li><span>' + escHtml(edge.relation || edge.edge_type || edge.type || "RELATED_TO") + '</span>' + escHtml(direction) + '</li>';
+        var otherId = source === nodeId ? target : source;
+        var otherNode = nodeById[otherId];
+        var otherLabel = otherNode ? (lsGraphFullDisplayLabel(otherNode) || otherId) : otherId;
+        var arrow = source === nodeId ? "→" : "←";
+        var relation = edge.relation || edge.edge_type || edge.type || "RELATED_TO";
+        var edgeLabel = lsGraphEdgeLabel(relation);
+        html += '<li><span>' + escHtml(edgeLabel) + '</span>' + escHtml(arrow + " " + otherLabel);
+        var evidence = edge.evidence || {};
+        var reason = String(evidence.reason || "").trim();
+        if (reason) {
+          html += '<div class="ls-graph-detail-edge-reason">' + escHtml(reason) + '</div>';
+        }
+        html += '</li>';
       });
       html += '</ul>';
     }
-    html += '</div><div class="ls-graph-detail-section"><b>System ID</b><code>' + escHtml(nodeId || "") + '</code></div>';
+    html += '</div>';
+
+    // 5. 根拠
+    var links = lsGraphSourceLinksHtml(node);
+    if (links) {
+      html += '<div class="ls-graph-detail-section"><b>根拠</b>' + links + '</div>';
+    }
+
+    // 6. 要確認事項
+    var hasReview = backing || (node.review_reasons || []).length;
+    if (hasReview) {
+      html += '<div class="ls-graph-detail-section"><b>要確認事項</b>';
+      if (backing) {
+        html += '<p class="ls-graph-backing ls-graph-backing-' + escHtml(backing) + '">' +
+          escHtml(lsGraphSourceBackingLabel(backing)) + '</p>';
+      }
+      if ((node.review_reasons || []).length) {
+        html += '<ul class="ls-graph-detail-reasons">';
+        node.review_reasons.forEach(function (reason) {
+          html += '<li>' + escHtml(lsGraphReviewReasonLabel(reason)) + '</li>';
+        });
+        html += '</ul>';
+      }
+      html += '</div>';
+    }
+
+    // 7. システム情報（折りたたみ）
+    html += '<div class="ls-graph-detail-section ls-graph-detail-system">' +
+      '<details><summary>システム情報</summary>' +
+      '<div class="ls-graph-detail-link"><b>ID</b> <code>' + escHtml(nodeId || "") + '</code></div>' +
+      '<div class="ls-graph-detail-link"><b>レイヤー</b> ' + escHtml(lsGraphLayerLabel(node.graph_layer)) + '</div>' +
+      '<div class="ls-graph-detail-link"><b>ステータス</b> ' + escHtml(node.review_status || node.origin || "paper") + '</div>';
+    var linkage = lsGraphLayerLinkageHtml(node);
+    if (linkage) html += linkage;
+    html += '</details></div>';
+
     detail.innerHTML = html;
   }
 
@@ -5901,13 +5953,14 @@
 
   function lsGraphRelationPriority(edge) {
     var relation = String((edge && (edge.relation || edge.edge_type || edge.type)) || "").toUpperCase();
-    if (relation === "DIAGNOSES") return 6;
-    if (relation === "DERIVES" || relation === "ELIMINATES_BIAS") return 5;
-    if (relation === "FEEDS_EQUATION_SYSTEM" || relation === "LINEARIZES" || relation === "DEFINES") return 4;
+    if (relation === "DIAGNOSES" || relation === "COMPARES") return 6;
+    if (relation === "DERIVES" || relation === "ELIMINATES_BIAS" || relation === "ELIMINATES" || relation === "SOLVES") return 5;
+    if (relation === "FEEDS_EQUATION_SYSTEM" || relation === "LINEARIZES" || relation === "DEFINES" || relation === "CONSTRUCTS" || relation === "NORMALIZES") return 4;
     if (relation === "REQUIRES") return 5;
-    if (relation === "PRODUCES_FOR" || relation === "ENABLES" || relation === "SUPPORTS") return 4;
+    if (relation === "PRODUCES_FOR" || relation === "ENABLES" || relation === "SUPPORTS" || relation === "SUBSTITUTES" || relation === "APPROXIMATES") return 4;
     if (relation === "UNCERTAIN_DUE_TO") return 3;
-    if (relation === "QUALIFIES" || relation === "CHECKED_BY") return 2;
+    if (relation === "QUALIFIES" || relation === "CHECKED_BY" || relation === "CONSTRAINS") return 2;
+    if (relation === "TRANSFORMS" || relation === "FEEDS" || relation === "REQUIRES_REVIEW") return 1;
     return 1;
   }
 
@@ -5932,6 +5985,15 @@
       CONSTRAINS: "制約",
       DIAGNOSES: "診断",
       REQUIRES_REVIEW: "要確認",
+      CONSTRUCTS: "構成",
+      NORMALIZES: "正規化",
+      SOLVES: "求解",
+      SUBSTITUTES: "代入",
+      ELIMINATES: "消去",
+      APPROXIMATES: "近似",
+      TRANSFORMS: "変換",
+      COMPARES: "比較",
+      FEEDS: "入力",
     };
     return labels[key] || key;
   }
@@ -5948,14 +6010,15 @@
 
   function lsGraphEdgeColor(edge) {
     var relation = String((edge && (edge.relation || edge.edge_type || edge.type)) || "").toUpperCase();
-    if (relation === "DIAGNOSES") return "#7c3aed";
-    if (relation === "DERIVES" || relation === "ELIMINATES_BIAS") return "#2563eb";
-    if (relation === "FEEDS_EQUATION_SYSTEM" || relation === "LINEARIZES") return "#0891b2";
+    if (relation === "DIAGNOSES" || relation === "COMPARES") return "#7c3aed";
+    if (relation === "DERIVES" || relation === "ELIMINATES_BIAS" || relation === "ELIMINATES" || relation === "SOLVES") return "#2563eb";
+    if (relation === "FEEDS_EQUATION_SYSTEM" || relation === "LINEARIZES" || relation === "CONSTRUCTS" || relation === "NORMALIZES" || relation === "SUBSTITUTES" || relation === "APPROXIMATES") return "#0891b2";
     if (relation === "UNCERTAIN_DUE_TO") return "#f97316";
     if (relation === "CONFLICTS_WITH" || relation === "INHIBITS") return "#ef4444";
-    if (relation === "CHECKED_BY" || relation === "QUALIFIES") return "#84cc16";
+    if (relation === "CHECKED_BY" || relation === "QUALIFIES" || relation === "CONSTRAINS") return "#84cc16";
     if (relation === "DEFINES") return "#22c55e";
     if (relation === "RELATED_TO") return "#f97316";
+    if (relation === "TRANSFORMS" || relation === "FEEDS" || relation === "REQUIRES_REVIEW") return "#94a3b8";
     return "#94a3b8";
   }
 

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5544,7 +5544,7 @@
     var html =
       '<div class="ls-graph-detail-badge ' + escHtml(lsGraphNodeGroup(node)) + '">' +
       escHtml(node.component_type_text || node.component_type || node.typeName || "component") + '</div>' +
-      '<h4>' + escHtml(lsGraphFullDisplayLabel(node) || nodeId || "無題") + '</h4>';
+      '<h4>' + escHtml((lsGraphNodeDisplayLabel(node, nodeId) || nodeId || "無題").replace(/\n/g, " — ")) + '</h4>';
 
     // 1. このノードの意味
     if (node.description) {
@@ -5564,6 +5564,9 @@
     }
     if ((node.input_claim_ids || []).length) {
       inputParts += '<div class="ls-graph-detail-link"><span>claim</span> ' + escHtml((node.input_claim_ids).join(", ")) + '</div>';
+    }
+    if ((node.required_claim_ids || []).length) {
+      inputParts += '<div class="ls-graph-detail-link"><span>前提claim</span> ' + escHtml((node.required_claim_ids).join(", ")) + '</div>';
     }
     if (inputParts) {
       html += '<div class="ls-graph-detail-section"><b>入力</b>' + inputParts + '</div>';
@@ -5592,7 +5595,7 @@
         var target = edge.target_component_id || edge.target || edge.to;
         var otherId = source === nodeId ? target : source;
         var otherNode = nodeById[otherId];
-        var otherLabel = otherNode ? (lsGraphFullDisplayLabel(otherNode) || otherId) : otherId;
+        var otherLabel = otherNode ? ((lsGraphNodeDisplayLabel(otherNode, otherId) || otherId).replace(/\n/g, " ")) : otherId;
         var arrow = source === nodeId ? "→" : "←";
         var relation = edge.relation || edge.edge_type || edge.type || "RELATED_TO";
         var edgeLabel = lsGraphEdgeLabel(relation);

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -5551,10 +5551,19 @@
       html += '<div class="ls-graph-detail-section"><b>このノードの意味</b><p>' + escHtml(node.description) + '</p></div>';
     }
 
+    // 1b. 抽出メモ（review_reason — step.reason からの抽出/検証メモ）
+    var reviewReason = String(node.review_reason || "").trim();
+    if (reviewReason) {
+      html += '<div class="ls-graph-detail-section"><b>抽出メモ</b><p class="ls-graph-detail-memo">' + escHtml(reviewReason) + '</p></div>';
+    }
+
     // 2. 入力
     var inputParts = "";
     if ((node.input_equation_ids || []).length) {
       inputParts += '<div class="ls-graph-detail-link"><span>式</span> ' + escHtml((node.input_equation_ids).join(", ")) + '</div>';
+    }
+    if ((node.input_claim_ids || []).length) {
+      inputParts += '<div class="ls-graph-detail-link"><span>claim</span> ' + escHtml((node.input_claim_ids).join(", ")) + '</div>';
     }
     if (inputParts) {
       html += '<div class="ls-graph-detail-section"><b>入力</b>' + inputParts + '</div>';
@@ -5564,6 +5573,9 @@
     var outputParts = "";
     if ((node.output_equation_ids || []).length) {
       outputParts += '<div class="ls-graph-detail-link"><span>式</span> ' + escHtml((node.output_equation_ids).join(", ")) + '</div>';
+    }
+    if ((node.output_claim_ids || []).length) {
+      outputParts += '<div class="ls-graph-detail-link"><span>claim</span> ' + escHtml((node.output_claim_ids).join(", ")) + '</div>';
     }
     if (outputParts) {
       html += '<div class="ls-graph-detail-section"><b>出力</b>' + outputParts + '</div>';
@@ -5745,10 +5757,77 @@
     return maturity === "deterministic_fallback" || backing === "inferred";
   }
 
+  // Issue #337: Japanese operation verb mapping for graph node display.
+  var LS_OPERATION_VERB_JA = {
+    "Apply definition": "定義を適用",
+    "Apply criterion": "基準を適用",
+    "Apply constraint": "制約を適用",
+    "Apply equation": "式を適用",
+    "Apply measurement": "測定を適用",
+    "Apply independence": "独立性を適用",
+    "Infer conclusion": "結論を導出",
+    "Infer intermediate claim": "中間主張を導出",
+    "Derive result": "結果を導出",
+    "Derive consistency relation": "整合関係を導出",
+    "Compare": "比較・検証",
+    "Flag limitation": "制約を確認",
+    "Eliminate parameter": "パラメータを消去",
+    "Solve linear system": "連立方程式を求解",
+    "State assumption": "仮定を提示",
+    "Branch on condition": "条件分岐",
+    "Introduce observable": "観測量を導入",
+    "Define": "定義",
+    "Construct": "構成",
+    "Linearize": "線形化",
+    "Normalize": "正規化",
+    "Approximate": "近似",
+    "Substitute": "代入",
+    "Eliminate": "消去",
+    "Derive": "導出",
+    "Constrain": "制約",
+    "Diagnose": "診断",
+    "Solve": "求解",
+    "Infer": "推論",
+    "Apply": "適用",
+    "Flag": "確認",
+    "State": "提示",
+    "Introduce": "導入",
+  };
+
+  // Issue #337: Japanese stage labels for main graph nodes.
+  var LS_STAGE_LABELS_JA = {
+    "Theory basis": "理論の前提",
+    "Observation model": "観測モデル",
+    "Observable construction": "観測量の構成",
+    "Equation system": "方程式系",
+    "Elimination": "消去",
+    "Consistency relation": "整合条件",
+    "Diagnostic / application": "診断・応用",
+  };
+
+  function lsGraphOperationLabelJa(verb) {
+    var label = String(verb || "").trim();
+    if (LS_OPERATION_VERB_JA[label]) return LS_OPERATION_VERB_JA[label];
+    if (LS_STAGE_LABELS_JA[label]) return LS_STAGE_LABELS_JA[label];
+    var parts = label.split(" ");
+    if (parts.length >= 2 && LS_OPERATION_VERB_JA[parts[0]]) {
+      return LS_OPERATION_VERB_JA[parts[0]] + ": " + parts.slice(1).join(" ");
+    }
+    return label;
+  }
+
   // Prefix a warning icon for fallback / inferred nodes so they are not mistaken
   // for confirmed, source-backed theory operations (issue #302).
+  // Issue #337: prefer visual_label (short), translate to Japanese.
   function lsGraphNodeDisplayLabel(node, id) {
-    var label = lsWrapGraphLabel(lsGraphFullDisplayLabel(node) || id);
+    var visualLabel = String((node && node.visual_label) || "").trim();
+    var raw;
+    if (visualLabel) {
+      raw = lsGraphOperationLabelJa(visualLabel);
+    } else {
+      raw = lsGraphFullDisplayLabel(node) || id;
+    }
+    var label = lsWrapGraphLabel(raw);
     return lsGraphNodeIsFallback(node) ? "⚠ " + label : label;
   }
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -176,10 +176,8 @@ class ComponentGraphNormalizer:
                     "is_generic": is_generic,
                     "inputs": _ordered_unique(getattr(step, "input_equation_ids", []) or []),
                     "outputs": _ordered_unique(getattr(step, "output_equation_ids", []) or []),
-                    "input_claims": _ordered_unique(
-                        list(getattr(step, "input_claim_ids", []) or [])
-                        + list(getattr(step, "required_claim_ids", []) or [])
-                    ),
+                    "input_claims": _ordered_unique(getattr(step, "input_claim_ids", []) or []),
+                    "required_claims": _ordered_unique(getattr(step, "required_claim_ids", []) or []),
                     "output_claims": _ordered_unique(getattr(step, "output_claim_ids", []) or []),
                 })
         return records
@@ -374,6 +372,9 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
     group_input_claim_ids = _ordered_unique(
         cid for rec in records for cid in rec.get("input_claims", [])
     )
+    group_required_claim_ids = _ordered_unique(
+        cid for rec in records for cid in rec.get("required_claims", [])
+    )
     group_output_claim_ids = _ordered_unique(
         cid for rec in records for cid in rec.get("output_claims", [])
     )
@@ -435,6 +436,7 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
         visual_label=label,
         input_claim_ids=group_input_claim_ids,
         output_claim_ids=group_output_claim_ids,
+        required_claim_ids=group_required_claim_ids,
         review_reason=group_review_reason,
     )
 
@@ -453,6 +455,7 @@ def _main_edges_from_groups(groups: list[dict]) -> list[ComponentGraphEdge]:
         inputs = {eq for rec in group["records"] for eq in rec["inputs"]}
         output_claims = {cid for rec in group["records"] for cid in rec.get("output_claims", [])}
         input_claims = {cid for rec in group["records"] for cid in rec.get("input_claims", [])}
+        input_claims.update(cid for rec in group["records"] for cid in rec.get("required_claims", []))
         step_ids = [rec["step_id"] for rec in group["records"]]
         claim_ids = _ordered_unique(
             [cid for rec in group["records"] for cid in _step_claim_ids(rec["step"])]
@@ -609,11 +612,11 @@ def _detail_node_from_record(
 
     detail_label = _build_detail_label(rec["verb"], step, inputs, outputs)
     step_reason = str(getattr(step, "reason", "") or "").strip()
-    step_input_claims = _ordered_unique(
-        list(getattr(step, "input_claim_ids", []) or [])
-        + list(getattr(step, "required_claim_ids", []) or [])
-    )
+    step_input_claims = _ordered_unique(getattr(step, "input_claim_ids", []) or [])
+    step_required_claims = _ordered_unique(getattr(step, "required_claim_ids", []) or [])
     step_output_claims = _ordered_unique(getattr(step, "output_claim_ids", []) or [])
+    visual = _build_detail_visual_label(rec["verb"], inputs, outputs,
+                                        step_input_claims, step_output_claims)
 
     return ComponentGraphNode(
         component_id=rec["detail_id"],
@@ -647,9 +650,10 @@ def _detail_node_from_record(
         source_backing_status=status,
         review_reasons=reasons,
         parent_component_id=parent_id,
-        visual_label=rec["verb"],
+        visual_label=visual,
         input_claim_ids=step_input_claims,
         output_claim_ids=step_output_claims,
+        required_claim_ids=step_required_claims,
         review_reason=step_reason[:240],
         **_support_metadata_for_components(list(rec.get("linked_component_ids", [])), [rec]),
         **_concepts_for_components(list(rec.get("linked_component_ids", [])), [rec]),
@@ -665,6 +669,7 @@ def _detail_edges_from_records(
     for j, target in enumerate(records):
         target_inputs = set(target["inputs"])
         target_input_claims = set(target.get("input_claims", []))
+        target_input_claims.update(target.get("required_claims", []))
         if not target_inputs and not target_input_claims:
             continue
         for source in records[:j]:
@@ -858,6 +863,28 @@ def _build_detail_label(verb: str, step, inputs: list[str], outputs: list[str]) 
     obj = (outputs[:1] or inputs[:1] or [""])[0]
     if obj:
         return f"{verb} {obj}".strip()
+    return verb
+
+
+def _build_detail_visual_label(
+    verb: str,
+    inputs: list[str],
+    outputs: list[str],
+    input_claims: list[str],
+    output_claims: list[str],
+) -> str:
+    """Short graph-canvas label for detail nodes, showing I/O flow (#337).
+
+    Format: ``"verb\\ninput → output"`` (capped at 30 chars per line).
+    Falls back to verb only when no I/O identifiers are available.
+    """
+    src = (inputs[:1] or input_claims[:1] or [""])[0]
+    dst = (outputs[:1] or output_claims[:1] or [""])[0]
+    if src and dst:
+        flow = f"{src} → {dst}"
+        return f"{verb}\n{flow[:30]}"
+    if src or dst:
+        return f"{verb}\n{(src or dst)[:30]}"
     return verb
 
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -370,12 +370,21 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
         is_generic=False,
     )
 
+    # Claim I/O: aggregate from group records (issue #337).
+    group_input_claim_ids = _ordered_unique(
+        cid for rec in records for cid in rec.get("input_claims", [])
+    )
+    group_output_claim_ids = _ordered_unique(
+        cid for rec in records for cid in rec.get("output_claims", [])
+    )
+    # Collect step reasons as review notes (not for node label/description).
+    group_review_reasons = [
+        str(getattr(rec["step"], "reason", "") or "").strip()
+        for rec in records
+    ]
+    group_review_reason = "; ".join(filter(None, group_review_reasons))[:240]
+
     rep = group.get("rep") or _representative_record(records)
-    # Main labels are SHORT theory-stage labels (issue #308): ``Theory basis`` …
-    # ``Diagnostic / application``. They are never equation-id fallbacks, so
-    # ``eq_...`` can no longer leak into the main graph. The longer atomic-claim /
-    # reason phrase that used to be appended to the label now lives in
-    # ``description`` and is shown in the UI's detail pane instead.
     label = theory_stage_label(stage)
     theory_object = _theory_object(rep, atomic_claim_ids, claim_index, records)
     description = _build_main_description(records, atomic_claim_ids, claim_index)
@@ -423,6 +432,10 @@ def _main_node_from_group(group: dict, claim_index: dict[str, dict]) -> Componen
         support_kind=support["support_kind"],
         concepts=concept_meta["concepts"],
         prerequisite_concepts=concept_meta["prerequisite_concepts"],
+        visual_label=label,
+        input_claim_ids=group_input_claim_ids,
+        output_claim_ids=group_output_claim_ids,
+        review_reason=group_review_reason,
     )
 
 
@@ -594,17 +607,25 @@ def _detail_node_from_record(
     # Generic / inferred steps are kept for traceability but never confirmed.
     layer = GRAPH_LAYER_DEBUG if rec["is_generic"] else GRAPH_LAYER_EQUATION_DETAIL
 
+    detail_label = _build_detail_label(rec["verb"], step, inputs, outputs)
+    step_reason = str(getattr(step, "reason", "") or "").strip()
+    step_input_claims = _ordered_unique(
+        list(getattr(step, "input_claim_ids", []) or [])
+        + list(getattr(step, "required_claim_ids", []) or [])
+    )
+    step_output_claims = _ordered_unique(getattr(step, "output_claim_ids", []) or [])
+
     return ComponentGraphNode(
         component_id=rec["detail_id"],
-        label=_build_detail_label(rec["verb"], step, inputs, outputs),
+        label=detail_label,
         component_type=EQUATION_OPERATION_NODE,
         review_status=review_status_for_backing(status),
         display_order=1000 + rec["order"],
         origin="derivation_chain",
         operation=rec["operation"],
         theory_object=rec["verb"],
-        display_label=_build_detail_label(rec["verb"], step, inputs, outputs),
-        description=str(getattr(step, "reason", "") or "").strip()[:240],
+        display_label=detail_label,
+        description="",
         linked_component_ids=list(rec.get("linked_component_ids", [])),
         supporting_derivation_ids=linked_derivation_ids,
         graph_layer=layer,
@@ -626,6 +647,10 @@ def _detail_node_from_record(
         source_backing_status=status,
         review_reasons=reasons,
         parent_component_id=parent_id,
+        visual_label=rec["verb"],
+        input_claim_ids=step_input_claims,
+        output_claim_ids=step_output_claims,
+        review_reason=step_reason[:240],
         **_support_metadata_for_components(list(rec.get("linked_component_ids", [])), [rec]),
         **_concepts_for_components(list(rec.get("linked_component_ids", [])), [rec]),
     )
@@ -846,23 +871,16 @@ def _build_main_description(
     atomic_claim_ids: list[str],
     claim_index: dict[str, dict],
 ) -> str:
-    """Longer explanation for a main node, shown in the UI detail pane (issue #308).
+    """Reader-facing explanation for a main node (issue #308, #337).
 
-    The main node's *label* stays short (the theory-stage name). This description
-    carries the human-readable detail: the atomic-claim text if one backs the
-    node, otherwise the first meaningful step reason. Equation-id-only reasons are
-    skipped so the description never degenerates into an equation reference.
-    Returns ``""`` when no meaningful phrase is available.
+    Returns only genuinely reader-friendly content: the atomic-claim text that
+    backs the node. Step reasons (extraction/review metadata) are NOT included
+    here — they live in ``review_reason`` and are shown separately in the UI.
+    Returns ``""`` when no reader-friendly phrase is available.
     """
-    # 1. atomic claim text (preferred)
     claim_phrase = _atomic_claim_phrase(atomic_claim_ids, claim_index, limit=240)
     if claim_phrase:
         return claim_phrase
-    # 2. meaningful step reason (skip bare generic words / equation-id-only text)
-    for rec in records:
-        reason = str(getattr(rec["step"], "reason", "") or "").strip()
-        if reason and reason.lower() not in _GENERIC_LABELS and not _looks_like_equation_id(reason):
-            return reason[:240]
     return ""
 
 
@@ -913,9 +931,8 @@ def _theory_object(
     )
     if symbols:
         return ", ".join(symbols[:3])[:120]
-    reason = str(getattr(rep["step"], "reason", "") or "").strip()
-    if reason and not _looks_like_equation_id(reason):
-        return reason[:120]
+    # Never fall back to step.reason here (#337) — reason is extraction metadata,
+    # not a theory-object phrase. It lives in review_reason instead.
     operation = str(rep.get("operation") or rep.get("verb") or "")
     return operation.replace("_", " ")[:120]
 

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -602,8 +602,9 @@ def _detail_node_from_record(
         display_order=1000 + rec["order"],
         origin="derivation_chain",
         operation=rec["operation"],
-        theory_object=str(getattr(step, "reason", "") or "").strip()[:120] or rec["verb"],
+        theory_object=rec["verb"],
         display_label=_build_detail_label(rec["verb"], step, inputs, outputs),
+        description=str(getattr(step, "reason", "") or "").strip()[:240],
         linked_component_ids=list(rec.get("linked_component_ids", [])),
         supporting_derivation_ids=linked_derivation_ids,
         graph_layer=layer,
@@ -824,13 +825,14 @@ def _claim_is_atomic(meta: dict) -> bool:
 # ---------------------------------------------------------------------- #
 
 def _build_detail_label(verb: str, step, inputs: list[str], outputs: list[str]) -> str:
-    """Equation-level label: equation IDs are acceptable here (traceability)."""
+    """Detail-level label: equation IDs are acceptable here (traceability).
+
+    Never uses step.reason as a label — reason is review/extraction metadata
+    and belongs in the node's ``description``, not in its graph label (#337).
+    """
     obj = (outputs[:1] or inputs[:1] or [""])[0]
     if obj:
         return f"{verb} {obj}".strip()
-    reason = str(getattr(step, "reason", "") or "").strip()
-    if reason and reason.lower() not in _GENERIC_LABELS:
-        return reason[:80]
     return verb
 
 

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -383,6 +383,18 @@ class ComponentGraphNode:
     # Concept tags carried from component assembly (issue #8).
     concepts: list[str] = field(default_factory=list)
     prerequisite_concepts: list[str] = field(default_factory=list)
+    # Short graph-display label, guaranteed ≤ 30 chars (issue #337). The primary
+    # label shown on graph nodes. For main nodes: theory-stage name; for detail
+    # nodes: operation verb. Frontend translates to Japanese.
+    visual_label: str = ""
+    # Claim I/O (issue #337): separate input/output claims carried from the
+    # derivation step so the right panel can display them.
+    input_claim_ids: list[str] = field(default_factory=list)
+    output_claim_ids: list[str] = field(default_factory=list)
+    # Extraction/review note (issue #337). Free-text step.reason from the
+    # derivation pipeline; distinct from ``review_reasons`` (structured codes)
+    # and ``description`` (reader-facing explanation).
+    review_reason: str = ""
 
 
 @dataclass
@@ -495,6 +507,10 @@ class ComponentGraphResult:
                     "review_reasons": n.review_reasons,
                     "parent_component_id": n.parent_component_id,
                     "member_component_ids": n.member_component_ids,
+                    "visual_label": n.visual_label,
+                    "input_claim_ids": n.input_claim_ids,
+                    "output_claim_ids": n.output_claim_ids,
+                    "review_reason": n.review_reason,
                 }
                 for n in self.nodes
             ],

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -391,6 +391,9 @@ class ComponentGraphNode:
     # derivation step so the right panel can display them.
     input_claim_ids: list[str] = field(default_factory=list)
     output_claim_ids: list[str] = field(default_factory=list)
+    # Precondition claims required (but not consumed) by this step (issue #337).
+    # Distinct from ``input_claim_ids`` (data-flow inputs).
+    required_claim_ids: list[str] = field(default_factory=list)
     # Extraction/review note (issue #337). Free-text step.reason from the
     # derivation pipeline; distinct from ``review_reasons`` (structured codes)
     # and ``description`` (reader-facing explanation).
@@ -510,6 +513,7 @@ class ComponentGraphResult:
                     "visual_label": n.visual_label,
                     "input_claim_ids": n.input_claim_ids,
                     "output_claim_ids": n.output_claim_ids,
+                    "required_claim_ids": n.required_claim_ids,
                     "review_reason": n.review_reason,
                 }
                 for n in self.nodes

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -703,8 +703,8 @@ def test_detail_node_label_never_uses_reason():
         )
 
 
-def test_detail_node_reason_goes_to_description():
-    """Issue #337: step.reason is stored in description, not label/theory_object."""
+def test_detail_node_reason_goes_to_review_reason():
+    """Issue #337: step.reason is stored in review_reason, not label/description."""
     reason_text = "Applies the EPR definition of physical reality"
     steps = [
         DerivationStep(
@@ -725,7 +725,8 @@ def test_detail_node_reason_goes_to_description():
     detail_nodes = _layer(result, "equation_detail")
     assert len(detail_nodes) >= 1
     node = detail_nodes[0]
-    assert node.description == reason_text
+    assert node.review_reason == reason_text
+    assert node.description == ""
     assert reason_text not in node.theory_object
 
 
@@ -760,8 +761,8 @@ def test_equation_detail_label_still_uses_equation_id():
         )
 
 
-def test_detail_node_empty_reason_gives_empty_description():
-    """Issue #337 edge case: empty/None reason produces empty description."""
+def test_detail_node_empty_reason_gives_empty_review_reason():
+    """Issue #337 edge case: empty reason produces empty review_reason."""
     steps = [
         DerivationStep(
             step_id="step_no_reason",
@@ -780,6 +781,7 @@ def test_detail_node_empty_reason_gives_empty_description():
     )
     detail_nodes = _layer(result, "equation_detail")
     assert len(detail_nodes) >= 1
+    assert detail_nodes[0].review_reason == ""
     assert detail_nodes[0].description == ""
     assert detail_nodes[0].label == "Define framework"
 
@@ -800,3 +802,86 @@ def test_detail_node_theory_object_is_verb_not_reason():
     node = detail_nodes[0]
     assert node.theory_object == "Flag limitation"
     assert reason not in node.theory_object
+
+
+def test_detail_node_has_visual_label():
+    """Issue #337: detail nodes carry a short visual_label (operation verb)."""
+    steps = [
+        _claim_step("infer_conclusion", ["claim_a"], ["claim_b"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    assert detail_nodes[0].visual_label == "Infer conclusion"
+
+
+def test_main_node_visual_label_is_stage_name():
+    """Issue #337: main nodes carry a short visual_label (theory stage name)."""
+    result = _normalized()
+    main_nodes = _layer(result, "main")
+    assert len(main_nodes) >= 1
+    for node in main_nodes:
+        assert node.visual_label, f"{node.component_id} missing visual_label"
+        assert len(node.visual_label) <= 30, (
+            f"visual_label too long: {node.visual_label}"
+        )
+
+
+def test_detail_node_has_claim_io():
+    """Issue #337: detail nodes store input/output claim IDs separately."""
+    steps = [
+        _claim_step("apply_definition", ["claim_a"], ["claim_b"],
+                     required_claim_ids=["claim_pre"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    node = detail_nodes[0]
+    assert "claim_a" in node.input_claim_ids
+    assert "claim_pre" in node.input_claim_ids
+    assert "claim_b" in node.output_claim_ids
+
+
+def test_main_node_has_aggregated_claim_io():
+    """Issue #337: main nodes aggregate claim I/O from group records."""
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), _claim_only_derivations()
+    )
+    main_nodes = _layer(result, "main")
+    assert len(main_nodes) >= 1
+    has_output = any(node.output_claim_ids for node in main_nodes)
+    assert has_output, "at least one main node should have output_claim_ids"
+
+
+def test_main_node_description_excludes_extraction_reason():
+    """Issue #337: main node description never contains step extraction reasons."""
+    reason = "The span is content-bearing and reviewable, but it is not minimal"
+    steps = [
+        DerivationStep(
+            step_id="step_def",
+            input_equation_ids=["eq_a"],
+            output_equation_ids=["eq_b"],
+            operation="define",
+            reason=reason,
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_nodes = _layer(result, "main")
+    assert len(main_nodes) >= 1
+    for node in main_nodes:
+        assert reason not in (node.description or ""), (
+            f"main description should not contain extraction reason"
+        )
+        assert reason not in (node.display_label or ""), (
+            f"main display_label should not contain extraction reason"
+        )

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -665,3 +665,138 @@ def test_mixed_equation_and_claim_chain_prefers_equations():
     assert len(main_edges) >= 1
     for edge in main_edges:
         assert edge.evidence_equation_ids, "equation evidence should be preferred when available"
+
+
+# --- detail node labels never use step.reason (issue #337) --------------------
+
+
+def test_detail_node_label_never_uses_reason():
+    """Issue #337: detail node labels must never be step.reason text."""
+    reason_text = (
+        "The span is content-bearing and reviewable, but it is not a minimal "
+        "reusable claim for the theory operation graph"
+    )
+    steps = [
+        DerivationStep(
+            step_id="step_with_reason",
+            input_equation_ids=[],
+            output_equation_ids=[],
+            operation="apply_definition",
+            input_claim_ids=["claim_a"],
+            output_claim_ids=["claim_b"],
+            reason=reason_text,
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    for node in detail_nodes:
+        assert reason_text[:40] not in node.label, (
+            f"detail node label must not contain reason text: {node.label}"
+        )
+        assert reason_text[:40] not in node.display_label, (
+            f"detail node display_label must not contain reason text: {node.display_label}"
+        )
+
+
+def test_detail_node_reason_goes_to_description():
+    """Issue #337: step.reason is stored in description, not label/theory_object."""
+    reason_text = "Applies the EPR definition of physical reality"
+    steps = [
+        DerivationStep(
+            step_id="step_apply",
+            input_equation_ids=[],
+            output_equation_ids=[],
+            operation="apply_definition",
+            input_claim_ids=["claim_a"],
+            output_claim_ids=["claim_b"],
+            reason=reason_text,
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    node = detail_nodes[0]
+    assert node.description == reason_text
+    assert reason_text not in node.theory_object
+
+
+def test_claim_only_detail_label_uses_verb():
+    """Issue #337: claim-only steps use the operation verb as label."""
+    steps = [
+        _claim_step("infer_conclusion", ["claim_a"], ["claim_b"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    node = detail_nodes[0]
+    assert node.label == "Infer conclusion"
+    assert node.display_label == "Infer conclusion"
+
+
+def test_equation_detail_label_still_uses_equation_id():
+    """Issue #337: equation steps still use equation IDs in detail labels."""
+    result = _normalized()
+    detail_nodes = _layer(result, "equation_detail")
+    eq_nodes = [n for n in detail_nodes if n.input_equation_ids or n.output_equation_ids]
+    assert len(eq_nodes) >= 1
+    for node in eq_nodes:
+        has_eq_ref = any(
+            eq_id in node.label for eq_id in node.input_equation_ids + node.output_equation_ids
+        )
+        assert has_eq_ref, (
+            f"equation detail node should reference equation IDs in label: {node.label}"
+        )
+
+
+def test_detail_node_empty_reason_gives_empty_description():
+    """Issue #337 edge case: empty/None reason produces empty description."""
+    steps = [
+        DerivationStep(
+            step_id="step_no_reason",
+            input_equation_ids=[],
+            output_equation_ids=[],
+            operation="define_framework",
+            input_claim_ids=[],
+            output_claim_ids=["claim_x"],
+            reason="",
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    assert detail_nodes[0].description == ""
+    assert detail_nodes[0].label == "Define framework"
+
+
+def test_detail_node_theory_object_is_verb_not_reason():
+    """Issue #337: theory_object should be the verb, not step.reason."""
+    reason = "Long extraction reason that should not appear in theory_object"
+    steps = [
+        _claim_step("flag_limitation", ["claim_a"], ["claim_b"],
+                     reason=reason),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    node = detail_nodes[0]
+    assert node.theory_object == "Flag limitation"
+    assert reason not in node.theory_object

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -805,7 +805,7 @@ def test_detail_node_theory_object_is_verb_not_reason():
 
 
 def test_detail_node_has_visual_label():
-    """Issue #337: detail nodes carry a short visual_label (operation verb)."""
+    """Issue #337: detail nodes carry a visual_label with verb and I/O flow."""
     steps = [
         _claim_step("infer_conclusion", ["claim_a"], ["claim_b"]),
     ]
@@ -815,7 +815,9 @@ def test_detail_node_has_visual_label():
     )
     detail_nodes = _layer(result, "equation_detail")
     assert len(detail_nodes) >= 1
-    assert detail_nodes[0].visual_label == "Infer conclusion"
+    vl = detail_nodes[0].visual_label
+    assert vl.startswith("Infer conclusion"), f"visual_label should start with verb: {vl}"
+    assert "claim_a" in vl, f"visual_label should show input claim: {vl}"
 
 
 def test_main_node_visual_label_is_stage_name():
@@ -844,7 +846,7 @@ def test_detail_node_has_claim_io():
     assert len(detail_nodes) >= 1
     node = detail_nodes[0]
     assert "claim_a" in node.input_claim_ids
-    assert "claim_pre" in node.input_claim_ids
+    assert "claim_pre" in node.required_claim_ids
     assert "claim_b" in node.output_claim_ids
 
 
@@ -885,3 +887,154 @@ def test_main_node_description_excludes_extraction_reason():
         assert reason not in (node.display_label or ""), (
             f"main display_label should not contain extraction reason"
         )
+
+
+# --- required_claim_ids separation (issue #337 round 3) ----------------------
+
+
+def test_detail_node_separates_required_claim_ids():
+    """Issue #337: required_claim_ids are stored separately from input_claim_ids."""
+    steps = [
+        _claim_step("apply_definition", ["claim_in"], ["claim_out"],
+                     required_claim_ids=["claim_req"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    node = detail_nodes[0]
+    assert "claim_in" in node.input_claim_ids
+    assert "claim_req" not in node.input_claim_ids, (
+        "required_claim_ids should not be merged into input_claim_ids"
+    )
+    assert "claim_req" in node.required_claim_ids
+    assert "claim_out" in node.output_claim_ids
+
+
+def test_main_node_aggregates_required_claim_ids():
+    """Issue #337: main nodes aggregate required_claim_ids from group records."""
+    steps = [
+        _claim_step("define_framework", [], ["claim_a"],
+                     required_claim_ids=["claim_pre"]),
+        _claim_step("derive_result", ["claim_a"], ["claim_b"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    main_nodes = _layer(result, "main")
+    has_required = any(node.required_claim_ids for node in main_nodes)
+    assert has_required, "at least one main node should have required_claim_ids"
+
+
+# --- visual_label never contains reason (regression, issue #337 round 3) ------
+
+
+def test_visual_label_never_contains_reason():
+    """Regression: visual_label must not contain step.reason text."""
+    reason = "Long extraction reason that must not leak into visual_label"
+    steps = [
+        DerivationStep(
+            step_id="step_def",
+            input_equation_ids=["eq_a"],
+            output_equation_ids=["eq_b"],
+            operation="define",
+            reason=reason,
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    for node in result.nodes:
+        assert reason not in (node.visual_label or ""), (
+            f"visual_label should never contain extraction reason: {node.visual_label}"
+        )
+
+
+# --- detail visual_label shows I/O flow (issue #337 round 3) -----------------
+
+
+def test_detail_visual_label_shows_equation_flow():
+    """Issue #337: detail visual_label includes equation I/O flow."""
+    steps = [
+        _step("define", ["eq_a"], ["eq_b"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    vl = detail_nodes[0].visual_label
+    assert "eq_a" in vl, f"visual_label should reference input equation: {vl}"
+    assert "eq_b" in vl, f"visual_label should reference output equation: {vl}"
+    assert "→" in vl, f"visual_label should contain arrow for flow: {vl}"
+
+
+def test_detail_visual_label_shows_claim_flow():
+    """Issue #337: claim-only detail visual_label includes claim I/O flow."""
+    steps = [
+        _claim_step("infer_conclusion", ["claim_x"], ["claim_y"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    detail_nodes = _layer(result, "equation_detail")
+    assert len(detail_nodes) >= 1
+    vl = detail_nodes[0].visual_label
+    assert "claim_x" in vl, f"visual_label should reference input claim: {vl}"
+    assert "claim_y" in vl, f"visual_label should reference output claim: {vl}"
+
+
+# --- to_graph_payload includes new fields (issue #337 round 3) ----------------
+
+
+def test_graph_payload_includes_required_claim_ids():
+    """Issue #337: to_graph_payload() includes required_claim_ids for each node."""
+    steps = [
+        _claim_step("apply_definition", ["claim_in"], ["claim_out"],
+                     required_claim_ids=["claim_req"]),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    payload = result.to_graph_payload()
+    for node_dict in payload["nodes"]:
+        assert "required_claim_ids" in node_dict, (
+            f"payload node missing required_claim_ids: {node_dict['component_id']}"
+        )
+    detail_nodes = [n for n in payload["nodes"] if n.get("graph_layer") == "equation_detail"]
+    assert len(detail_nodes) >= 1
+    node_with_req = [n for n in detail_nodes if "claim_req" in n.get("required_claim_ids", [])]
+    assert node_with_req, "payload should contain detail node with claim_req in required_claim_ids"
+
+
+def test_graph_payload_includes_visual_label_and_review_reason():
+    """Issue #337: to_graph_payload() includes visual_label and review_reason."""
+    reason = "Some extraction note"
+    steps = [
+        DerivationStep(
+            step_id="step_def",
+            input_equation_ids=["eq_a"],
+            output_equation_ids=["eq_b"],
+            operation="define",
+            reason=reason,
+            review_status="teacher_review_required",
+        ),
+    ]
+    derivations = _short_derivations(steps)
+    result = ComponentGraphNormalizer().normalize(
+        _empty_graph(), _empty_components(), derivations
+    )
+    payload = result.to_graph_payload()
+    for node_dict in payload["nodes"]:
+        assert "visual_label" in node_dict
+        assert "review_reason" in node_dict
+    detail_nodes = [n for n in payload["nodes"] if n.get("graph_layer") == "equation_detail"]
+    assert any(n["review_reason"] == reason for n in detail_nodes)


### PR DESCRIPTION
## Summary

This PR restructures the component graph detail panel UI to improve information organization and adds comprehensive support for additional edge relation types with proper labeling and color coding.

## Key Changes

### Frontend UI Improvements (admin.js)
- **Detail panel reorganization**: Restructured the node detail panel into 7 clearly labeled sections:
  1. Node description ("このノードの意味")
  2. Input equations
  3. Output equations
  4. Connections (with connected node labels and edge reasons)
  5. Evidence/source links ("根拠")
  6. Review items ("要確認事項")
  7. System information (collapsed by default in `<details>`)

- **Enhanced connection display**: 
  - Shows connected node labels instead of just IDs
  - Displays edge relation reasons when available
  - Uses directional arrows (→/←) for clarity

- **System info collapsible**: Moved ID, layer, status, and linkage info into a `<details>` element to reduce visual clutter

- **Edge relation support**: Added 11 new relation types with Japanese labels and color assignments:
  - `CONSTRUCTS`, `NORMALIZES`, `SOLVES`, `SUBSTITUTES`, `ELIMINATES`, `APPROXIMATES` (cyan)
  - `TRANSFORMS`, `FEEDS`, `REQUIRES_REVIEW` (slate)
  - `COMPARES` (purple, priority 6)

- **Relation priority updates**: Adjusted `lsGraphRelationPriority()` to properly rank new relations and ensure consistent edge rendering order

### Styling (styles.css)
- Added `.ls-graph-detail-edge-reason`: Styled edge reason text with dashed border separator
- Added `.ls-graph-detail-system`: Styling for collapsed system information section with `<details>` support

### Backend Normalization (normalizer.py)
- **Fixed issue #337**: Detail node labels no longer use `step.reason` text
  - `theory_object` now always uses the operation verb (e.g., "Apply definition")
  - `step.reason` is moved to the `description` field (max 240 chars)
  - Ensures detail node labels remain concise and operation-focused

- **Label generation**: `_build_detail_label()` now:
  - Prefers equation IDs for traceability when available
  - Falls back to operation verb for claim-only steps
  - Never includes step.reason in the label

### Tests (test_normalizer.py)
- Added 6 comprehensive tests for issue #337:
  - `test_detail_node_label_never_uses_reason`: Validates reason text is excluded from labels
  - `test_detail_node_reason_goes_to_description`: Confirms reason is stored in description
  - `test_claim_only_detail_label_uses_verb`: Verifies verb-based labels for claim steps
  - `test_equation_detail_label_still_uses_equation_id`: Ensures equation IDs remain in labels
  - `test_detail_node_empty_reason_gives_empty_description`: Edge case handling
  - `test_detail_node_theory_object_is_verb_not_reason`: Confirms theory_object uses verb

## Implementation Details

- The detail panel now builds HTML in logical sections with clear visual hierarchy
- Node connectivity is resolved via a `nodeById` map for efficient label lookup
- Edge reasons are displayed as secondary text with visual separation
- System information is hidden by default but remains accessible via `<details>` disclosure
- All new relation types follow existing color and priority conventions
- Backward compatibility maintained for existing edge types and node structures

https://claude.ai/code/session_01ArJZBQe7v6cfAhkZS9Whdw