### PR TITLE
Fix claim ID canonicalization for atomically rewritten spans

### DIFF
--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -130,7 +130,14 @@ class ComponentAssemblyInputBuilder:
         for record in result.qualified_spans:
             claim_id = canonical_claim_id_for_span(record, claim_objects)
             claim_obj = claim_index.get(claim_id)
-            if has_claim_objects and claim_obj and _claim_is_non_atomic(claim_obj):
+            # claim_object_builder is the source of truth for claim IDs (issue
+            # #340). A span that doesn't resolve to a final claim object would
+            # inject a provisional/legacy ID that the assembly preflight rejects
+            # (accepted_claim_ids_not_available); its claims, if any, are added
+            # from claim_objects below instead.
+            if has_claim_objects and claim_obj is None:
+                continue
+            if has_claim_objects and _claim_is_non_atomic(claim_obj):
                 continue
             row = {
                 "claim_id": claim_id,

--- a/src/episteme_graph/agents/id_canonicalization.py
+++ b/src/episteme_graph/agents/id_canonicalization.py
@@ -226,8 +226,9 @@ def _claim_lookup(claim_objects: Any | None) -> dict[tuple[str, str] | tuple[str
         return {}
 
     lookup: dict[tuple[str, str] | tuple[str, str, str], str] = {}
-    span_to_ids: dict[str, list[str]] = defaultdict(list)
-    safe_span_to_ids: dict[str, list[str]] = defaultdict(list)
+    span_claims: dict[str, list[Any]] = defaultdict(list)
+    section_span_claims: dict[tuple[str, str], list[Any]] = defaultdict(list)
+    safe_span_claims: dict[str, list[Any]] = defaultdict(list)
     for claim in claims:
         claim_id = str(getattr(claim, "claim_id", "") or "")
         if not claim_id:
@@ -237,21 +238,64 @@ def _claim_lookup(claim_objects: Any | None) -> dict[tuple[str, str] | tuple[str
         section_id = str(getattr(claim, "section_id", "") or "")
         for span_id_raw in getattr(claim, "source_span_ids", []) or []:
             span_id = str(span_id_raw)
-            span_to_ids[span_id].append(claim_id)
+            span_claims[span_id].append(claim)
             if section_id:
-                lookup[("section_span", section_id, span_id)] = claim_id
+                section_span_claims[(section_id, span_id)].append(claim)
             safe = re.sub(r"[^A-Za-z0-9_]+", "_", span_id)
-            safe_span_to_ids[f"claim_{safe}"].append(claim_id)
+            safe_span_claims[f"claim_{safe}"].append(claim)
 
-    for span_id, ids in span_to_ids.items():
-        unique = _unique(ids)
-        if len(unique) == 1:
-            lookup[("span", span_id)] = unique[0]
-    for legacy_id, ids in safe_span_to_ids.items():
-        unique = _unique(ids)
-        if len(unique) == 1:
-            lookup[("legacy", legacy_id)] = unique[0]
+    for span_id, group in span_claims.items():
+        resolved = _resolve_span_claim_id(group)
+        if resolved:
+            lookup[("span", span_id)] = resolved
+    for (section_id, span_id), group in section_span_claims.items():
+        resolved = _resolve_span_claim_id(group)
+        if resolved:
+            lookup[("section_span", section_id, span_id)] = resolved
+    for legacy_id, group in safe_span_claims.items():
+        resolved = _resolve_span_claim_id(group)
+        if resolved and ("legacy", legacy_id) not in lookup:
+            lookup[("legacy", legacy_id)] = resolved
     return lookup
+
+
+def _resolve_span_claim_id(group: list[Any]) -> str:
+    """Pick the canonical claim ID for a span shared by several claim objects.
+
+    A span rewritten into atomic claims keeps its span_id on both the composite
+    parent and each child (issue #317), so the parent — the record representing
+    the whole span — is canonical. The parent is identified by hierarchy links
+    (children carry ``parent_claim_id`` / parents list ``subclaim_ids``) or,
+    failing that, as the single non-atomic record among atomic ones. Returns ""
+    when the span is genuinely ambiguous (multiple unrelated claims).
+    """
+    ids = _unique([str(getattr(c, "claim_id", "") or "") for c in group])
+    if len(ids) == 1:
+        return ids[0]
+    child_ids = set()
+    for c in group:
+        child_ids.update(str(v) for v in getattr(c, "subclaim_ids", None) or [])
+    roots = _unique([
+        str(getattr(c, "claim_id", "") or "")
+        for c in group
+        if not getattr(c, "parent_claim_id", None)
+        and str(getattr(c, "claim_id", "") or "") not in child_ids
+    ])
+    if len(roots) == 1:
+        return roots[0]
+    non_atomic = _unique([
+        str(getattr(c, "claim_id", "") or "")
+        for c in group
+        if not _claim_obj_is_atomic(c)
+    ])
+    if len(non_atomic) == 1 and len(non_atomic) < len(ids):
+        return non_atomic[0]
+    return ""
+
+
+def _claim_obj_is_atomic(claim: Any) -> bool:
+    atomicity = str(getattr(claim, "atomicity", "atomic") or "atomic").lower()
+    return bool(getattr(claim, "is_atomic", atomicity == "atomic")) and atomicity == "atomic"
 
 
 def _map_claim_ref_list(

--- a/src/tests/agents/component_assembly/test_input_builder.py
+++ b/src/tests/agents/component_assembly/test_input_builder.py
@@ -240,7 +240,7 @@ def test_build_uses_atomic_claim_objects_before_component_construction():
 
     claim_ids = [c["claim_id"] for c in llm_input.accepted_claims]
     assert "claim_parent" not in claim_ids
-    assert claim_ids == ["claim_atomic_2", "claim_atomic_1"]
+    assert claim_ids == ["claim_atomic_1", "claim_atomic_2"]
     assert all(c["atomicity"] == "atomic" and c["is_atomic"] for c in llm_input.accepted_claims)
 
 
@@ -290,3 +290,108 @@ def test_limits_claims():
     qualified = ClaimQualificationResult("doc", None, [_claim("s1", "b1", "A", "relation"), _claim("s2", "b2", "B", "relation")], [], [], {})
     llm_input = BUILDER.build(qualified, config={"max_claims": 1})
     assert len(llm_input.accepted_claims) == 1
+
+
+def test_span_without_section_id_split_into_atomic_claims_resolves_canonically():
+    """Regression: a span with no section_id whose claim was atomically rewritten
+    (composite parent + atomic children sharing the span_id) must not leak the
+    legacy `claim:<block>:<span>` ID into accepted_claims — that ID is absent
+    from available_claims and hard-fails the assembly preflight
+    (accepted_claim_ids_not_available → deterministic fallback → export gate error).
+    """
+    span = QualifiedSpanRecord(
+        "span_07", "blk_3", None, "The model derives X and shows Y.", ["result"],
+        {"status": "accepted", "claim_tier": "paper_core", "claim_type_candidate": "main_result"},
+        {}, "reason", 0.9,
+    )
+    qualified = ClaimQualificationResult("doc", None, [span], [], [], {})
+    claim_objects = ClaimObjectBuildResult(
+        "doc",
+        None,
+        claims=[
+            ClaimObjectRecord(
+                claim_id="claim_span_07_sub01",
+                document_id="doc",
+                claim_type="derivation_result",
+                text="The model derives X.",
+                source_evidence_ids=["ev_1"],
+                source_span_ids=["span_07"],
+                concepts=[],
+                section_id=None,
+                atomicity="atomic",
+                is_atomic=True,
+                parent_claim_id="claim_span_07",
+            ),
+            ClaimObjectRecord(
+                claim_id="claim_span_07_sub02",
+                document_id="doc",
+                claim_type="main_result",
+                text="The model shows Y.",
+                source_evidence_ids=["ev_1"],
+                source_span_ids=["span_07"],
+                concepts=[],
+                section_id=None,
+                atomicity="atomic",
+                is_atomic=True,
+                parent_claim_id="claim_span_07",
+            ),
+            ClaimObjectRecord(
+                claim_id="claim_span_07",
+                document_id="doc",
+                claim_type="main_result",
+                text="The model derives X and shows Y.",
+                source_evidence_ids=["ev_1"],
+                source_span_ids=["span_07"],
+                concepts=[],
+                section_id=None,
+                atomicity="composite",
+                is_atomic=False,
+                subclaim_ids=["claim_span_07_sub01", "claim_span_07_sub02"],
+            ),
+        ],
+    )
+
+    llm_input = BUILDER.build(qualified, claim_objects=claim_objects)
+
+    accepted_ids = [c["claim_id"] for c in llm_input.accepted_claims]
+    available_ids = {c["claim_id"] for c in llm_input.available_claims}
+    assert set(accepted_ids) <= available_ids
+    assert accepted_ids == ["claim_span_07_sub01", "claim_span_07_sub02"]
+
+
+def test_span_unresolvable_against_claim_objects_is_skipped():
+    """Regression: when claim_objects exist (e.g. resumed artifact) but a span
+    has no corresponding claim object, the span must be skipped instead of
+    injecting a provisional/legacy ID that fails the assembly preflight.
+    """
+    qualified = ClaimQualificationResult(
+        "doc", None,
+        [
+            _claim("s1", "b1", "Known claim.", "result"),
+            _claim("s_orphan", "b9", "Orphan claim.", "result"),
+        ],
+        [], [], {},
+    )
+    claim_objects = ClaimObjectBuildResult(
+        "doc",
+        None,
+        claims=[
+            ClaimObjectRecord(
+                claim_id="claim_s1",
+                document_id="doc",
+                claim_type="result",
+                text="Known claim.",
+                source_evidence_ids=["ev_1"],
+                source_span_ids=["s1"],
+                concepts=[],
+                section_id="sec_1",
+            ),
+        ],
+    )
+
+    llm_input = BUILDER.build(qualified, claim_objects=claim_objects)
+
+    accepted_ids = [c["claim_id"] for c in llm_input.accepted_claims]
+    available_ids = {c["claim_id"] for c in llm_input.available_claims}
+    assert accepted_ids == ["claim_s1"]
+    assert set(accepted_ids) <= available_ids

--- a/src/tests/agents/dsl_linking/test_input_builder.py
+++ b/src/tests/agents/dsl_linking/test_input_builder.py
@@ -206,5 +206,5 @@ def test_build_uses_atomic_claim_objects_for_dsl_materials():
 
     claim_ids = [c["claim_id"] for c in llm_input.accepted_claims]
     assert "claim_parent" not in claim_ids
-    assert claim_ids == ["claim_atomic_2", "claim_atomic_1"]
+    assert claim_ids == ["claim_atomic_1", "claim_atomic_2"]
     assert all(c["atomicity"] == "atomic" and c["is_atomic"] for c in llm_input.accepted_claims)

--- a/src/tests/agents/test_claim_id_canonicalization.py
+++ b/src/tests/agents/test_claim_id_canonicalization.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from episteme_graph.agents.id_canonicalization import (
+    canonical_claim_id_for_span,
     canonical_claim_id_set,
     canonicalize_derivation_claim_refs,
     canonicalize_equation_claim_links,
@@ -38,11 +39,22 @@ class _Claim:
     claim_id: str
     source_span_ids: list = field(default_factory=list)
     section_id: str | None = None
+    parent_claim_id: str | None = None
+    subclaim_ids: list = field(default_factory=list)
+    atomicity: str = "atomic"
+    is_atomic: bool = True
 
 
 @dataclass
 class _ClaimObjects:
     claims: list = field(default_factory=list)
+
+
+@dataclass
+class _Span:
+    span_id: str
+    block_id: str | None = None
+    section_id: str | None = None
 
 
 def _eq(eq_id: str, linked_claim_ids: list[str]) -> EquationRecord:
@@ -132,6 +144,37 @@ def test_filter_remaps_span_provisional_to_final():
     kept, dropped = filter_claim_ref_list(["claim_span_001"], objs)
     assert kept == ["claim_final"]
     assert dropped == []
+
+
+def test_span_shared_by_parent_and_children_resolves_to_parent():
+    # Regression (component assembly preflight): a span atomically rewritten
+    # into a composite parent + atomic children shares its span_id with all
+    # three claims. Even without a section_id the span must resolve to the
+    # parent instead of falling back to the legacy `claim:<block>:<span>` ID.
+    objs = _ClaimObjects(claims=[
+        _Claim("claim_p_sub01", source_span_ids=["span_07"], parent_claim_id="claim_p"),
+        _Claim("claim_p_sub02", source_span_ids=["span_07"], parent_claim_id="claim_p"),
+        _Claim(
+            "claim_p",
+            source_span_ids=["span_07"],
+            subclaim_ids=["claim_p_sub01", "claim_p_sub02"],
+            atomicity="composite",
+            is_atomic=False,
+        ),
+    ])
+    span = _Span(span_id="span_07", block_id="blk_3", section_id=None)
+    assert canonical_claim_id_for_span(span, objs) == "claim_p"
+
+
+def test_span_shared_by_unrelated_claims_stays_legacy():
+    # Genuinely ambiguous: two unrelated atomic claims share a span with no
+    # hierarchy links — no canonical pick is possible, keep the legacy ID.
+    objs = _ClaimObjects(claims=[
+        _Claim("claim_a", source_span_ids=["span_07"]),
+        _Claim("claim_b", source_span_ids=["span_07"]),
+    ])
+    span = _Span(span_id="span_07", block_id="blk_3", section_id=None)
+    assert canonical_claim_id_for_span(span, objs) == "claim:blk_3:span_07"
 
 
 def test_filter_none_claim_objects_is_noop():


### PR DESCRIPTION
## Summary

Fixes a regression in claim ID resolution when spans are atomically rewritten into composite parent + atomic children claims. The issue caused the assembly preflight to reject accepted claims with provisional/legacy IDs that don't exist in the available claims set.

## Key Changes

- **`id_canonicalization.py`**: Refactored `_claim_lookup()` to track full claim objects instead of just IDs, enabling hierarchy-aware resolution. Added `_resolve_span_claim_id()` to pick the canonical claim ID for spans shared by multiple claim objects:
  - Prefers composite parent claims (identified via `parent_claim_id` / `subclaim_ids` links)
  - Falls back to the single non-atomic record among atomic ones
  - Returns empty string for genuinely ambiguous (unrelated) claims
  - Added `_claim_obj_is_atomic()` helper for atomicity detection

- **`input_builder.py`**: Updated `_accepted_claims()` to skip spans that don't resolve to a claim object when claim_objects exist, preventing injection of provisional IDs that fail assembly validation. This ensures only claims present in `claim_objects` are accepted.

- **Test updates**: 
  - Added regression test `test_span_without_section_id_split_into_atomic_claims_resolves_canonically()` verifying that atomically rewritten spans without section_id resolve to the parent claim
  - Added regression test `test_span_unresolvable_against_claim_objects_is_skipped()` verifying that orphan spans are skipped when claim_objects exist
  - Added unit tests in `test_claim_id_canonicalization.py` for parent/child hierarchy resolution and ambiguous span handling
  - Fixed test assertion ordering (claim IDs now sorted consistently)

## Implementation Details

The fix addresses issue #340 by making `claim_object_builder` the source of truth for claim IDs. When claim_objects are provided (e.g., resumed artifact), spans must resolve to actual claim objects or be skipped entirely—no provisional IDs are injected. The hierarchy-aware resolution ensures that atomically rewritten spans (where parent and children share the same span_id) correctly identify the parent as canonical, avoiding fallback to legacy `claim:<block>:<span>` format that the assembly preflight rejects.

https://claude.ai/code/session_01QW2ZJwcHrn3VP6TJ7uKTJG