### PR TITLE
Surface deterministic fallback root cause in export validation errors

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -208,6 +208,35 @@ def _ordered_unique(values) -> list:
     return result
 
 
+def _append_fallback_diagnostics(message: str, artifact: dict) -> str:
+    """Append the stage artifact's fallback root cause to an escalated error.
+
+    The deterministic-fallback hard error (#347) is what operators see in the
+    exported ERROR log, but the underlying reason (LLM exception, repair
+    exhausted, ...) is only recorded in the artifact's diagnostics or on the
+    fallback components themselves. Inline it so the error is self-contained.
+    """
+    diagnostics = artifact.get("diagnostics") or {}
+    reason = str(diagnostics.get("fallback_reason") or "")
+    failure_codes = list(diagnostics.get("original_failure_codes") or [])
+    if not reason:
+        for component in artifact.get("components") or []:
+            if not isinstance(component, dict):
+                continue
+            reason = str(component.get("fallback_reason") or "")
+            if reason:
+                failure_codes = failure_codes or list(
+                    component.get("original_failure_codes") or []
+                )
+                break
+    if not reason and not failure_codes:
+        return message
+    suffix = f"; fallback_reason={reason!r}" if reason else ""
+    if failure_codes:
+        suffix += f"; original_failure_codes={failure_codes}"
+    return f"{message}{suffix}"
+
+
 def _component_low_confidence_equation_ids(component) -> list:
     """Low-confidence equation ids a component carries (Step 3 fields, #326).
 
@@ -490,6 +519,11 @@ class ExportValidationGate:
                 severity = issue.get("severity", "warning")
                 message = issue.get("message", "")
                 path = issue.get("field") or issue.get("path")
+                if code in _FORCED_ERROR_RULE_IDS:
+                    # Surface the root cause in the hard error itself: the
+                    # exported ERROR log often only carries this message, while
+                    # fallback_reason lives in the stage artifact diagnostics.
+                    message = _append_fallback_diagnostics(message, artifact)
 
                 entry = ValidationEntry(
                     code=code,

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -766,8 +766,13 @@ def run_document_pipeline(
 
         # ── Stage 12: component_assembly ───────────────────────────────────
         component_artifact = artifact("component_assembly")
-        if should_use_artifact("component_assembly"):
+        reuse_component_artifact = should_use_artifact("component_assembly")
+        if reuse_component_artifact:
             component_result = _from_agent_dict("component_assembly", component_artifact)
+            reuse_component_artifact = _component_assembly_artifact_reusable(
+                component_result, document_id=document_id, material_id=material_id,
+            )
+        if reuse_component_artifact:
             logger.info("Resuming document pipeline: loaded component_assembly artifact for document %s", document_id)
         else:
             report_start("component_assembly", total=1, unit="llm_call")
@@ -1082,6 +1087,34 @@ def _instantiate(agent_class_or_instance):
     if isinstance(agent_class_or_instance, type):
         return agent_class_or_instance()
     return agent_class_or_instance
+
+
+def _component_assembly_artifact_reusable(
+    component_result: Any,
+    *,
+    document_id: str,
+    material_id: str,
+) -> bool:
+    """Decide whether a resumed component_assembly artifact may be reused.
+
+    A deterministic-fallback artifact can never pass the export gate (#347), so
+    reusing it would fail every resumed run at export_validation with the same
+    hard error. Re-running the stage gives the LLM another chance, which is
+    exactly what the gate error message instructs ("rerun component_assembly
+    instead of persisting").
+    """
+    fallback_info = _component_assembly_fallback_info(component_result)
+    if not fallback_info:
+        return True
+    logger.warning(
+        "Resumed component_assembly artifact is a deterministic fallback "
+        "(document=%s material=%s fallback_reason=%r original_failure_codes=%s); "
+        "re-running component_assembly instead of reusing it",
+        document_id, material_id,
+        fallback_info["fallback_reason"],
+        fallback_info["original_failure_codes"],
+    )
+    return False
 
 
 def _component_assembly_fallback_info(component_result: Any) -> dict | None:

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -1634,6 +1634,31 @@ def test_component_assembly_fallback_info_none_for_normal_result():
     assert _component_assembly_fallback_info(result) is None
 
 
+def test_resumed_fallback_component_assembly_artifact_is_not_reusable():
+    """fallback artifact は resume で再利用せず stage を再実行する (#347).
+
+    deterministic fallback の artifact は export gate を絶対に通過できないため、
+    再利用すると resume のたびに export_validation で同じ hard error になる。
+    """
+    from core.document_pipeline.orchestrator import _component_assembly_artifact_reusable
+
+    fallback_result = types.SimpleNamespace(
+        components=[_fallback_component()],
+        diagnostics={
+            "fallback_reason": "Repair failed after max attempts",
+            "original_failure_codes": ["unresolved_claim_id"],
+        },
+    )
+    assert _component_assembly_artifact_reusable(
+        fallback_result, document_id="doc-1", material_id="mat-1"
+    ) is False
+
+    normal_result = types.SimpleNamespace(components=[_normal_component()], diagnostics={})
+    assert _component_assembly_artifact_reusable(
+        normal_result, document_id="doc-1", material_id="mat-1"
+    ) is True
+
+
 def test_persist_components_hard_fails_when_all_components_are_fallback():
     """全件 fallback は silent skip せず hard fail する (#347 review).
 

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -249,6 +249,64 @@ def test_deterministic_fallback_issue_is_hard_error():
     )
 
 
+def test_deterministic_fallback_error_includes_root_cause_from_diagnostics():
+    """escalated error には artifact diagnostics の fallback_reason を含める."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [],
+            "validation_issues": [
+                {
+                    "rule_id": "component_assembly_deterministic_fallback",
+                    "severity": "warning",
+                    "message": "LLM component assembly failed; emitted 12 fallback component(s)",
+                }
+            ],
+            "diagnostics": {
+                "fallback_reason": "Repair failed after max attempts",
+                "original_failure_codes": ["unresolved_claim_id"],
+            },
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    fallback_errors = [
+        e for e in result.errors
+        if e.code == "component_assembly_deterministic_fallback"
+    ]
+    assert len(fallback_errors) == 1
+    assert "Repair failed after max attempts" in fallback_errors[0].message
+    assert "unresolved_claim_id" in fallback_errors[0].message
+
+
+def test_deterministic_fallback_error_includes_root_cause_from_components():
+    """diagnostics が無い artifact でも component の fallback_reason を拾う."""
+    artifacts = _make_artifacts(
+        component_assembly={
+            "components": [
+                {
+                    "component_id": "comp_fallback_001",
+                    "maturity_source": "deterministic_fallback",
+                    "fallback_reason": "LLM component assembly returned no components",
+                    "original_failure_codes": ["no_components"],
+                }
+            ],
+            "validation_issues": [
+                {
+                    "rule_id": "component_assembly_deterministic_fallback",
+                    "severity": "warning",
+                    "message": "LLM component assembly failed; emitted 1 fallback component(s)",
+                }
+            ],
+        }
+    )
+    result = _run_gate(artifacts=artifacts)
+    fallback_errors = [
+        e for e in result.errors
+        if e.code == "component_assembly_deterministic_fallback"
+    ]
+    assert len(fallback_errors) == 1
+    assert "LLM component assembly returned no components" in fallback_errors[0].message
+
+
 def test_deterministic_fallback_components_block_export_without_artifact_issue():
     """resume 等で validation_issues が無くても fallback component 自体を検出する (#347)."""
     component_result = _ComponentResult([


### PR DESCRIPTION
## Summary

When a component_assembly stage produces a deterministic fallback result, the export validation gate now escalates this to a hard error and includes the underlying root cause (fallback_reason and original_failure_codes) directly in the error message. Additionally, resumed component_assembly artifacts that are deterministic fallbacks are no longer reused; instead, the stage is re-run to give the LLM another chance.

## Key Changes

- **Export validation gate error enrichment** (`export_validation_gate.py`):
  - Added `_append_fallback_diagnostics()` function to extract fallback root cause from artifact diagnostics or component-level fallback_reason fields
  - Modified `_aggregate_artifact_issues()` to inline fallback diagnostics into hard error messages for `component_assembly_deterministic_fallback` rule
  - This ensures operators see the underlying reason (e.g., "Repair failed after max attempts", "unresolved_claim_id") in the exported ERROR log, not just the generic fallback message

- **Resume artifact reusability check** (`orchestrator.py`):
  - Added `_component_assembly_artifact_reusable()` function to detect and reject deterministic fallback artifacts during resume
  - Deterministic fallback artifacts cannot pass the export gate, so reusing them would cause every resumed run to fail with the same hard error
  - Re-running the stage gives the LLM another opportunity to succeed
  - Logs a warning when a fallback artifact is skipped during resume

- **Test coverage** (`test_export_validation_gate.py`, `test_document_pipeline.py`):
  - Added `test_deterministic_fallback_error_includes_root_cause_from_diagnostics()` to verify fallback_reason and original_failure_codes from artifact diagnostics are included in the error
  - Added `test_deterministic_fallback_error_includes_root_cause_from_components()` to verify fallback_reason is extracted from component-level fields when diagnostics are absent
  - Added `test_resumed_fallback_component_assembly_artifact_is_not_reusable()` to verify fallback artifacts are not reused during resume while normal artifacts are

## Implementation Details

- The fallback diagnostics extraction prioritizes artifact-level diagnostics over component-level fields, but falls back to component fields if diagnostics are missing
- The reusability check uses the existing `_component_assembly_fallback_info()` helper to detect fallback artifacts
- Error messages are enriched with both `fallback_reason` (as a quoted string) and `original_failure_codes` (as a list) for complete context
- Addresses issue #347: prevents infinite loops of failed resume attempts by forcing re-execution of the component_assembly stage

https://claude.ai/code/session_01SRcH8HuW77HodvmC83Qznq