### PR TITLE
Fix deterministic fallback to skip non-atomic claims (issue #345)

### DIFF
--- a/src/episteme_graph/agents/component_assembly/repair.py
+++ b/src/episteme_graph/agents/component_assembly/repair.py
@@ -24,6 +24,30 @@ from .schema import (
 logger = logging.getLogger(__name__)
 _MAX_REPAIR_ATTEMPTS = 2
 
+# Atomicity values that disqualify a claim from being a component's primary
+# support. Mirrors export_validation_gate._claim_is_non_atomic / input_builder
+# so the deterministic fallback never emits a component the export gate rejects
+# with NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT (issue #345).
+_NON_ATOMIC_ATOMICITIES = {
+    "composite",
+    "split_required",
+    "compound",
+    "non_atomic",
+    "split_pending",
+}
+
+
+def _claim_row_is_non_atomic(row: dict) -> bool:
+    """Return True for an available_claims row that must not back a component.
+
+    A row is non-atomic when its ``atomicity`` is one of the disqualifying
+    values or ``is_atomic`` is explicitly false. Unknown/missing metadata
+    defaults to atomic (the prior behavior) so legacy rows are still usable.
+    """
+    atomicity = str(row.get("atomicity", "atomic") or "atomic").lower()
+    is_atomic = bool(row.get("is_atomic", atomicity == "atomic"))
+    return atomicity in _NON_ATOMIC_ATOMICITIES or not is_atomic
+
 
 class ComponentAssemblyRepairer:
     def __init__(self, cleanup: ComponentOverlapCleanup | None = None) -> None:
@@ -168,25 +192,37 @@ def make_deterministic_fallback(
     """
     components: list[ComponentRecord] = []
     original_failure_codes = _issue_codes(validation_issues or [])
+    # Only atomic available claims may back a fallback component. Non-atomic
+    # parents (composite / split_required / ...) are dropped so the fallback
+    # never points a component's primary claim support at a non-atomic claim;
+    # any atomic children appear as their own available_claims rows and are
+    # kept (issue #345). accepted_claims is already non-atomic-filtered upstream.
+    atomic_available_claims = [
+        c
+        for c in llm_input.available_claims or []
+        if c.get("claim_id") and not _claim_row_is_non_atomic(c)
+    ]
     evidence_by_claim = {
         str(c.get("claim_id")): list(c.get("source_evidence_ids") or [])
-        for c in llm_input.available_claims or []
-        if c.get("claim_id")
+        for c in atomic_available_claims
     }
     equations_by_claim = {
         str(c.get("claim_id")): list(c.get("equation_ids") or [])
-        for c in llm_input.available_claims or []
-        if c.get("claim_id")
+        for c in atomic_available_claims
     }
+    atomic_accepted_claims = [
+        c
+        for c in llm_input.accepted_claims or []
+        if c.get("claim_id") and not _claim_row_is_non_atomic(c)
+    ]
     accepted_by_claim = {
         str(c.get("claim_id")): c
-        for c in llm_input.accepted_claims or []
-        if c.get("claim_id")
+        for c in atomic_accepted_claims
     }
 
     claim_ids = _ordered_unique(
-        [str(c.get("claim_id")) for c in llm_input.available_claims or [] if c.get("claim_id")]
-        + [str(c.get("claim_id")) for c in llm_input.accepted_claims or [] if c.get("claim_id")]
+        [str(c.get("claim_id")) for c in atomic_available_claims]
+        + [str(c.get("claim_id")) for c in atomic_accepted_claims]
     )
     for idx, claim_id in enumerate(claim_ids[:12], start=1):
         accepted = accepted_by_claim.get(claim_id, {})

--- a/src/tests/agents/component_assembly/test_repair_fallback_atomicity.py
+++ b/src/tests/agents/component_assembly/test_repair_fallback_atomicity.py
@@ -1,0 +1,158 @@
+"""Regression tests for deterministic fallback claim atomicity (issue #345).
+
+The deterministic fallback in ComponentAssemblyRepairer must never build a
+component whose primary claim support points at a non-atomic claim
+(composite / split_required / compound / non_atomic / split_pending). Otherwise
+the final ExportValidationGate rejects the bundle with
+``NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from dataclasses import dataclass, field
+
+from episteme_graph.agents.component_assembly.repair import make_deterministic_fallback
+from episteme_graph.agents.component_assembly.schema import ComponentAssemblyLLMInput
+
+# Import the gate module directly to avoid pulling in sqlalchemy via __init__.py.
+_GATE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "../../../../backend/core/document_pipeline/export_validation_gate.py",
+)
+_spec = importlib.util.spec_from_file_location("export_validation_gate_fallback", _GATE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["export_validation_gate_fallback"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+ExportValidationGate = _mod.ExportValidationGate
+
+
+def _llm_input(available_claims: list[dict]) -> ComponentAssemblyLLMInput:
+    return ComponentAssemblyLLMInput(
+        document_id="doc_test",
+        cartridge_id=None,
+        accepted_claims=[],
+        equations=[],
+        thesis_nodes=[],
+        dsl_nodes=[],
+        dsl_edges=[],
+        allowed_component_types=["ClaimBundleComponent"],
+        allowed_dependency_types=[],
+        available_claims=available_claims,
+    )
+
+
+def _available_claim(claim_id: str, *, atomicity: str = "atomic", is_atomic: bool = True) -> dict:
+    return {
+        "claim_id": claim_id,
+        "claim_type": "result",
+        "text": f"text for {claim_id}",
+        "source_evidence_ids": [f"ev_{claim_id}"],
+        "equation_ids": [],
+        "support_status": "source_backed",
+        "review_status": "source_backed",
+        "atomicity": atomicity,
+        "is_atomic": is_atomic,
+        "split_suggestions": [],
+        "concepts": [],
+        "concept_assignment_status": "ok",
+    }
+
+
+# Minimal claim_objects / evidence stand-ins for driving the export gate's
+# NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT check end-to-end.
+@dataclass
+class _ClaimObj:
+    claim_id: str
+    atomicity: str = "atomic"
+    is_atomic: bool = True
+    source_evidence_ids: list[str] = field(default_factory=list)
+    claim_type: str = "result"
+    support_status: str = "source_backed"
+
+
+@dataclass
+class _Claims:
+    claims: list[_ClaimObj]
+
+
+@dataclass
+class _EvidenceRecord:
+    evidence_id: str
+
+
+@dataclass
+class _Evidence:
+    records: list[_EvidenceRecord]
+
+
+def test_fallback_uses_only_atomic_children_when_composite_parent_present():
+    """A composite parent plus atomic children → fallback uses only the children."""
+    available = [
+        _available_claim("claim_parent", atomicity="composite", is_atomic=False),
+        _available_claim("claim_child_a"),
+        _available_claim("claim_child_b"),
+    ]
+    result = make_deterministic_fallback(_llm_input(available), "Repair failed after max attempts")
+
+    backed = {
+        cid
+        for component in result.components
+        for cid in component.evidence_refs["claim_ids"]
+    }
+    assert backed == {"claim_child_a", "claim_child_b"}
+    # No component refers to the composite parent in any claim-support field.
+    for component in result.components:
+        assert "claim_parent" not in component.evidence_refs["claim_ids"]
+        assert "claim_parent" not in component.linked_claim_ids
+        assert "claim_parent" not in component.supports_claim_ids
+
+
+def test_fallback_skips_when_only_non_atomic_claim_available():
+    """Only a non-atomic claim available → no invalid component is created."""
+    available = [
+        _available_claim("claim_span_001", atomicity="composite", is_atomic=False),
+    ]
+    result = make_deterministic_fallback(_llm_input(available), "Repair failed after max attempts")
+
+    for component in result.components:
+        assert "claim_span_001" not in component.evidence_refs["claim_ids"]
+        assert "claim_span_001" not in component.linked_claim_ids
+        assert "claim_span_001" not in component.supports_claim_ids
+
+    # And the export gate does not fail because of fallback output.
+    claim_objects = _Claims([_ClaimObj("claim_span_001", atomicity="composite", is_atomic=False)])
+    evidence = _Evidence([_EvidenceRecord("ev_claim_span_001")])
+    gate_result = ExportValidationGate().run(
+        artifacts={},
+        component_result=result,
+        claim_objects=claim_objects,
+        evidence=evidence,
+    )
+    assert not any(
+        e.code == "NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT" for e in gate_result.errors
+    )
+
+
+def test_export_gate_still_rejects_explicit_non_atomic_component_support():
+    """The gate stays strict: an explicit non-atomic claim ref still fails."""
+    available = [_available_claim("claim_child_a")]
+    result = make_deterministic_fallback(_llm_input(available), "Repair failed after max attempts")
+    # Force a component to explicitly cite a non-atomic claim (not via fallback).
+    result.components[0].evidence_refs["claim_ids"] = ["claim_bad"]
+    result.components[0].linked_claim_ids = ["claim_bad"]
+    result.components[0].supports_claim_ids = ["claim_bad"]
+
+    claim_objects = _Claims([_ClaimObj("claim_bad", atomicity="composite", is_atomic=False)])
+    evidence = _Evidence([_EvidenceRecord("ev_claim_child_a")])
+    gate_result = ExportValidationGate().run(
+        artifacts={},
+        component_result=result,
+        claim_objects=claim_objects,
+        evidence=evidence,
+    )
+    assert any(
+        e.code == "NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT" for e in gate_result.errors
+    )


### PR DESCRIPTION
## Summary

Fixes a regression in `ComponentAssemblyRepairer.make_deterministic_fallback()` where non-atomic claims (composite, split_required, compound, non_atomic, split_pending) could be used as a component's primary claim support. This caused the `ExportValidationGate` to reject bundles with `NON_ATOMIC_CLAIM_USED_AS_COMPONENT_SUPPORT` errors.

The deterministic fallback now filters out non-atomic claims before building components, ensuring only atomic claims can back component support.

## Key Changes

- **Added `_claim_row_is_non_atomic()` helper** in `repair.py`: Checks both the `atomicity` field (against a set of disqualifying values) and the `is_atomic` boolean flag to determine if a claim row must not back a component.

- **Updated `make_deterministic_fallback()`** to filter both `available_claims` and `accepted_claims` through the new atomicity check before constructing:
  - `evidence_by_claim` and `equations_by_claim` mappings
  - `accepted_by_claim` mapping
  - The final `claim_ids` list used to generate components

- **Added comprehensive regression tests** in `test_repair_fallback_atomicity.py`:
  - Verifies fallback uses only atomic children when a composite parent is present
  - Confirms no invalid component is created when only non-atomic claims are available
  - Validates that the export gate still rejects explicit non-atomic claim references (gate remains strict)

## Implementation Details

The fix mirrors the atomicity checks already present in `export_validation_gate.py` and `input_builder.py`, ensuring the deterministic fallback never emits a component that the export gate would reject. Non-atomic parents (e.g., composite claims) are dropped entirely, while their atomic children (if present as separate rows in `available_claims`) are retained and used normally.

Unknown or missing atomicity metadata defaults to atomic (preserving backward compatibility with legacy rows).

https://claude.ai/code/session_01M6wHRJnfyENYSzK7ediXVe