### PR TITLE
Log export validation errors with rule code, artifact, and JSON path

### DIFF
--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -959,6 +959,19 @@ def run_document_pipeline(
                 ),
             )
             result.final_stage = "export_validation"
+            # Log every hard error with its rule code, artifact, and JSON path so
+            # the exact failing rule can be identified from logs alone, without
+            # querying document_analysis_runs.stage_outputs._artifacts (#343).
+            for entry in _iter_export_validation_errors(validation_result_dict):
+                logger.warning(
+                    "ExportValidationGate hard error document=%s material=%s "
+                    "code=%s artifact=%s path=%s message=%s",
+                    document_id, material_id,
+                    entry.get("code") or "UNKNOWN",
+                    entry.get("artifact") or "-",
+                    entry.get("path") or "-",
+                    (entry.get("message") or "").strip(),
+                )
             logger.warning(
                 "ExportValidationGate blocked persist for document=%s: %d error(s)%s",
                 document_id, error_count, error_details,
@@ -1072,17 +1085,31 @@ def _instantiate(agent_class_or_instance):
     return agent_class_or_instance
 
 
-def _summarize_export_validation_errors(validation_result_dict: dict, limit: int = 3) -> str:
+def _iter_export_validation_errors(validation_result_dict: dict) -> list[dict]:
+    """Return the hard-error entries (dicts) from an export_validation result."""
     errors = validation_result_dict.get("errors") or []
-    if not isinstance(errors, list) or not errors:
+    if not isinstance(errors, list):
+        return []
+    return [error for error in errors if isinstance(error, dict)]
+
+
+def _summarize_export_validation_errors(validation_result_dict: dict, limit: int = 3) -> str:
+    errors = _iter_export_validation_errors(validation_result_dict)
+    if not errors:
         return ""
     parts: list[str] = []
     for error in errors[:limit]:
-        if not isinstance(error, dict):
-            continue
         code = str(error.get("code") or "UNKNOWN")
         message = str(error.get("message") or "").strip()
-        parts.append(f"{code}: {message}" if message else code)
+        # Include the owning artifact + JSON path so the failing rule can be
+        # traced to a concrete ID without opening the stored artifact (#343).
+        location = " ".join(
+            str(value)
+            for value in (error.get("artifact"), error.get("path"))
+            if value
+        ).strip()
+        head = f"{code}: {message}" if message else code
+        parts.append(f"{head} [{location}]" if location else head)
     if not parts:
         return ""
     suffix = f"; first_errors={parts}"

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1313,6 +1313,42 @@ def test_export_validation_error_summary_includes_first_errors():
     assert "(+1 more)" in summary
 
 
+def test_export_validation_error_summary_includes_artifact_and_path():
+    """#343: the failing rule must be traceable to a concrete artifact + JSON path."""
+    from core.document_pipeline.orchestrator import _summarize_export_validation_errors
+
+    summary = _summarize_export_validation_errors({
+        "errors": [
+            {
+                "code": "COMPONENT_MISSING_INTERNAL_FLOW",
+                "message": "component 'c1' has no internal_flow",
+                "artifact": "component_assembly",
+                "path": "$.components[c1].internal_flow",
+            },
+        ]
+    })
+
+    assert "COMPONENT_MISSING_INTERNAL_FLOW: component 'c1' has no internal_flow" in summary
+    assert "component_assembly $.components[c1].internal_flow" in summary
+
+
+def test_iter_export_validation_errors_skips_non_dict_entries():
+    from core.document_pipeline.orchestrator import _iter_export_validation_errors
+
+    entries = _iter_export_validation_errors({
+        "errors": [
+            {"code": "A"},
+            "not-a-dict",
+            None,
+            {"code": "B"},
+        ]
+    })
+
+    assert [e.get("code") for e in entries] == ["A", "B"]
+    assert _iter_export_validation_errors({}) == []
+    assert _iter_export_validation_errors({"errors": None}) == []
+
+
 # --- issue #282: GROBID integration ----------------------------------------
 
 


### PR DESCRIPTION
## Summary

Improve observability of export validation failures by logging detailed error information (rule code, artifact ID, and JSON path) directly to logs, eliminating the need to query `document_analysis_runs.stage_outputs._artifacts` to identify failing rules.

Addresses #343.

## Changes

- **New helper function `_iter_export_validation_errors()`**: Extracts and filters hard-error entries from validation results, skipping non-dict entries and handling edge cases (missing/null errors list).

- **Enhanced error logging in `finish_target_stage()`**: Added a loop that logs each hard error with:
  - `code`: Rule identifier (e.g., `COMPONENT_MISSING_INTERNAL_FLOW`)
  - `artifact`: Owning artifact name (e.g., `component_assembly`)
  - `path`: JSON path to the failing field (e.g., `$.components[c1].internal_flow`)
  - `message`: Human-readable error description
  
  This allows engineers to trace failing rules from logs alone without database queries.

- **Refactored `_summarize_export_validation_errors()`**: 
  - Now delegates error extraction to `_iter_export_validation_errors()`
  - Enhanced error summary format to include artifact + JSON path in brackets: `CODE: message [artifact path]`
  - Improves traceability in error summaries and logs

## Implementation Details

- The new logging statement uses `logger.warning()` with structured fields for easy parsing and filtering in log aggregation systems.
- Both functions handle malformed input gracefully (non-dict errors, missing/null fields) by returning empty lists or using fallback values (`"UNKNOWN"`, `"-"`).
- Tests added to verify:
  - Error summary includes artifact and JSON path information
  - `_iter_export_validation_errors()` correctly filters out non-dict entries and handles edge cases

https://claude.ai/code/session_01LunjLTQ8HazZGNg8bF363E