### PR TITLE
Implement claim ID canonicalization contract (issue #340)

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -368,6 +369,13 @@ class ExportValidationGate:
 
         # 6. Required artifact presence
         self._check_required_artifacts(artifacts, errors)
+
+        # 6b. provisional claim ref leakage (#340): equation_semantics /
+        # derivation_chain must not carry claim refs that are absent from the
+        # final claims.json. Reported as warnings (review metadata), never a
+        # hard block — the root-cause canonicalization happens upstream.
+        if claim_objects is not None:
+            self._check_unresolved_claim_refs(artifacts, claim_objects, warnings)
 
         # 7. source-backed claim must reference EvidenceRegistry (#257 / #312).
         # Per #312 these are hard errors regardless of the code path (freshly
@@ -1290,6 +1298,92 @@ class ExportValidationGate:
             and plain_text is None
             and extraction_status in ("partial", "fragment_only", "label_only", "missing", "unparsed")
         )
+
+    # Provisional / pre-canonical claim ID patterns (issue #340). Mirrors the
+    # export-side _LEGACY_REF_PATTERNS so the pipeline catches the same leaks.
+    _PROVISIONAL_CLAIM_REF_PATTERNS = (
+        re.compile(r"^claim_span_"),
+        re.compile(r"^claim:[^:]+:[^:]+$"),
+        re.compile(r"^claim::"),
+    )
+
+    @classmethod
+    def _looks_provisional_claim_ref(cls, ref: str) -> bool:
+        return any(p.match(ref) for p in cls._PROVISIONAL_CLAIM_REF_PATTERNS)
+
+    def _check_unresolved_claim_refs(
+        self,
+        artifacts: dict,
+        claim_objects,
+        warnings: list,
+    ) -> None:
+        """Report claim refs in equations / derivations absent from claims.json (#340).
+
+        The claim_object_builder stage is the source of truth for claim IDs. Any
+        claim ref carried by equation_semantics or derivation_chain that is not in
+        the final claim set (or that still looks provisional) indicates a broken
+        artifact ID contract. These are surfaced as warnings so they show up in
+        export_validation review metadata without blocking persist.
+        """
+        final_claim_ids = {
+            str(getattr(c, "claim_id", "") or "")
+            for c in (getattr(claim_objects, "claims", []) or [])
+            if getattr(c, "claim_id", None)
+        }
+
+        def report(refs, artifact: str, path: str) -> None:
+            for ref in refs or []:
+                ref_id = str(ref)
+                if not ref_id:
+                    continue
+                if ref_id in final_claim_ids:
+                    continue
+                provisional = self._looks_provisional_claim_ref(ref_id)
+                warnings.append(ValidationEntry(
+                    code=(
+                        "PROVISIONAL_CLAIM_REF_IN_ARTIFACT"
+                        if provisional
+                        else "UNRESOLVED_CLAIM_REF_IN_ARTIFACT"
+                    ),
+                    message=(
+                        f"{path} references claim {ref_id!r} which is not in the final "
+                        "claims.json claim set"
+                    ),
+                    artifact=artifact,
+                    path=path,
+                    source_stage="export_validation",
+                ))
+
+        equations = artifacts.get("equation_semantics") or {}
+        if isinstance(equations, dict):
+            for idx, eq in enumerate(equations.get("equations") or []):
+                if not isinstance(eq, dict):
+                    continue
+                report(
+                    eq.get("linked_claim_ids"),
+                    "equation_semantics",
+                    f"$.equations[{idx}].linked_claim_ids",
+                )
+
+        derivations = artifacts.get("derivation_chain") or {}
+        if isinstance(derivations, dict):
+            for chain_idx, chain in enumerate(derivations.get("chains") or []):
+                if not isinstance(chain, dict):
+                    continue
+                for step_idx, step in enumerate(chain.get("steps") or []):
+                    if not isinstance(step, dict):
+                        continue
+                    for key in (
+                        "required_claim_ids",
+                        "input_claim_ids",
+                        "output_claim_ids",
+                        "claim_ids",
+                    ):
+                        report(
+                            step.get(key),
+                            "derivation_chain",
+                            f"$.chains[{chain_idx}].steps[{step_idx}].{key}",
+                        )
 
     def _check_derivation_equation_confidence(
         self,

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -597,6 +597,26 @@ def run_document_pipeline(
         if finish_target_stage("claim_object_builder", {"claims": len(getattr(claim_objects, "claims", []) or []), "total": 1, "processed": 1}):
             return result
 
+        # ── Stage 8c.1: claim ID canonicalization contract (issue #340) ────
+        # claim_object_builder is the source of truth for claim IDs. Re-map or
+        # drop any provisional claim refs still carried by equation_semantics so
+        # the downstream derivation_chain / component / graph / export artifacts
+        # only ever reference final claim IDs (or nothing). Dropped refs are kept
+        # as review warnings — we never silently retain an unresolved ref.
+        try:
+            eq_dropped = _canonicalize_equation_claim_links(equations, claim_objects)
+            if eq_dropped:
+                save_artifact("equation_semantics", equations)
+                logger.info(
+                    "Canonicalized equation claim links for document %s: dropped provisional refs on %d equation(s)",
+                    document_id, len(eq_dropped),
+                )
+        except Exception:
+            logger.warning(
+                "equation claim-link canonicalization failed (non-fatal): document=%s",
+                document_id, exc_info=True,
+            )
+
         # ── Stage 8d: derivation_chain (deterministic from equation links) ─
         derivation_artifact = artifact("derivation_chain")
         if should_use_artifact("derivation_chain"):
@@ -619,6 +639,23 @@ def run_document_pipeline(
                 )
                 derivations = _empty_derivation_chain_result(document_id, cartridge_id)
             save_artifact("derivation_chain", derivations)
+        # Defensive canonicalization (issue #340): even though equations were
+        # canonicalized before this stage, re-resolve every derivation step's
+        # claim refs against the final claim set so no provisional claim ID can
+        # reach component / graph / export from a resumed or stale artifact.
+        try:
+            deriv_dropped = _canonicalize_derivation_claim_refs(derivations, claim_objects)
+            if deriv_dropped:
+                save_artifact("derivation_chain", derivations)
+                logger.info(
+                    "Canonicalized derivation claim refs for document %s: dropped provisional refs on %d step(s)",
+                    document_id, len(deriv_dropped),
+                )
+        except Exception:
+            logger.warning(
+                "derivation claim-ref canonicalization failed (non-fatal): document=%s",
+                document_id, exc_info=True,
+            )
         report_done("derivation_chain", {
             "chains": len(getattr(derivations, "chains", []) or []),
             "total": 1,
@@ -1268,6 +1305,64 @@ def _build_derivation_chains(
         claim_build_result=claim_objects,
         evidence_registry=evidence,
     )
+
+
+def _canonicalize_equation_claim_links(equations: Any, claim_objects: Any) -> list[dict]:
+    """Strip provisional claim refs from equation_semantics (issue #340).
+
+    Resolves each equation's ``linked_claim_ids`` against the final claim set
+    produced by claim_object_builder, dropping any that don't resolve and
+    recording them as warning-level validation issues on the equations result.
+    Returns the dropped-ref report (empty when nothing changed).
+    """
+    from episteme_graph.agents.equation_semantics.schema import (
+        ValidationIssue as EqValidationIssue,
+    )
+    from episteme_graph.agents.id_canonicalization import (
+        canonicalize_equation_claim_links,
+    )
+
+    dropped = canonicalize_equation_claim_links(equations, claim_objects)
+    for entry in dropped:
+        equations.validation_issues.append(EqValidationIssue(
+            rule_id="unresolved_claim_ref_dropped",
+            severity="warning",
+            message=(
+                f"equation {entry['equation_id']!r} dropped provisional claim ref(s) "
+                f"not present in claims.json: {entry['dropped_claim_ids']}"
+            ),
+            field=entry["equation_id"],
+        ))
+    return dropped
+
+
+def _canonicalize_derivation_claim_refs(derivations: Any, claim_objects: Any) -> list[dict]:
+    """Strip provisional claim refs from derivation_chain steps (issue #340).
+
+    Resolves every step's claim reference fields against the final claim set,
+    dropping unresolved refs and recording them as warning-level validation
+    issues on the derivation result. Returns the dropped-ref report.
+    """
+    from episteme_graph.agents.derivation_chain.schema import (
+        ValidationIssue as DerivValidationIssue,
+    )
+    from episteme_graph.agents.id_canonicalization import (
+        canonicalize_derivation_claim_refs,
+    )
+
+    dropped = canonicalize_derivation_claim_refs(derivations, claim_objects)
+    for entry in dropped:
+        derivations.validation_issues.append(DerivValidationIssue(
+            rule_id="unresolved_claim_ref_dropped",
+            severity="warning",
+            message=(
+                f"derivation {entry['derivation_id']!r} step {entry['step_id']!r} "
+                f"dropped provisional claim ref(s) not present in claims.json: "
+                f"{entry['dropped_claim_ids']}"
+            ),
+            field=entry["derivation_id"],
+        ))
+    return dropped
 
 
 def _empty_derivation_chain_result(document_id: str, cartridge_id: str | None):

--- a/backend/tests/test_claim_id_canonicalization_pipeline.py
+++ b/backend/tests/test_claim_id_canonicalization_pipeline.py
@@ -1,0 +1,164 @@
+"""Pipeline-level claim ID canonicalization contract (issue #340).
+
+Exercises the orchestrator helpers that re-map / drop provisional claim refs on
+equation_semantics and derivation_chain against the final claim set produced by
+claim_object_builder, recording dropped refs as review warnings.
+"""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from core.document_pipeline import orchestrator
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+from episteme_graph.agents.equation_semantics.schema import (
+    EquationConfidencePolicy,
+    EquationReconstruction,
+    EquationRecord,
+    EquationSemantics,
+    EquationSemanticsResult,
+    EquationSourceExtraction,
+)
+
+
+@dataclass
+class _Claim:
+    claim_id: str
+    source_span_ids: list = field(default_factory=list)
+    section_id: str | None = None
+
+
+@dataclass
+class _ClaimObjects:
+    claims: list = field(default_factory=list)
+
+
+def _equation(eq_id: str, linked_claim_ids: list[str]) -> EquationRecord:
+    src = EquationSourceExtraction(
+        raw_text="x = y",
+        latex=None,
+        plain_text=None,
+        source_location={"block_id": f"blk_{eq_id}", "section_id": "sec_1"},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+        needs_math_review=False,
+        review_reason=[],
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type="relation",
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason="",
+        defined_symbols=[],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=list(linked_claim_ids),
+        summary="",
+        review_flags=[],
+    )
+    cp = EquationConfidencePolicy.derive(src, rec, sem)
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id="doc",
+        label=eq_id,
+        candidate_trace_ids=[],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=cp,
+    )
+
+
+def _equations(*records: EquationRecord) -> EquationSemanticsResult:
+    return EquationSemanticsResult(
+        document_id="doc",
+        cartridge_id=None,
+        equation_candidates=[],
+        equations=list(records),
+    )
+
+
+def _derivations(*steps: DerivationStep) -> DerivationChainResult:
+    chain = DerivationChainRecord(
+        derivation_id="derivation_eq_tex_b62",
+        document_id="doc",
+        source_section_ids=["sec_1"],
+        steps=list(steps),
+    )
+    return DerivationChainResult(document_id="doc", cartridge_id=None, chains=[chain])
+
+
+# ---------------------------------------------------------------------------
+# Issue #340 acceptance: claims empty → no claim_span_* left downstream
+# ---------------------------------------------------------------------------
+
+def test_equation_links_purged_when_claims_empty_and_warning_recorded():
+    equations = _equations(
+        _equation("eq_tex_b62", ["claim_span_001_5_sub07", "claim_span_001_5_sub08"])
+    )
+    claim_objects = _ClaimObjects(claims=[])
+
+    dropped = orchestrator._canonicalize_equation_claim_links(equations, claim_objects)
+
+    assert equations.equations[0].semantics.linked_claim_ids == []
+    assert dropped
+    assert any(
+        i.rule_id == "unresolved_claim_ref_dropped"
+        for i in equations.validation_issues
+    )
+
+
+def test_derivation_refs_purged_when_claims_empty_and_warning_recorded():
+    step = DerivationStep(
+        step_id="step_001",
+        input_equation_ids=["eq_tex_b62"],
+        operation="derive_result",
+        output_equation_ids=["eq_tex_b62"],
+        required_claim_ids=["claim_span_001_5_sub07"],
+        output_claim_ids=["claim_span_001_5_sub08"],
+    )
+    derivations = _derivations(step)
+    claim_objects = _ClaimObjects(claims=[])
+
+    dropped = orchestrator._canonicalize_derivation_claim_refs(derivations, claim_objects)
+
+    s = derivations.chains[0].steps[0]
+    assert s.required_claim_ids == []
+    assert s.output_claim_ids == []
+    assert dropped
+    assert any(
+        i.rule_id == "unresolved_claim_ref_dropped"
+        for i in derivations.validation_issues
+    )
+
+
+def test_provisional_refs_remapped_to_final_claim_id():
+    equations = _equations(_equation("eq_1", ["claim_span_001"]))
+    claim_objects = _ClaimObjects(
+        claims=[_Claim("claim_final", source_span_ids=["span_001"], section_id="sec_1")]
+    )
+
+    dropped = orchestrator._canonicalize_equation_claim_links(equations, claim_objects)
+
+    assert equations.equations[0].semantics.linked_claim_ids == ["claim_final"]
+    assert dropped == []
+    assert all(
+        i.rule_id != "unresolved_claim_ref_dropped"
+        for i in equations.validation_issues
+    )

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1078,6 +1078,16 @@ def test_orchestrator_runs_newly_integrated_agents_and_saves_artifacts():
         review_reason: list = field(default_factory=list)
 
     @dataclass
+    class _ConfidencePolicy:
+        can_be_used_in_derivation: bool = True
+        can_support_claim: bool = True
+        can_be_rendered_as_final_formula: bool = True
+        allowed_downstream_use: str = "unrestricted"
+        can_be_displayed_in_course: bool = True
+        display_requires_note: bool = False
+        must_not_treat_as_source_extracted: bool = False
+
+    @dataclass
     class _EquationRecord:
         equation_id: str
         document_id: str = "doc-int"
@@ -1086,7 +1096,7 @@ def test_orchestrator_runs_newly_integrated_agents_and_saves_artifacts():
         source_extraction: _EquationSourceExtraction = field(default_factory=_EquationSourceExtraction)
         reconstruction: object = None
         semantics: _EquationSemantics = field(default_factory=_EquationSemantics)
-        confidence_policy: object = None
+        confidence_policy: object = field(default_factory=_ConfidencePolicy)
 
     @dataclass
     class _Component:

--- a/backend/tests/test_lecture_studio.py
+++ b/backend/tests/test_lecture_studio.py
@@ -226,6 +226,17 @@ class TestLectureStudioModeUI:
         assert "lsScopeHasDocumentContext" in js
         assert 'lsState.view === "graph"' in js
 
+    def test_theory_graph_top_tab_opens_graph_view(self):
+        """The document-structure theory graph entry should open the graph, not an empty claims view."""
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[2]
+        html = (root / "frontend" / "public" / "admin.html").read_text(encoding="utf-8")
+        js = (root / "frontend" / "public" / "js" / "admin.js").read_text(encoding="utf-8")
+        assert '<button class="ls-work-tab" data-ls-view="graph" hidden>理論グラフ</button>' in html
+        assert 'if (lsState.leftTab === "document") return ["edit", "structure", "graph"];' in js
+        assert 'var topView = lsIsTheoryGraphView(view) ? "graph" : view;' in js
+
     def test_course_draft_check_question_detail_fields_exist(self):
         from pathlib import Path
 

--- a/frontend/public/admin.html
+++ b/frontend/public/admin.html
@@ -226,7 +226,7 @@
             <div class="ls-work-tabs" id="ls-work-tabs">
               <button class="ls-work-tab active" data-ls-view="edit">原稿</button>
               <button class="ls-work-tab" data-ls-view="structure" hidden>構造</button>
-              <button class="ls-work-tab" data-ls-view="claims" hidden>理論グラフ</button>
+              <button class="ls-work-tab" data-ls-view="graph" hidden>理論グラフ</button>
             </div>
             <div class="ls-work-tabs ls-theory-graph-tabs" id="ls-theory-graph-tabs" hidden>
               <button class="ls-work-tab active" data-ls-view="claims">主張</button>

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -3055,7 +3055,7 @@
 
   function lsTopWorkViewsForCurrentMode() {
     if (lsState.leftTab === "course") return ["edit"];
-    if (lsState.leftTab === "document") return ["edit", "structure", "claims"];
+    if (lsState.leftTab === "document") return ["edit", "structure", "graph"];
     return [];
   }
 
@@ -3075,7 +3075,7 @@
       view = "edit";
       lsState.view = view;
     }
-    var topView = lsIsTheoryGraphView(view) ? "claims" : view;
+    var topView = lsIsTheoryGraphView(view) ? "graph" : view;
     var topTabs = document.getElementById("ls-work-tabs");
     var topViews = lsTopWorkViewsForCurrentMode();
     if (topTabs) {

--- a/src/episteme_graph/agents/id_canonicalization.py
+++ b/src/episteme_graph/agents/id_canonicalization.py
@@ -74,6 +74,141 @@ def canonicalize_claim_refs(
     }
 
 
+def canonical_claim_id_set(claim_objects: Any | None) -> set[str]:
+    """Return the set of final claim IDs from a ClaimObjectBuildResult-like object.
+
+    ClaimObjectBuilder is the single source of truth for claim IDs after the
+    claim_object_builder stage (issue #340). Downstream artifacts may only
+    reference IDs in this set; anything else is a provisional/unresolved ref.
+    """
+    ids: set[str] = set()
+    for claim in getattr(claim_objects, "claims", []) or []:
+        cid = str(getattr(claim, "claim_id", "") or "")
+        if cid:
+            ids.add(cid)
+    return ids
+
+
+def filter_claim_ref_list(
+    refs: Any,
+    claim_objects: Any | None,
+    extra_aliases: dict[str, str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Resolve claim refs to canonical IDs, dropping any that don't resolve (issue #340).
+
+    Each ref is mapped through the canonicalization lookup / aliases. A ref is
+    kept (in canonical form) only when it resolves to an ID present in the final
+    claim set; otherwise it is reported as dropped. When ``claim_objects`` is
+    ``None`` the canonicalization context is unknown, so refs are returned
+    unchanged (standalone / partial-pipeline behaviour).
+
+    Returns ``(kept_canonical_ids, dropped_original_refs)``.
+    """
+    if claim_objects is None:
+        return [str(r) for r in (refs or [])], []
+
+    lookup = _claim_lookup(claim_objects)
+    aliases = dict(extra_aliases or {})
+    final_ids = canonical_claim_id_set(claim_objects)
+
+    kept: list[str] = []
+    dropped: list[str] = []
+    for ref in refs or []:
+        value = str(ref)
+        mapped = (
+            aliases.get(value)
+            or lookup.get(("id", value))
+            or lookup.get(("legacy", value))
+            or value
+        )
+        if mapped in final_ids:
+            if mapped not in kept:
+                kept.append(mapped)
+        elif value not in dropped:
+            dropped.append(value)
+    return kept, dropped
+
+
+def canonicalize_equation_claim_links(
+    equations: Any,
+    claim_objects: Any | None,
+    extra_aliases: dict[str, str] | None = None,
+) -> list[dict]:
+    """Rewrite equation ``semantics.linked_claim_ids`` to canonical claim IDs (issue #340).
+
+    Mutates each EquationRecord in place so that ``linked_claim_ids`` only holds
+    IDs present in the final claim set. Provisional / unresolved refs are removed
+    and reported so the caller can keep them as review metadata.
+
+    Returns a list of ``{"equation_id", "dropped_claim_ids"}`` for equations that
+    lost references.
+    """
+    dropped_report: list[dict] = []
+    for eq in getattr(equations, "equations", []) or []:
+        sem = getattr(eq, "semantics", None)
+        if sem is None:
+            continue
+        refs = list(getattr(sem, "linked_claim_ids", []) or [])
+        if not refs:
+            continue
+        kept, dropped = filter_claim_ref_list(refs, claim_objects, extra_aliases)
+        if kept != refs:
+            sem.linked_claim_ids = kept
+        if dropped:
+            dropped_report.append({
+                "equation_id": str(getattr(eq, "equation_id", "") or ""),
+                "dropped_claim_ids": dropped,
+            })
+    return dropped_report
+
+
+_DERIVATION_STEP_CLAIM_FIELDS = (
+    "required_claim_ids",
+    "input_claim_ids",
+    "output_claim_ids",
+    "claim_ids",
+)
+
+
+def canonicalize_derivation_claim_refs(
+    derivations: Any,
+    claim_objects: Any | None,
+    extra_aliases: dict[str, str] | None = None,
+) -> list[dict]:
+    """Rewrite derivation step claim refs to canonical claim IDs (issue #340).
+
+    Mutates each DerivationStep in place so that its claim reference fields only
+    hold IDs present in the final claim set. Provisional / unresolved refs are
+    removed and reported.
+
+    Returns a list of ``{"derivation_id", "step_id", "dropped_claim_ids"}`` for
+    steps that lost references.
+    """
+    dropped_report: list[dict] = []
+    for chain in getattr(derivations, "chains", []) or []:
+        for step in getattr(chain, "steps", []) or []:
+            step_dropped: list[str] = []
+            for field_name in _DERIVATION_STEP_CLAIM_FIELDS:
+                if not hasattr(step, field_name):
+                    continue
+                refs = list(getattr(step, field_name) or [])
+                if not refs:
+                    continue
+                kept, dropped = filter_claim_ref_list(refs, claim_objects, extra_aliases)
+                if kept != refs:
+                    setattr(step, field_name, kept)
+                for ref in dropped:
+                    if ref not in step_dropped:
+                        step_dropped.append(ref)
+            if step_dropped:
+                dropped_report.append({
+                    "derivation_id": str(getattr(chain, "derivation_id", "") or ""),
+                    "step_id": str(getattr(step, "step_id", "") or ""),
+                    "dropped_claim_ids": step_dropped,
+                })
+    return dropped_report
+
+
 def claim_aliases_from_accepted_claims(accepted_claims: list[dict]) -> dict[str, str]:
     """Build legacy/ref aliases from LLM input claims."""
     aliases: dict[str, str] = {}

--- a/src/tests/agents/test_claim_id_canonicalization.py
+++ b/src/tests/agents/test_claim_id_canonicalization.py
@@ -1,0 +1,230 @@
+"""Tests for cross-artifact claim ID canonicalization (issue #340).
+
+The claim_object_builder stage is the single source of truth for claim IDs.
+Provisional ``claim_span_*`` refs left on equation_semantics / derivation_chain
+must be re-mapped to the final claim ID or dropped (and reported), never kept.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from episteme_graph.agents.id_canonicalization import (
+    canonical_claim_id_set,
+    canonicalize_derivation_claim_refs,
+    canonicalize_equation_claim_links,
+    filter_claim_ref_list,
+)
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+from episteme_graph.agents.equation_semantics.schema import (
+    EquationConfidencePolicy,
+    EquationReconstruction,
+    EquationRecord,
+    EquationSemantics,
+    EquationSemanticsResult,
+    EquationSourceExtraction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal claim_objects stub
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Claim:
+    claim_id: str
+    source_span_ids: list = field(default_factory=list)
+    section_id: str | None = None
+
+
+@dataclass
+class _ClaimObjects:
+    claims: list = field(default_factory=list)
+
+
+def _eq(eq_id: str, linked_claim_ids: list[str]) -> EquationRecord:
+    src = EquationSourceExtraction(
+        raw_text="x = y",
+        latex=None,
+        plain_text=None,
+        source_location={"block_id": f"blk_{eq_id}", "section_id": "sec_1"},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+        needs_math_review=False,
+        review_reason=[],
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type="relation",
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason="",
+        defined_symbols=[],
+        used_symbols=[],
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=list(linked_claim_ids),
+        summary="",
+        review_flags=[],
+    )
+    cp = EquationConfidencePolicy.derive(src, rec, sem)
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id="doc",
+        label=eq_id,
+        candidate_trace_ids=[],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=cp,
+    )
+
+
+def _equations(*records: EquationRecord) -> EquationSemanticsResult:
+    return EquationSemanticsResult(
+        document_id="doc",
+        cartridge_id=None,
+        equation_candidates=[],
+        equations=list(records),
+    )
+
+
+def _derivations(*steps: DerivationStep) -> DerivationChainResult:
+    chain = DerivationChainRecord(
+        derivation_id="derivation_eq_2",
+        document_id="doc",
+        source_section_ids=["sec_1"],
+        steps=list(steps),
+    )
+    return DerivationChainResult(document_id="doc", cartridge_id=None, chains=[chain])
+
+
+# ---------------------------------------------------------------------------
+# filter_claim_ref_list / canonical_claim_id_set
+# ---------------------------------------------------------------------------
+
+def test_canonical_claim_id_set():
+    objs = _ClaimObjects(claims=[_Claim("claim_a"), _Claim("claim_b")])
+    assert canonical_claim_id_set(objs) == {"claim_a", "claim_b"}
+
+
+def test_filter_drops_unresolved_refs():
+    objs = _ClaimObjects(claims=[_Claim("claim_real")])
+    kept, dropped = filter_claim_ref_list(
+        ["claim_real", "claim_span_001_5_sub07"], objs
+    )
+    assert kept == ["claim_real"]
+    assert dropped == ["claim_span_001_5_sub07"]
+
+
+def test_filter_remaps_span_provisional_to_final():
+    # A provisional ref keyed by span_id resolves to the final claim ID.
+    objs = _ClaimObjects(
+        claims=[_Claim("claim_final", source_span_ids=["span_001"], section_id="sec_1")]
+    )
+    kept, dropped = filter_claim_ref_list(["claim_span_001"], objs)
+    assert kept == ["claim_final"]
+    assert dropped == []
+
+
+def test_filter_none_claim_objects_is_noop():
+    kept, dropped = filter_claim_ref_list(["claim_span_001"], None)
+    assert kept == ["claim_span_001"]
+    assert dropped == []
+
+
+def test_filter_empty_claims_drops_everything():
+    objs = _ClaimObjects(claims=[])
+    kept, dropped = filter_claim_ref_list(
+        ["claim_span_001_5_sub07", "claim_span_001_5_sub08"], objs
+    )
+    assert kept == []
+    assert dropped == ["claim_span_001_5_sub07", "claim_span_001_5_sub08"]
+
+
+# ---------------------------------------------------------------------------
+# Equation canonicalization (case 1 / 3: empty / unresolved)
+# ---------------------------------------------------------------------------
+
+def test_equation_links_stripped_when_claims_empty():
+    equations = _equations(_eq("eq_tex_b62", ["claim_span_001_5_sub07", "claim_span_001_5_sub08"]))
+    objs = _ClaimObjects(claims=[])
+
+    dropped = canonicalize_equation_claim_links(equations, objs)
+
+    assert equations.equations[0].semantics.linked_claim_ids == []
+    assert dropped == [{
+        "equation_id": "eq_tex_b62",
+        "dropped_claim_ids": ["claim_span_001_5_sub07", "claim_span_001_5_sub08"],
+    }]
+
+
+def test_equation_links_remapped_when_resolvable():
+    equations = _equations(_eq("eq_1", ["claim_span_001"]))
+    objs = _ClaimObjects(
+        claims=[_Claim("claim_final", source_span_ids=["span_001"], section_id="sec_1")]
+    )
+
+    dropped = canonicalize_equation_claim_links(equations, objs)
+
+    assert equations.equations[0].semantics.linked_claim_ids == ["claim_final"]
+    assert dropped == []
+
+
+# ---------------------------------------------------------------------------
+# Derivation canonicalization (case 1 / 3)
+# ---------------------------------------------------------------------------
+
+def test_derivation_claim_refs_stripped_when_claims_empty():
+    step = DerivationStep(
+        step_id="step_001",
+        input_equation_ids=["eq_tex_b62"],
+        operation="derive_result",
+        output_equation_ids=["eq_tex_b62"],
+        required_claim_ids=["claim_span_001_5_sub07", "claim_span_001_5_sub08"],
+        input_claim_ids=[],
+        output_claim_ids=["claim_span_001_5_sub08"],
+    )
+    derivations = _derivations(step)
+    objs = _ClaimObjects(claims=[])
+
+    dropped = canonicalize_derivation_claim_refs(derivations, objs)
+
+    s = derivations.chains[0].steps[0]
+    assert s.required_claim_ids == []
+    assert s.output_claim_ids == []
+    assert len(dropped) == 1
+    assert dropped[0]["derivation_id"] == "derivation_eq_2"
+    assert set(dropped[0]["dropped_claim_ids"]) == {
+        "claim_span_001_5_sub07",
+        "claim_span_001_5_sub08",
+    }
+
+
+def test_derivation_claim_refs_remapped_when_resolvable():
+    step = DerivationStep(
+        step_id="step_001",
+        input_equation_ids=["eq_1"],
+        operation="derive_result",
+        output_equation_ids=["eq_2"],
+        required_claim_ids=["claim_span_001"],
+        output_claim_ids=["claim_span_001"],
+    )
+    derivations = _derivations(step)
+    objs = _ClaimObjects(
+        claims=[_Claim("claim_final", source_span_ids=["span_001"], section_id="sec_1")]
+    )
+
+    dropped = canonicalize_derivation_claim_refs(derivations, objs)
+
+    s = derivations.chains[0].steps[0]
+    assert s.required_claim_ids == ["claim_final"]
+    assert s.output_claim_ids == ["claim_final"]
+    assert dropped == []

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1238,3 +1238,65 @@ def test_teaching_output_blueprint_dangling_ref_is_hard_error():
     result = _run_gate(component_result=_BundleComponentResult([comp], block))
     assert result.teaching_output_validation["blueprint_refs_valid"] is False
     assert any(e.code == "TEACHING_OUTPUT_BLUEPRINT_DANGLING_REF" for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Tests: provisional claim ref leakage in pipeline artifacts (issue #340)
+# ---------------------------------------------------------------------------
+
+def test_provisional_claim_ref_in_equation_is_warned():
+    """equation linked_claim_ids not in claims.json → warning, not a hard error."""
+    artifacts = _make_artifacts(
+        equation_semantics={
+            "equations": [
+                {"equation_id": "eq_tex_b62",
+                 "linked_claim_ids": ["claim_span_001_5_sub07"]},
+            ],
+            "validation_issues": [],
+        },
+    )
+    result = _run_gate(artifacts=artifacts, claim_objects=_ClaimObjectResult([]))
+    assert any(
+        w.code == "PROVISIONAL_CLAIM_REF_IN_ARTIFACT"
+        and w.artifact == "equation_semantics"
+        for w in result.warnings
+    )
+    # Reported, but never a hard block.
+    assert all(e.code != "PROVISIONAL_CLAIM_REF_IN_ARTIFACT" for e in result.errors)
+
+
+def test_provisional_claim_ref_in_derivation_is_warned():
+    artifacts = _make_artifacts(
+        derivation_chain={
+            "chains": [
+                {"derivation_id": "derivation_eq_2", "steps": [
+                    {"step_id": "step_001",
+                     "required_claim_ids": ["claim_span_001_5_sub07"],
+                     "output_claim_ids": ["claim_span_001_5_sub08"]},
+                ]},
+            ],
+            "validation_issues": [],
+        },
+    )
+    result = _run_gate(artifacts=artifacts, claim_objects=_ClaimObjectResult([]))
+    codes = {w.code for w in result.warnings if w.artifact == "derivation_chain"}
+    assert "PROVISIONAL_CLAIM_REF_IN_ARTIFACT" in codes
+
+
+def test_resolved_claim_refs_produce_no_leak_warning():
+    artifacts = _make_artifacts(
+        equation_semantics={
+            "equations": [
+                {"equation_id": "eq_1", "linked_claim_ids": ["claim_abc"]},
+            ],
+            "validation_issues": [],
+        },
+    )
+    result = _run_gate(
+        artifacts=artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_abc")]),
+    )
+    assert all(
+        w.code not in ("PROVISIONAL_CLAIM_REF_IN_ARTIFACT", "UNRESOLVED_CLAIM_REF_IN_ARTIFACT")
+        for w in result.warnings
+    )


### PR DESCRIPTION
## Summary

Enforce a strict claim ID canonicalization contract across the document pipeline to prevent provisional/unresolved claim references from leaking into downstream artifacts. The `claim_object_builder` stage is established as the single source of truth for claim IDs; all provisional `claim_span_*` refs in `equation_semantics` and `derivation_chain` are re-mapped to final claim IDs or dropped and reported as review warnings.

## Key Changes

### Core Canonicalization Logic (`src/episteme_graph/agents/id_canonicalization.py`)

- **`canonical_claim_id_set()`**: Extract the set of final claim IDs from a `ClaimObjectBuildResult`-like object
- **`filter_claim_ref_list()`**: Resolve claim refs to canonical IDs using the claim lookup table, dropping any that don't resolve to the final claim set. Returns `(kept_canonical_ids, dropped_original_refs)` tuple
- **`canonicalize_equation_claim_links()`**: Mutate `equation_semantics.linked_claim_ids` in place, stripping provisional refs and returning a dropped-ref report
- **`canonicalize_derivation_claim_refs()`**: Mutate all claim reference fields in derivation steps (`required_claim_ids`, `input_claim_ids`, `output_claim_ids`, `claim_ids`), returning dropped-ref report

### Pipeline Integration (`backend/core/document_pipeline/orchestrator.py`)

- **Stage 8c.1 (post-claim_object_builder)**: Call `_canonicalize_equation_claim_links()` to re-map equation claim links before derivation_chain generation
- **Stage 8d (post-derivation_chain)**: Defensively call `_canonicalize_derivation_claim_refs()` to catch any stale/resumed artifacts
- **Wrapper functions**: `_canonicalize_equation_claim_links()` and `_canonicalize_derivation_claim_refs()` convert dropped-ref reports into warning-level `ValidationIssue` entries with rule_id `"unresolved_claim_ref_dropped"`

### Export Validation Gate (`backend/core/document_pipeline/export_validation_gate.py`)

- **`_check_unresolved_claim_refs()`**: Secondary validation gate that scans exported artifacts for any claim refs absent from the final claims.json
- **Provisional ref detection**: Pattern matching for `claim_span_*`, `claim:*:*`, and `claim::*` formats
- **Dual reporting**: Distinguishes `PROVISIONAL_CLAIM_REF_IN_ARTIFACT` (still looks provisional) from `UNRESOLVED_CLAIM_REF_IN_ARTIFACT` (resolved but missing)
- **Non-blocking warnings**: Reported as warnings, never hard errors (root-cause canonicalization happens upstream)

## Test Coverage

### Unit Tests (`src/tests/agents/test_claim_id_canonicalization.py`)

- `test_canonical_claim_id_set()`: Verify final claim ID extraction
- `test_filter_drops_unresolved_refs()`: Unresolved refs are dropped
- `test_filter_remaps_span_provisional_to_final()`: Provisional `claim_span_*` refs resolve to final claim IDs via source_span_ids lookup
- `test_filter_none_claim_objects_is_noop()`: Graceful handling when claim_objects is None (standalone/partial-pipeline)
- `test_equation_links_stripped_when_claims_empty()`: Empty claims → all equation refs dropped
- `test_equation_links_remapped_when_resolvable()`: Resolvable refs are re-mapped
- `test_derivation_claim_refs_stripped_when_claims_empty()`: Empty claims → all derivation refs dropped
- `test_derivation_claim_refs_remapped_when_resolvable()`: Resolvable refs are re-mapped

### Pipeline Tests (`backend/tests/test_claim_id_canonicalization_pipeline.py`)

- `test_equation_links_purged_when_claims_empty_and_warning_recorded()`: Orchestrator integration

https://claude.ai/code/session_01Lheo3xEJrtMxz8bvfspzma