### PR TITLE
Deterministic fallback handling for component assembly (#347)

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -216,6 +216,73 @@ def _load_analysis_artifacts(session: Any, document_ids: list[str]) -> dict[str,
     return out
 
 
+_COMPONENT_ASSEMBLY_DIAG_KEY_PREFIXES = (
+    "fallback_reason",
+    "original_failure_codes",
+    "component_assembly_input_validation",
+    "initial_llm_exception",
+    "initial_llm_raw_output",
+    "initial_validation_issues",
+    "initial_error_codes",
+    "initial_llm_output_component_count",
+    "parsed_component_count",
+    "cleanup_component_count",
+    "enriched_component_count",
+    "repair_attempt_",
+)
+
+
+def _build_component_assembly_debug(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+    include_llm_raw: bool = False,
+) -> list[dict]:
+    """component_assembly artifact の diagnostics を debug export 用に整形する (#347)。
+
+    fallback 原因調査に必要な issue code / count / validation_issues を含める。
+    raw LLM テキストはサイズ・機微情報の懸念があるため include_llm_raw が
+    真のときのみ含める（parsed JSON の component_count は常に含める）。
+    """
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifact = (artifacts_by_doc.get(doc_id) or {}).get("component_assembly")
+        if not isinstance(artifact, dict):
+            continue
+        diagnostics_raw = artifact.get("diagnostics") or {}
+        diagnostics: dict[str, Any] = {}
+        for key, value in (diagnostics_raw.items() if isinstance(diagnostics_raw, dict) else []):
+            if not any(
+                key == prefix or key.startswith(prefix)
+                for prefix in _COMPONENT_ASSEMBLY_DIAG_KEY_PREFIXES
+            ):
+                continue
+            if isinstance(value, dict) and ("raw_text" in value or "parsed" in value):
+                sanitized = {
+                    "component_count": value.get("component_count"),
+                    "parse_error": value.get("parse_error"),
+                }
+                if include_llm_raw:
+                    sanitized["parsed"] = value.get("parsed")
+                    sanitized["raw_text"] = value.get("raw_text")
+                diagnostics[key] = sanitized
+            else:
+                diagnostics[key] = value
+        components = artifact.get("components") or []
+        fallback_component_ids = [
+            c.get("component_id")
+            for c in components
+            if isinstance(c, dict) and c.get("maturity_source") == "deterministic_fallback"
+        ]
+        out.append({
+            "document_id": doc_id,
+            "component_count": len(components) if isinstance(components, list) else 0,
+            "fallback_component_ids": fallback_component_ids,
+            "validation_issues": artifact.get("validation_issues") or [],
+            "diagnostics": diagnostics,
+        })
+    return out
+
+
 def _build_evidence_for_documents(
     artifacts_by_doc: dict[str, dict],
     document_ids: list[str],
@@ -1599,6 +1666,11 @@ def _build_zip(
         if include_debug and debug_data:
             zf.writestr("debug/validation_errors.json", _json_bytes(debug_data.get("validation_errors", [])))
             zf.writestr("debug/pipeline_logs.json", _json_bytes(debug_data.get("pipeline_logs", [])))
+            if debug_data.get("component_assembly_artifacts") is not None:
+                zf.writestr(
+                    "debug/component_assembly_artifact.json",
+                    _json_bytes({"documents": debug_data.get("component_assembly_artifacts", [])}),
+                )
             if debug_data.get("llm_prompts") is not None:
                 zf.writestr("debug/llm_prompts.json", _json_bytes(debug_data.get("llm_prompts", [])))
             if debug_data.get("llm_raw_outputs") is not None:
@@ -1720,7 +1792,13 @@ def export_course_bundle(
             document_boundaries=document_boundaries,
             include_ndjson=req.include_ndjson,
             include_debug=req.include_debug_data,
-            debug_data={"validation_errors": [], "pipeline_logs": []} if req.include_debug_data else None,
+            debug_data={
+                "validation_errors": [],
+                "pipeline_logs": [],
+                "component_assembly_artifacts": _build_component_assembly_debug(
+                    artifacts_by_doc, document_ids, include_llm_raw=req.include_llm_raw_outputs
+                ),
+            } if req.include_debug_data else None,
             export_validation=export_validation,
         )
 
@@ -1838,7 +1916,13 @@ def export_document_bundle(
             document_boundaries=document_boundaries,
             include_ndjson=req.include_ndjson,
             include_debug=req.include_debug_data,
-            debug_data={"validation_errors": [], "pipeline_logs": []} if req.include_debug_data else None,
+            debug_data={
+                "validation_errors": [],
+                "pipeline_logs": [],
+                "component_assembly_artifacts": _build_component_assembly_debug(
+                    artifacts_by_doc, document_ids, include_llm_raw=req.include_llm_raw_outputs
+                ),
+            } if req.include_debug_data else None,
             export_validation=export_validation,
         )
 

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -175,6 +175,14 @@ _NEEDS_REVIEW_RULE_IDS = {
     "review_required_claim_in_component",
 }
 
+# Rule IDs escalated to hard errors regardless of their reported severity.
+# Deterministic-fallback components are conservative placeholders, not
+# source-backed reusable components, and must never be silently persisted
+# as regular theory_components (#347).
+_FORCED_ERROR_RULE_IDS = {
+    "component_assembly_deterministic_fallback",
+}
+
 # Stage names where validation_issues with severity=error are hard errors
 _HARD_ERROR_STAGES = {
     "component_assembly",
@@ -345,6 +353,7 @@ class ExportValidationGate:
             )
 
         if component_result:
+            self._check_deterministic_fallback_components(component_result, errors)
             self._check_component_internal_flow(component_result, errors)
             self._check_summary_only_derivation_components(component_result, errors)
             component_quality = self._check_component_quality(
@@ -492,6 +501,8 @@ class ExportValidationGate:
 
                 if code in _NEEDS_REVIEW_RULE_IDS:
                     review_items.append(entry)
+                elif code in _FORCED_ERROR_RULE_IDS:
+                    errors.append(entry)
                 elif severity == _SEVERITY_ERROR and (
                     stage in _HARD_ERROR_STAGES or code in _HARD_ERROR_RULE_IDS
                 ):
@@ -738,6 +749,40 @@ class ExportValidationGate:
                         path=f"$.components[{comp_id}].review_status",
                         source_stage="export_validation",
                     ))
+
+    def _check_deterministic_fallback_components(
+        self, component_result, errors: list
+    ) -> None:
+        """Hard-block deterministic-fallback components from persist (#347).
+
+        Fallback components (maturity_source="deterministic_fallback") are
+        conservative placeholders emitted when LLM component assembly failed.
+        They may remain in the stage artifact for debugging, but must never be
+        persisted as regular theory_components. Checking the components
+        directly (not just the artifact validation_issues) also covers resumed
+        runs that reloaded the component_assembly artifact.
+        """
+        fallback_components = [
+            c for c in (getattr(component_result, "components", []) or [])
+            if str(getattr(c, "maturity_source", "") or "") == "deterministic_fallback"
+        ]
+        if not fallback_components:
+            return
+        if any(e.code == "component_assembly_deterministic_fallback" for e in errors):
+            return  # already escalated from the stage artifact's validation_issues
+        comp_ids = [getattr(c, "component_id", "?") for c in fallback_components]
+        reason = str(getattr(fallback_components[0], "fallback_reason", "") or "unknown")
+        errors.append(ValidationEntry(
+            code="component_assembly_deterministic_fallback",
+            message=(
+                f"{len(fallback_components)} deterministic-fallback component(s) "
+                f"present ({', '.join(comp_ids[:5])}{'…' if len(comp_ids) > 5 else ''}); "
+                f"fallback_reason={reason!r}; rerun component_assembly instead of persisting"
+            ),
+            artifact="component_assembly",
+            path="$.components[*].maturity_source",
+            source_stage="export_validation",
+        ))
 
     def _check_component_internal_flow(self, component_result, errors: list) -> None:
         """Derivation-like components must expose their internal flow before export."""

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -785,10 +785,22 @@ def run_document_pipeline(
                 raise PipelineStageError("component_assembly", str(exc), cause=exc) from exc
             save_artifact("component_assembly", component_result)
         result.component_count = len(component_result.components)
-        report_done("component_assembly", {
+        component_done_payload: dict[str, Any] = {
             "components": len(component_result.components), "total": 1, "processed": 1,
-        })
-        if finish_target_stage("component_assembly", {"components": len(component_result.components), "total": 1, "processed": 1}):
+        }
+        fallback_info = _component_assembly_fallback_info(component_result)
+        if fallback_info:
+            logger.warning(
+                "component_assembly used deterministic fallback: document=%s material=%s "
+                "fallback_reason=%r original_failure_codes=%s fallback_components=%d",
+                document_id, material_id,
+                fallback_info["fallback_reason"],
+                fallback_info["original_failure_codes"],
+                fallback_info["fallback_component_count"],
+            )
+            component_done_payload.update(fallback_info)
+        report_done("component_assembly", component_done_payload)
+        if finish_target_stage("component_assembly", component_done_payload):
             return result
 
         # ── Stage 12a: component_graph (hybrid deterministic/LLM edge builder) ─
@@ -1070,6 +1082,31 @@ def _instantiate(agent_class_or_instance):
     if isinstance(agent_class_or_instance, type):
         return agent_class_or_instance()
     return agent_class_or_instance
+
+
+def _component_assembly_fallback_info(component_result: Any) -> dict | None:
+    """Detect a deterministic-fallback component_assembly result (#347).
+
+    Works for both freshly built results and results reloaded from a stage
+    artifact: the diagnostics carry fallback_reason, and each fallback
+    component carries maturity_source="deterministic_fallback".
+    """
+    diagnostics = getattr(component_result, "diagnostics", {}) or {}
+    fallback_components = [
+        c for c in (getattr(component_result, "components", []) or [])
+        if str(getattr(c, "maturity_source", "") or "") == "deterministic_fallback"
+    ]
+    fallback_reason = str(diagnostics.get("fallback_reason") or "")
+    if not fallback_reason and not fallback_components:
+        return None
+    if not fallback_reason and fallback_components:
+        fallback_reason = str(getattr(fallback_components[0], "fallback_reason", "") or "unknown")
+    return {
+        "fallback": True,
+        "fallback_reason": fallback_reason,
+        "original_failure_codes": list(diagnostics.get("original_failure_codes") or []),
+        "fallback_component_count": len(fallback_components),
+    }
 
 
 def _summarize_export_validation_errors(validation_result_dict: dict, limit: int = 3) -> str:

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -15,6 +15,15 @@ from core.postgres import get_session as _pg_session
 logger = logging.getLogger(__name__)
 
 
+class DeterministicFallbackPersistError(RuntimeError):
+    """component_assembly の deterministic-fallback 結果を persist しようとした (#347)。
+
+    ExportValidationGate を通らない経路（resume / 古い export_validation
+    artifact）でも、fallback-only の結果を theory_components へ反映させず、
+    かつ既存の通常成果物を silent に残さないために hard fail する。
+    """
+
+
 def _strip_nuls(value: Any) -> Any:
     if isinstance(value, str):
         return value.replace("\x00", "")
@@ -482,26 +491,41 @@ def persist_components(
         agent component_id → DB UUID のマッピング（dependency 解決用）。
     """
     components = list(getattr(component_result, "components", []) or [])
+    if not components:
+        return {}
 
     # deterministic_fallback component は通常成果物として永続化しない (#347)。
     # ExportValidationGate が persist 前にブロックするのが正規経路だが、
     # 旧 artifact からの resume 等でここまで届いた場合の最終ガード。
+    # 全件 fallback の場合は hard fail にする: silently return すると
+    # 同 document の既存 theory_components（前回 run の通常成果物）が
+    # 削除も置換もされず「成功」扱いのまま downstream に見え続けるため、
+    # 例外で run を failed にして再処理が必要なことを明示する。
     fallback_components = [
         c for c in components
         if str(getattr(c, "maturity_source", "") or "") == "deterministic_fallback"
     ]
     if fallback_components:
+        fallback_reason = str(
+            getattr(fallback_components[0], "fallback_reason", "") or "unknown"
+        )
+        components = [c for c in components if c not in fallback_components]
+        if not components:
+            raise DeterministicFallbackPersistError(
+                f"persist_components blocked for document={document_id}: all "
+                f"{len(fallback_components)} component(s) are deterministic-fallback "
+                f"(fallback_reason={fallback_reason!r}); rerun component_assembly "
+                "instead of persisting. Existing theory_components for this "
+                "document are left untouched."
+            )
         logger.warning(
             "persist_components: skipping %d deterministic-fallback component(s) "
             "for document=%s (fallback_reason=%r); they remain in the stage "
             "artifact only and are not persisted to theory_components",
             len(fallback_components),
             document_id,
-            str(getattr(fallback_components[0], "fallback_reason", "") or "unknown"),
+            fallback_reason,
         )
-        components = [c for c in components if c not in fallback_components]
-    if not components:
-        return {}
 
     id_map: dict[str, str] = {}
     claim_id_map = claim_id_map or {}

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -482,6 +482,24 @@ def persist_components(
         agent component_id → DB UUID のマッピング（dependency 解決用）。
     """
     components = list(getattr(component_result, "components", []) or [])
+
+    # deterministic_fallback component は通常成果物として永続化しない (#347)。
+    # ExportValidationGate が persist 前にブロックするのが正規経路だが、
+    # 旧 artifact からの resume 等でここまで届いた場合の最終ガード。
+    fallback_components = [
+        c for c in components
+        if str(getattr(c, "maturity_source", "") or "") == "deterministic_fallback"
+    ]
+    if fallback_components:
+        logger.warning(
+            "persist_components: skipping %d deterministic-fallback component(s) "
+            "for document=%s (fallback_reason=%r); they remain in the stage "
+            "artifact only and are not persisted to theory_components",
+            len(fallback_components),
+            document_id,
+            str(getattr(fallback_components[0], "fallback_reason", "") or "unknown"),
+        )
+        components = [c for c in components if c not in fallback_components]
     if not components:
         return {}
 

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1565,3 +1565,105 @@ def test_chunker_metadata_includes_extraction_source_from_grobid_blocks():
             f"Expected extraction_source='grobid_hybrid', got {chunk.metadata}"
         )
         assert chunk.metadata.get("tei_section_id") == "div_1"
+
+
+# --- component_assembly deterministic fallback handling (#347) --------------
+
+def _fallback_component(component_id="comp_fallback_001"):
+    return types.SimpleNamespace(
+        component_id=component_id,
+        component_type="ClaimBundleComponent",
+        label="fallback",
+        summary="fallback",
+        evidence_refs={"claim_ids": []},
+        inputs=[], outputs=[], preconditions=[], cautions=[],
+        dependencies=[], internal_flow=[],
+        maturity_source="deterministic_fallback",
+        fallback_reason="LLM component assembly returned no components",
+        review_status="teacher_review_required",
+    )
+
+
+def _normal_component(component_id="comp_001"):
+    return types.SimpleNamespace(
+        component_id=component_id,
+        component_type="RelationComponent",
+        label="relation",
+        summary="relation",
+        evidence_refs={"claim_ids": ["claim_1"]},
+        inputs=[], outputs=[], preconditions=[], cautions=[],
+        dependencies=[], internal_flow=[],
+        maturity_source="llm_proposed",
+        fallback_reason="",
+        review_status="teacher_review_required",
+    )
+
+
+def test_component_assembly_fallback_info_detects_fallback():
+    from core.document_pipeline.orchestrator import _component_assembly_fallback_info
+
+    result = types.SimpleNamespace(
+        components=[_fallback_component()],
+        diagnostics={
+            "fallback_reason": "LLM component assembly returned no components",
+            "original_failure_codes": ["no_components"],
+        },
+    )
+    info = _component_assembly_fallback_info(result)
+    assert info is not None
+    assert info["fallback"] is True
+    assert info["fallback_reason"] == "LLM component assembly returned no components"
+    assert info["original_failure_codes"] == ["no_components"]
+    assert info["fallback_component_count"] == 1
+
+
+def test_component_assembly_fallback_info_detects_resumed_artifact_without_diagnostics():
+    from core.document_pipeline.orchestrator import _component_assembly_fallback_info
+
+    result = types.SimpleNamespace(components=[_fallback_component()], diagnostics={})
+    info = _component_assembly_fallback_info(result)
+    assert info is not None
+    assert info["fallback_reason"] == "LLM component assembly returned no components"
+    assert info["fallback_component_count"] == 1
+
+
+def test_component_assembly_fallback_info_none_for_normal_result():
+    from core.document_pipeline.orchestrator import _component_assembly_fallback_info
+
+    result = types.SimpleNamespace(components=[_normal_component()], diagnostics={})
+    assert _component_assembly_fallback_info(result) is None
+
+
+def test_persist_components_skips_all_fallback_components_without_db_access():
+    from core.document_pipeline import persistence
+
+    component_result = types.SimpleNamespace(
+        components=[_fallback_component("comp_fallback_001"), _fallback_component("comp_fallback_002")]
+    )
+    with patch.object(persistence, "_pg_session") as session_factory:
+        id_map = persistence.persist_components(
+            document_id="doc_1", component_result=component_result
+        )
+    assert id_map == {}
+    session_factory.assert_not_called()
+
+
+def test_persist_components_filters_fallback_but_persists_normal_components():
+    from core.document_pipeline import persistence
+
+    component_result = types.SimpleNamespace(
+        components=[_fallback_component(), _normal_component()]
+    )
+    session = MagicMock()
+    session.execute.return_value.fetchone.return_value = ("db-uuid-1",)
+    with patch.object(persistence, "_pg_session", return_value=session):
+        id_map = persistence.persist_components(
+            document_id="doc_1", component_result=component_result
+        )
+    assert id_map == {"comp_001": "db-uuid-1"}
+    inserted_names = [
+        call.args[1].get("name")
+        for call in session.execute.call_args_list
+        if len(call.args) > 1 and isinstance(call.args[1], dict) and "maturity_source" in call.args[1]
+    ]
+    assert inserted_names == ["relation"]

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1634,12 +1634,32 @@ def test_component_assembly_fallback_info_none_for_normal_result():
     assert _component_assembly_fallback_info(result) is None
 
 
-def test_persist_components_skips_all_fallback_components_without_db_access():
+def test_persist_components_hard_fails_when_all_components_are_fallback():
+    """全件 fallback は silent skip せず hard fail する (#347 review).
+
+    silent に return {} すると同 document の既存 theory_components が
+    削除も置換もされないまま run が成功扱いになり、古い通常成果物が
+    downstream に見え続けるため。既存 rows は破壊しない（DB 未接続のまま）。
+    """
     from core.document_pipeline import persistence
 
     component_result = types.SimpleNamespace(
         components=[_fallback_component("comp_fallback_001"), _fallback_component("comp_fallback_002")]
     )
+    with patch.object(persistence, "_pg_session") as session_factory:
+        with pytest.raises(persistence.DeterministicFallbackPersistError) as exc_info:
+            persistence.persist_components(
+                document_id="doc_1", component_result=component_result
+            )
+    assert "doc_1" in str(exc_info.value)
+    assert "deterministic-fallback" in str(exc_info.value)
+    session_factory.assert_not_called()
+
+
+def test_persist_components_empty_result_returns_empty_without_db_access():
+    from core.document_pipeline import persistence
+
+    component_result = types.SimpleNamespace(components=[])
     with patch.object(persistence, "_pg_session") as session_factory:
         id_map = persistence.persist_components(
             document_id="doc_1", component_result=component_result

--- a/backend/tests/test_export_bundle.py
+++ b/backend/tests/test_export_bundle.py
@@ -726,3 +726,91 @@ class TestExportApiRoute:
     def test_export_zip_compression_deflated(self):
         source = _read(EXPORT_ROUTE)
         assert "ZIP_DEFLATED" in source
+
+# ---------------------------------------------------------------------------
+# Unit: component_assembly debug export (#347)
+# ---------------------------------------------------------------------------
+
+class TestComponentAssemblyDebugExport:
+    @staticmethod
+    def _artifacts_by_doc():
+        return {
+            "doc_1": {
+                "component_assembly": {
+                    "components": [
+                        {"component_id": "comp_fallback_001", "maturity_source": "deterministic_fallback"},
+                        {"component_id": "comp_002", "maturity_source": "llm_proposed"},
+                    ],
+                    "validation_issues": [
+                        {"rule_id": "component_assembly_deterministic_fallback", "severity": "warning", "message": "fallback"}
+                    ],
+                    "diagnostics": {
+                        "fallback_reason": "LLM component assembly returned no components",
+                        "original_failure_codes": ["no_components"],
+                        "initial_llm_raw_output": {
+                            "parsed": {"components": []},
+                            "component_count": 0,
+                            "raw_text": "RAW LLM TEXT",
+                            "parse_error": None,
+                        },
+                        "initial_validation_issues": [{"code": "no_components"}],
+                        "repair_attempt_1_issues": [{"code": "no_components"}],
+                        "unrelated_internal_key": {"big": "blob"},
+                    },
+                }
+            }
+        }
+
+    def test_debug_includes_fallback_diagnostics_without_raw_text(self):
+        mod = _get_export_helpers()
+        out = mod._build_component_assembly_debug(self._artifacts_by_doc(), ["doc_1"])
+        assert len(out) == 1
+        entry = out[0]
+        assert entry["document_id"] == "doc_1"
+        assert entry["fallback_component_ids"] == ["comp_fallback_001"]
+        diag = entry["diagnostics"]
+        assert diag["fallback_reason"] == "LLM component assembly returned no components"
+        assert diag["original_failure_codes"] == ["no_components"]
+        assert diag["initial_validation_issues"] == [{"code": "no_components"}]
+        assert diag["repair_attempt_1_issues"] == [{"code": "no_components"}]
+        # raw LLM テキストは default off
+        assert diag["initial_llm_raw_output"] == {"component_count": 0, "parse_error": None}
+        # ホワイトリスト外の diagnostics キーは含めない
+        assert "unrelated_internal_key" not in diag
+
+    def test_debug_includes_raw_text_when_opted_in(self):
+        mod = _get_export_helpers()
+        out = mod._build_component_assembly_debug(
+            self._artifacts_by_doc(), ["doc_1"], include_llm_raw=True
+        )
+        diag = out[0]["diagnostics"]
+        assert diag["initial_llm_raw_output"]["raw_text"] == "RAW LLM TEXT"
+        assert diag["initial_llm_raw_output"]["parsed"] == {"components": []}
+
+    def test_debug_skips_documents_without_artifact(self):
+        mod = _get_export_helpers()
+        out = mod._build_component_assembly_debug({}, ["doc_1"])
+        assert out == []
+
+    def test_zip_contains_component_assembly_artifact_when_debug_enabled(self):
+        mod = _get_export_helpers()
+        debug_entries = mod._build_component_assembly_debug(self._artifacts_by_doc(), ["doc_1"])
+        zip_bytes = mod._build_zip(
+            manifest={},
+            claims=[],
+            dsl_graph={},
+            components=[],
+            component_graph={},
+            evidence_snippets=[],
+            include_debug=True,
+            debug_data={
+                "validation_errors": [],
+                "pipeline_logs": [],
+                "component_assembly_artifacts": debug_entries,
+            },
+        )
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            assert "debug/component_assembly_artifact.json" in names
+            payload = json.loads(zf.read("debug/component_assembly_artifact.json"))
+            assert payload["documents"][0]["fallback_component_ids"] == ["comp_fallback_001"]

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -75,6 +75,11 @@ class ComponentAssemblyAgent:
             "component_assembly_input_validation": _preflight_check(llm_input),
         }
         if diagnostics["component_assembly_input_validation"]["status"] == "failed":
+            logger.warning(
+                "Component assembly input preflight failed: document=%s issue_codes=%s",
+                qualified_claims.document_id,
+                [issue["code"] for issue in diagnostics["component_assembly_input_validation"]["issues"]],
+            )
             result = make_deterministic_fallback(
                 llm_input,
                 "component_assembly_input_validation failed",
@@ -107,17 +112,23 @@ class ComponentAssemblyAgent:
             result.diagnostics = diagnostics
             return result
         diagnostics["initial_llm_raw_output"] = _llm_capture(self._llm_client, raw_output)
+        diagnostics["initial_llm_output_component_count"] = diagnostics["initial_llm_raw_output"]["component_count"]
         raw_output = canonicalize_claim_refs(
             raw_output,
             claim_objects,
             claim_aliases_from_accepted_claims(llm_input.accepted_claims),
         )
-        result = self._cleanup.cleanup(
-            _parse_raw(raw_output, qualified_claims.document_id, llm_input.cartridge_id)
-        )
+        parsed = _parse_raw(raw_output, qualified_claims.document_id, llm_input.cartridge_id)
+        diagnostics["parsed_component_count"] = len(parsed.components)
+        result = self._cleanup.cleanup(parsed)
+        diagnostics["cleanup_component_count"] = len(result.components)
         result = enrich_component_assembly(result, llm_input)
+        diagnostics["enriched_component_count"] = len(result.components)
         issues = self._validator.validate(result, cartridge, llm_input=llm_input)
         diagnostics["initial_validation_issues"] = _issue_dicts(issues, llm_input=llm_input)
+        diagnostics["initial_error_codes"] = [
+            issue.rule_id for issue in issues if issue.severity == "error"
+        ]
         if [i for i in issues if i.severity == "error"]:
             result = self._repairer.repair(
                 llm_input=llm_input,

--- a/src/episteme_graph/agents/component_assembly/prompt.py
+++ b/src/episteme_graph/agents/component_assembly/prompt.py
@@ -208,8 +208,20 @@ class ComponentAssemblyPromptFactory:
             + issue_text
             + "\n\n## Validation Issues JSON\n"
             + json.dumps(issue_payload, ensure_ascii=False, indent=2)
-            + "\nReturn corrected JSON."
         )
+        if any(getattr(i, "rule_id", "") == "no_components" for i in issues):
+            content += (
+                "\n\n## Regeneration Required\n"
+                "Your previous output contained NO components. An empty components"
+                " array is never a valid answer when accepted claims exist.\n"
+                "- You MUST return a non-empty components array.\n"
+                "- Build at least one component for every accepted claim, grouping"
+                " related claims into ClaimBundleComponent entries when no richer"
+                " component type applies.\n"
+                "- Use ONLY claim_ids / evidence_ids / equation_ids listed in the"
+                " Available Artifact IDs section.\n"
+            )
+        content += "\nReturn corrected JSON."
         return [
             {"role": "system", "content": _SYSTEM_CONTENT},
             {"role": "user", "content": content},

--- a/src/episteme_graph/agents/component_assembly/repair.py
+++ b/src/episteme_graph/agents/component_assembly/repair.py
@@ -64,15 +64,11 @@ class ComponentAssemblyRepairer:
         validator: object,
         diagnostics: dict | None = None,
     ) -> ComponentAssemblyResult:
-        if _has_no_components_error(validation_issues):
-            if diagnostics is not None:
-                diagnostics["fallback_reason"] = "LLM component assembly returned no components"
-                diagnostics["original_failure_codes"] = _issue_codes(validation_issues)
-            return make_deterministic_fallback(
-                llm_input,
-                "LLM component assembly returned no components",
-                validation_issues,
-            )
+        # no_components is repaired like any other validation error (#347):
+        # the repair prompt explicitly demands a non-empty components array, so
+        # an empty initial LLM output gets at least one regeneration attempt
+        # before the deterministic fallback kicks in.
+        had_no_components = _has_no_components_error(validation_issues)
 
         for attempt in range(1, _MAX_REPAIR_ATTEMPTS + 1):
             logger.info("Component assembly repair attempt %d/%d", attempt, _MAX_REPAIR_ATTEMPTS)
@@ -87,16 +83,18 @@ class ComponentAssemblyRepairer:
                     diagnostics[f"repair_attempt_{attempt}_exception"] = str(exc)
                 break
             if diagnostics is not None:
+                attempt_component_count = (
+                    len(raw_output.get("components", []))
+                    if isinstance(raw_output.get("components"), list)
+                    else 0
+                )
                 diagnostics[f"repair_attempt_{attempt}_output"] = {
                     "parsed": raw_output,
-                    "component_count": (
-                        len(raw_output.get("components", []))
-                        if isinstance(raw_output.get("components"), list)
-                        else 0
-                    ),
+                    "component_count": attempt_component_count,
                     "raw_text": getattr(llm_client, "last_raw_text", None),
                     "parse_error": getattr(llm_client, "last_parse_error", None),
                 }
+                diagnostics[f"repair_attempt_{attempt}_component_count"] = attempt_component_count
             raw_output = canonicalize_claim_refs(
                 raw_output,
                 None,
@@ -109,16 +107,24 @@ class ComponentAssemblyRepairer:
                 diagnostics[f"repair_attempt_{attempt}_issues"] = [
                     _issue_dict(issue, llm_input) for issue in remaining
                 ]
+                diagnostics[f"repair_attempt_{attempt}_error_codes"] = [
+                    issue.rule_id for issue in remaining if issue.severity == "error"
+                ]
             if not [i for i in remaining if i.severity == "error"]:
                 result.validation_issues = remaining
                 return result
             validation_issues = remaining
+        reason = (
+            "LLM component assembly returned no components"
+            if had_no_components and _has_no_components_error(validation_issues)
+            else "Repair failed after max attempts"
+        )
         if diagnostics is not None:
-            diagnostics["fallback_reason"] = "Repair failed after max attempts"
+            diagnostics["fallback_reason"] = reason
             diagnostics["original_failure_codes"] = _issue_codes(validation_issues)
         fallback = make_deterministic_fallback(
             llm_input,
-            "Repair failed after max attempts",
+            reason,
             validation_issues,
         )
         return fallback
@@ -286,6 +292,18 @@ def make_deterministic_fallback(
             fallback_reason=reason,
             original_failure_codes=original_failure_codes,
         ))
+
+    logger.warning(
+        "Component assembly deterministic fallback: document=%s reason=%r "
+        "original_failure_codes=%s atomic_available_claims=%d atomic_accepted_claims=%d "
+        "fallback_components=%d",
+        llm_input.document_id,
+        reason,
+        original_failure_codes,
+        len(atomic_available_claims),
+        len(atomic_accepted_claims),
+        len(components),
+    )
 
     if components:
         result = ComponentAssemblyResult(

--- a/src/episteme_graph/agents/component_assembly/validator.py
+++ b/src/episteme_graph/agents/component_assembly/validator.py
@@ -104,6 +104,21 @@ class ComponentAssemblyValidator:
         issues += self._check_duplicates(result)
         if not (0.0 <= result.confidence <= 1.0):
             issues.append(ValidationIssue("confidence_out_of_range", "error", "result confidence out of range", "confidence"))
+        # deterministic-fallback component の存在は再 validate でも必ず報告する
+        # (#347): downstream の ExportValidationGate がこの issue / maturity_source
+        # を検出して persist をブロックする。
+        fallback_count = sum(
+            1 for c in result.components
+            if str(getattr(c, "maturity_source", "") or "") == "deterministic_fallback"
+        )
+        if fallback_count:
+            issues.append(ValidationIssue(
+                "component_assembly_deterministic_fallback",
+                "warning",
+                f"result contains {fallback_count} deterministic-fallback component(s); "
+                "LLM component assembly failed and must be rerun before publish",
+                "components",
+            ))
         return issues
 
     def _check_component(

--- a/src/tests/agents/component_assembly/test_agent.py
+++ b/src/tests/agents/component_assembly/test_agent.py
@@ -311,9 +311,8 @@ def test_llm_failure_returns_fallback():
     assert result.validation_issues[0].rule_id == "component_assembly_deterministic_fallback"
 
 
-def test_empty_llm_components_falls_back_to_claim_components_without_repair():
-    agent = ComponentAssemblyAgent()
-    empty = {
+def _empty_response():
+    return {
         "document_id": "doc_test",
         "components_version": "v1",
         "components": [],
@@ -322,14 +321,47 @@ def test_empty_llm_components_falls_back_to_claim_components_without_repair():
         "confidence": 0.0,
     }
 
-    with patch.object(agent._llm_client, "generate", return_value=empty) as mocked:
+
+def test_empty_llm_components_triggers_repair_regeneration():
+    """no_components は即 fallback せず repair で再生成を試みる (#347)."""
+    agent = ComponentAssemblyAgent()
+
+    with patch.object(
+        agent._llm_client, "generate", side_effect=[_empty_response(), _valid_response()]
+    ) as mocked:
         result = agent.run(_qualified(), equations=_equations(), thesis=_thesis(), dsl=_dsl())
 
-    assert mocked.call_count == 1
+    assert mocked.call_count == 2
     assert len(result.components) == 4
-    assert {c.component_type for c in result.components} == {"ClaimBundleComponent"}
-    assert result.components[0].evidence_refs["claim_ids"] == ["claim:b1:s1"]
+    assert any(c.component_type == "RelationComponent" for c in result.components)
+    assert all(c.maturity_source != "deterministic_fallback" for c in result.components)
     assert result.diagnostics["initial_llm_raw_output"]["component_count"] == 0
     assert result.diagnostics["initial_validation_issues"][0]["code"] == "no_components"
+    assert result.diagnostics["initial_error_codes"] == ["no_components"]
+    assert "fallback_reason" not in result.diagnostics
+
+
+def test_empty_llm_components_falls_back_after_repair_attempts():
+    agent = ComponentAssemblyAgent()
+
+    with patch.object(
+        agent._llm_client,
+        "generate",
+        side_effect=[_empty_response(), _empty_response(), _empty_response()],
+    ) as mocked:
+        result = agent.run(_qualified(), equations=_equations(), thesis=_thesis(), dsl=_dsl())
+
+    # 初回 + repair 2 回（_MAX_REPAIR_ATTEMPTS）試行後に fallback
+    assert mocked.call_count == 3
+    assert len(result.components) == 4
+    assert {c.component_type for c in result.components} == {"ClaimBundleComponent"}
+    assert {c.maturity_source for c in result.components} == {"deterministic_fallback"}
+    assert result.components[0].evidence_refs["claim_ids"] == ["claim:b1:s1"]
     assert result.diagnostics["fallback_reason"] == "LLM component assembly returned no components"
-    assert not [i for i in result.validation_issues if i.severity == "error"]
+    assert "no_components" in result.diagnostics["original_failure_codes"]
+    assert result.diagnostics["repair_attempt_1_component_count"] == 0
+    assert result.diagnostics["repair_attempt_1_error_codes"] == ["no_components"]
+    assert any(
+        i.rule_id == "component_assembly_deterministic_fallback"
+        for i in result.validation_issues
+    )

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -66,7 +66,11 @@ class _ComponentRecord:
         assumptions=None,
         split_recommendation=None,
         component_quality=None,
+        maturity_source: str = "",
+        fallback_reason: str = "",
     ):
+        self.maturity_source = maturity_source
+        self.fallback_reason = fallback_reason
         self.component_id = component_id
         self.component_type = component_type
         self.label = label
@@ -221,6 +225,93 @@ def test_failed_validation_hard_error_from_component_assembly():
     assert result.exportable is False
     assert result.publish_ready is False
     assert result.summary.error_count >= 1
+
+
+def test_deterministic_fallback_issue_is_hard_error():
+    """component_assembly_deterministic_fallback は severity=warning でも hard error (#347)."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [],
+            "validation_issues": [
+                {
+                    "rule_id": "component_assembly_deterministic_fallback",
+                    "severity": "warning",
+                    "message": "LLM component assembly failed; emitted 12 fallback component(s)",
+                }
+            ],
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert result.status == "failed_validation"
+    assert result.exportable is False
+    assert any(
+        e.code == "component_assembly_deterministic_fallback" for e in result.errors
+    )
+
+
+def test_deterministic_fallback_components_block_export_without_artifact_issue():
+    """resume 等で validation_issues が無くても fallback component 自体を検出する (#347)."""
+    component_result = _ComponentResult([
+        _ComponentRecord(
+            "comp_fallback_001",
+            {"claim_ids": [], "evidence_ids": []},
+            maturity_source="deterministic_fallback",
+            fallback_reason="LLM component assembly returned no components",
+        ),
+    ])
+    result = _run_gate(component_result=component_result)
+    assert result.status == "failed_validation"
+    fallback_errors = [
+        e for e in result.errors
+        if e.code == "component_assembly_deterministic_fallback"
+    ]
+    assert len(fallback_errors) == 1
+    assert "comp_fallback_001" in fallback_errors[0].message
+    assert "LLM component assembly returned no components" in fallback_errors[0].message
+
+
+def test_deterministic_fallback_error_not_duplicated():
+    """artifact issue と component 検査の両方が該当しても error は 1 件 (#347)."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [],
+            "validation_issues": [
+                {
+                    "rule_id": "component_assembly_deterministic_fallback",
+                    "severity": "warning",
+                    "message": "fallback emitted",
+                }
+            ],
+        }
+    )
+    component_result = _ComponentResult([
+        _ComponentRecord(
+            "comp_fallback_001",
+            {"claim_ids": [], "evidence_ids": []},
+            maturity_source="deterministic_fallback",
+            fallback_reason="reason",
+        ),
+    ])
+    result = _run_gate(artifacts=artifacts, component_result=component_result)
+    fallback_errors = [
+        e for e in result.errors
+        if e.code == "component_assembly_deterministic_fallback"
+    ]
+    assert len(fallback_errors) == 1
+
+
+def test_non_fallback_components_pass_fallback_check():
+    component_result = _ComponentResult([
+        _ComponentRecord(
+            "comp_001",
+            {"claim_ids": ["claim_1"], "evidence_ids": ["ev_1"]},
+            maturity_source="llm",
+        ),
+    ])
+    result = _run_gate(component_result=component_result)
+    assert not any(
+        e.code == "component_assembly_deterministic_fallback" for e in result.errors
+    )
 
 
 def test_needs_review_summary_only():


### PR DESCRIPTION
## Summary

Implements comprehensive handling of deterministic fallback components in the component assembly pipeline. When LLM component assembly fails, the system now emits conservative placeholder components (`maturity_source="deterministic_fallback"`) and prevents their persistence to the database. This ensures failed assembly attempts are visible for debugging but never silently persisted as regular theory components.

## Key Changes

### Component Assembly Repair Logic
- **Modified repair strategy**: `no_components` error no longer triggers immediate fallback; instead, it triggers repair regeneration attempts (up to `_MAX_REPAIR_ATTEMPTS`). Only after exhausting repair attempts does the system fall back to deterministic placeholders.
- **Enhanced diagnostics**: Added detailed tracking of repair attempts including `repair_attempt_N_output`, `repair_attempt_N_component_count`, `repair_attempt_N_issues`, and `repair_attempt_N_error_codes`.
- **Improved fallback reason**: Distinguishes between "LLM component assembly returned no components" (persistent empty output) and "Repair failed after max attempts" (other validation failures).
- **Repair prompt enhancement**: Added explicit regeneration instructions when `no_components` is detected, demanding non-empty components array and requiring at least one component per accepted claim.

### Validation & Export Gate
- **Hard-error escalation**: `component_assembly_deterministic_fallback` is now a forced hard error regardless of reported severity in validation issues (`_FORCED_ERROR_RULE_IDS`).
- **Direct component inspection**: `ExportValidationGate._check_deterministic_fallback_components()` detects fallback components directly from the component result, covering both fresh runs and resumed artifacts that reloaded the stage artifact.
- **Deduplication**: Prevents duplicate errors when both artifact validation issues and component inspection detect fallback components.

### Persistence Layer
- **Fallback filtering**: `persist_components()` filters out all deterministic-fallback components before database insertion, with logging of skipped components and fallback reasons.
- **Final guard**: Acts as a safety net in case fallback components somehow bypass the export validation gate.

### Orchestrator & Diagnostics
- **Fallback detection helper**: New `_component_assembly_fallback_info()` function detects fallback results from both fresh builds and reloaded artifacts, extracting fallback reason, original failure codes, and component count.
- **Structured logging**: Reports fallback events with document ID, material ID, reason, failure codes, and component count for observability.

### Debug Export
- **Component assembly artifact export**: New `_build_component_assembly_debug()` function sanitizes and exports component assembly diagnostics for debugging, including:
  - Fallback component IDs
  - Validation issues
  - Filtered diagnostics (fallback_reason, original_failure_codes, repair attempts, etc.)
  - Optional raw LLM text (controlled by `include_llm_raw` flag)
- **Zip integration**: Debug exports now include `debug/component_assembly_artifact.json` with per-document fallback and diagnostic information.

### Validator Enhancement
- **Fallback detection in validation**: `ComponentAssemblyValidator.validate()` now always reports `component_assembly_deterministic_fallback` warning when fallback components are present, ensuring downstream detection even on re-validation.

## Implementation Details

- **Maturity source tracking**: Fallback components carry `maturity_source="deterministic_fallback"` and `fallback_reason` fields for identification and debugging.
- **Backward compatibility**: Handles both fresh component assembly results and resumed artifacts that reloaded stage artifacts without diagnostics.
- **Whitelist-based diagnostics filtering**: Only exports diagnostics keys matching `_COMPONENT_ASSEMBLY_DIAG_KEY_PREFIXES` to avoid leaking internal state while preserving repair attempt history.
- **Test coverage**: Added comprehensive tests for fallback detection, filtering, deduplication, and debug export functionality across multiple test files.

## Related Issue

Fixes #347 - Deterministic fallback component assembly handling

https://claude.ai/code/session_01789fapg34VL5D4oANoGwhf