### PR TITLE
Add deterministic graph health checks, symbol registry, and narrative layer

### DIFF
--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -294,7 +294,8 @@ prefix から導出し、特定分野・特定論文の用語をハードコー�
 - **equation_detail 層** (`graph_layer="equation_detail"`, `component_type="EquationOperationNode"`):
   derivation step ごとの式単位 node（ここでは equation ID 入り label を許容）。`parent_component_id` で
   main node を、main node は `member_component_ids` で detail node を相互参照する。generic step は
-  `debug` 層へ。
+  input/output 両方の式 backing があれば equation_detail 層に `partially_source_backed` +
+  `review_reasons=["generic_operation"]` で残し、式 backing が無い場合のみ `debug` 層へ (#361)。
 - **ComponentRefiner は「1 component = 1 reusable theory unit」(#308)**:
   `component_assembly/component_refiner.py` は derivation step を **operation family** 単位の
   再利用可能な理論ユニットに分割する（式 step 1 個 = 1 component ではない）。同 family の複数 step は

--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -173,6 +173,7 @@ OpenAI 形式                      → Gemini への変換
 | RhetoricalRoleAgent | #218 | Structure + Skeleton | RhetoricalRoleResult | LLM-first |
 | ClaimQualificationAgent | #219 | Structure + Skeleton + Roles | ClaimQualificationResult | LLM-first |
 | EquationSemanticsAgent | #220 | Structure + Skeleton + Roles | EquationSemanticsResult | LLM-first |
+| SymbolRegistryBuilder | #355 | EquationSemanticsResult | SymbolRegistryResult | 非LLM, deterministic（表記ゆれ正規化・redefinition 検出・scope 導出） |
 | ThesisReconstructionAgent | #221 | Skeleton + Claims + Equations | ThesisReconstructionResult | LLM-first |
 | DSLLinkingAgent | #222 | Claims + Equations + Thesis | DSLLinkingResult | LLM-first |
 | ComponentAssemblyAgent | #223 | Claims + Equations + Thesis + DSL | ComponentAssemblyResult | LLM-first + cartridge-aware |

--- a/.claude/skills/episteme-graph-knowledge/SKILL.md
+++ b/.claude/skills/episteme-graph-knowledge/SKILL.md
@@ -177,6 +177,7 @@ OpenAI 形式                      → Gemini への変換
 | ThesisReconstructionAgent | #221 | Skeleton + Claims + Equations | ThesisReconstructionResult | LLM-first |
 | DSLLinkingAgent | #222 | Claims + Equations + Thesis | DSLLinkingResult | LLM-first |
 | ComponentAssemblyAgent | #223 | Claims + Equations + Thesis + DSL | ComponentAssemblyResult | LLM-first + cartridge-aware |
+| NarrativeAnnotator | #360 | ComponentGraphResult + Thesis + Derivations | NarrativeAnnotationResult | LLM-first（annotation のみ、graph 構造は変更しない・全出力 provisional） |
 
 ### 各Agentの標準ファイル構成
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ PDF ファイル
 [#220] EquationSemanticsAgent   — 数式ブロック意味役割復元（LLM-first）
                                   + to_equations_export() で equations.json 化
     ↓  EquationSemanticsResult (JSON)
+[#355] SymbolRegistryBuilder    — 数式記号の定義・表記ゆれ・スコープの一元管理（非LLM）
+    ↓  SymbolRegistryResult (JSON)
 [#237] DerivationChainAgent     — 式間導出チェーン構築（非LLM）
     ↓  DerivationChainResult (JSON)
 [#237] FigureTableSemanticsAgent — 図表の意味復元（caption-first, LLM enricher 任意）
@@ -137,6 +139,7 @@ src/episteme_graph/agents/
   claim_qualification/     → ClaimQualificationAgent (#219)
   claim_object_builder/    → ClaimObjectBuilder (#237)
   equation_semantics/      → EquationSemanticsAgent (#220)
+  symbol_registry/         → SymbolRegistryBuilder (#355)
   derivation_chain/        → DerivationChainAgent (#237)
   figure_table_semantics/  → FigureTableSemanticsAgent (#237)
   course_mapping/          → CourseMappingAgent (#237)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ src/episteme_graph/agents/
   dsl_linking/          → DSLLinkingAgent (#222)
   component_assembly/   → ComponentAssemblyAgent (#223)
   component_graph/      → ComponentGraphAgent (#266) — TheoryOperationGraph 構築
+  narrative_annotator/  → NarrativeAnnotator (#360) — main graph への narrative 注釈（LLM-first, graph 構造非変更）
 ```
 
 各Agentディレクトリは最低限以下のファイルを持つ:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,9 @@ split_pending claim（`is_atomic=False`）は ComponentGraph / TheoryOperationGr
   `eliminate_* → eliminates` / `derive_* → derives` / `constrain_* → constrains` /
   `diagnose_* → diagnoses` / `compare_* → compares` のように prefix で edge_type を決める。
   `transform` / `relate` / `connect` / `support` / `associate` など抽象的な operation は
-  generic 扱いとし、`inferred` / `requires_review` にして warning を出す。
+  generic 扱いとし warning を出す。generic step でも input/output 両方の式 backing があれば
+  equation_detail 層に `partially_source_backed` + `review_reasons=["generic_operation"]` で残し、
+  式 backing が無い generic のみ debug 層で `inferred` にする (#361)。
 - **source-backing を必ず明示する**: 各 node は
   `linked_equation_ids` / `linked_derivation_ids` / `linked_claim_ids` / `linked_evidence_ids` と
   `source_backing_status`（`source_backed` / `partially_source_backed` / `inferred` / `review_required`）を持つ。
@@ -219,7 +221,8 @@ split_pending claim（`is_atomic=False`）は ComponentGraph / TheoryOperationGr
   (`graph_layer = "main"`, `component_type = "TheoryOperationNode"`)、式単位の step は
   (`graph_layer = "equation_detail"`, `component_type = "EquationOperationNode"`) に保持する。
   各 detail node は `parent_component_id`、各 main node は `member_component_ids` で相互参照する。
-  generic operation は main node にしない（detail / debug に置き `inferred`）。
+  generic operation は main node にしない（式 backing があれば detail に `partially_source_backed`、
+  無ければ debug に `inferred`。#361）。
 - **main graph は theory stage 単位で集約する (#308)**: 式 step は `(derivation_id, operation family)`
   ではなく **theory stage** で集約する。stage は `schema.stage_for_edge_type()` が operation の
   edge_type family から domain-neutral に導出する（`defines → theory_basis` /

--- a/backend/api/routes/theory_components.py
+++ b/backend/api/routes/theory_components.py
@@ -2097,6 +2097,8 @@ def _normalize_stored_component_graph(document_id: str, graph: dict, components:
         "nodes": normalized_nodes,
         "edges": normalized_edges,
         "validation_results": graph.get("validation_results") if isinstance(graph.get("validation_results"), list) else [],
+        # NarrativeAnnotator reading layer (issue #360); pass through as-is.
+        "narrative": graph.get("narrative") if isinstance(graph.get("narrative"), dict) else {},
     }
 
 

--- a/backend/api/schemas.py
+++ b/backend/api/schemas.py
@@ -915,6 +915,11 @@ class ComponentGraphResponse(BaseModel):
     nodes: list[ComponentGraphNode] = Field(default_factory=list)
     edges: list[ComponentGraphEdge] = Field(default_factory=list)
     validation_results: list[dict] = Field(default_factory=list)
+    # NarrativeAnnotator reading layer (issue #360): {graph_summary,
+    # maturity_source, node_narratives: {component_id: {...}},
+    # edge_narratives: {edge_id: {...}}}. Annotation only — never part of
+    # nodes / edges.
+    narrative: dict = Field(default_factory=dict)
 
 
 class LectureStudioSettings(BaseModel):

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -107,6 +107,16 @@ def _empty_theory_bundle_validation() -> dict:
     }
 
 
+def _empty_thesis_coverage() -> dict:
+    return {
+        "thesis_present": False,
+        "coverage_by_section": {},
+        "total_refs": 0,
+        "reachable_refs": 0,
+        "unreachable_refs": [],
+    }
+
+
 def _empty_teaching_output_validation() -> dict:
     return {
         "errors": [],
@@ -138,6 +148,9 @@ class ExportValidationResult:
     theory_bundle_validation: dict = field(default_factory=_empty_theory_bundle_validation)
     # TeachingOutputMapper Step 5 reporting (issue #326).
     teaching_output_validation: dict = field(default_factory=_empty_teaching_output_validation)
+    # Thesis coverage report (issue #354): is the central thesis (and each
+    # support_structure section) actually backed by the exported main graph?
+    thesis_coverage: dict = field(default_factory=_empty_thesis_coverage)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -458,6 +471,14 @@ class ExportValidationGate:
             component_result, errors, warnings, review_items
         )
 
+        # 7g. thesis coverage reporting (#354): verify each claim / equation the
+        # reconstructed thesis references is still present in the final claim /
+        # equation sets and is reachable from a main-layer graph node. Coverage
+        # gaps are review items (never hard errors).
+        thesis_coverage = self._check_thesis_coverage(
+            artifacts, component_result, claim_objects, review_items
+        )
+
         # 6. Determine status
         summary = ValidationSummary(
             error_count=len(errors),
@@ -496,6 +517,7 @@ class ExportValidationGate:
             derivation_graph_alignment=derivation_graph_alignment,
             theory_bundle_validation=theory_bundle_validation,
             teaching_output_validation=teaching_output_validation,
+            thesis_coverage=thesis_coverage,
         )
 
     # ------------------------------------------------------------------
@@ -1785,6 +1807,167 @@ class ExportValidationGate:
                     path=f"$.claims[{claim_id}].atomicity",
                     source_stage="export_validation",
                 ))
+
+    def _check_thesis_coverage(
+        self,
+        artifacts: dict,
+        component_result,
+        claim_objects,
+        review_items: list,
+    ) -> dict:
+        """Thesis coverage report (issue #354).
+
+        For the central thesis and each support_structure section, verify every
+        referenced claim_id / equation_id (a) still exists in the final claim /
+        equation sets and (b) is reachable from a main-layer graph node (or an
+        assembled component when the component_graph artifact is absent).
+        Unreachable refs are recorded with review_reasons=["thesis_support_unreachable"]
+        and surfaced as review items — never hard errors.
+        """
+        result = _empty_thesis_coverage()
+        thesis = artifacts.get("thesis_reconstruction")
+        if not isinstance(thesis, dict):
+            return result
+        central = thesis.get("central_thesis")
+        if not isinstance(central, dict):
+            return result
+        result["thesis_present"] = True
+
+        final_claim_ids = {
+            str(getattr(c, "claim_id", "") or "")
+            for c in (getattr(claim_objects, "claims", []) or [])
+            if getattr(c, "claim_id", None)
+        }
+        known_equation_ids = set(self._equation_index_from_artifacts(artifacts))
+        main_claim_ids, main_equation_ids = self._main_graph_backing_ids(
+            artifacts, component_result
+        )
+
+        sections: list[tuple[str, list[dict]]] = [("central_thesis", [central])]
+        support = thesis.get("support_structure")
+        if isinstance(support, dict):
+            for name, entries in support.items():
+                if isinstance(entries, list):
+                    sections.append(
+                        (str(name), [e for e in entries if isinstance(e, dict)])
+                    )
+
+        for section, entries in sections:
+            section_total = 0
+            section_reachable = 0
+            for entry in entries:
+                ref_groups = (
+                    ("claim", entry.get("claim_ids") or [],
+                     final_claim_ids, main_claim_ids),
+                    ("equation", entry.get("equation_ids") or [],
+                     known_equation_ids, main_equation_ids),
+                )
+                for ref_type, refs, known_ids, covered_ids in ref_groups:
+                    for ref in refs:
+                        ref_id = str(ref or "")
+                        if not ref_id:
+                            continue
+                        section_total += 1
+                        if known_ids and ref_id not in known_ids:
+                            reason = f"missing_{ref_type}"
+                        elif ref_id not in covered_ids:
+                            reason = "not_linked_to_main_graph"
+                        else:
+                            section_reachable += 1
+                            continue
+                        result["unreachable_refs"].append({
+                            "ref_id": ref_id,
+                            "ref_type": ref_type,
+                            "section": section,
+                            "reason": reason,
+                            "review_reasons": ["thesis_support_unreachable"],
+                        })
+                        review_items.append(ValidationEntry(
+                            code="THESIS_SUPPORT_UNREACHABLE",
+                            message=(
+                                f"thesis section {section!r} references {ref_type} "
+                                f"{ref_id!r} which is not reachable from the exported "
+                                f"main graph ({reason})"
+                            ),
+                            artifact="thesis_reconstruction",
+                            path=f"$.support_structure[{section}]"
+                            if section != "central_thesis"
+                            else "$.central_thesis",
+                            source_stage="export_validation",
+                        ))
+            if section_total:
+                result["coverage_by_section"][section] = round(
+                    section_reachable / section_total, 4
+                )
+                result["total_refs"] += section_total
+                result["reachable_refs"] += section_reachable
+        return result
+
+    @staticmethod
+    def _main_graph_backing_ids(
+        artifacts: dict, component_result
+    ) -> tuple[set[str], set[str]]:
+        """Claim / equation ids backed by main-layer graph nodes (issue #354).
+
+        A main node covers its own linked ids plus those of the equation_detail
+        members it aggregates. When the component_graph artifact is absent the
+        assembled components stand in as reachability targets so the report
+        degrades instead of marking everything unreachable.
+        """
+        claim_ids: set[str] = set()
+        equation_ids: set[str] = set()
+        node_claim_keys = (
+            "linked_claim_ids", "supports_claim_ids", "input_claim_ids",
+            "output_claim_ids", "required_claim_ids",
+        )
+        node_equation_keys = (
+            "linked_equation_ids", "input_equation_ids",
+            "intermediate_equation_ids", "output_equation_ids",
+            "definition_equation_ids", "constraint_equation_ids",
+        )
+
+        graph = artifacts.get("component_graph")
+        nodes = graph.get("nodes") if isinstance(graph, dict) else None
+        if isinstance(nodes, list) and nodes:
+            node_by_id = {
+                str(n.get("component_id") or ""): n
+                for n in nodes if isinstance(n, dict)
+            }
+            for node in nodes:
+                if not isinstance(node, dict):
+                    continue
+                if str(node.get("graph_layer") or "main") != "main":
+                    continue
+                members = [node] + [
+                    node_by_id.get(str(m))
+                    for m in node.get("member_component_ids") or []
+                ]
+                for member in members:
+                    if not isinstance(member, dict):
+                        continue
+                    for key in node_claim_keys:
+                        claim_ids.update(
+                            str(v) for v in member.get(key) or [] if v
+                        )
+                    for key in node_equation_keys:
+                        equation_ids.update(
+                            str(v) for v in member.get(key) or [] if v
+                        )
+            return claim_ids, equation_ids
+
+        for component in getattr(component_result, "components", []) or []:
+            refs = getattr(component, "evidence_refs", {}) or {}
+            claim_ids.update(
+                str(v) for v in (refs.get("claim_ids") or []) if v
+            )
+            for key in node_claim_keys:
+                claim_ids.update(
+                    str(v) for v in (getattr(component, key, []) or []) if v
+                )
+            equation_ids.update(
+                ExportValidationGate._component_equation_refs(component, refs)
+            )
+        return claim_ids, equation_ids
 
     def _check_concepts(
         self,

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -471,6 +471,18 @@ class ExportValidationGate:
             component_result, errors, warnings, review_items
         )
 
+        # 7g-0. graph health checks (#358): claim↔equation link symmetry and
+        # equation role conflicts across stages. Warnings only — the links are
+        # kept, never dropped.
+        if claim_objects is not None:
+            self._check_claim_equation_link_symmetry(
+                claim_objects, artifacts, warnings
+            )
+        if component_result is not None:
+            self._check_equation_role_conflicts(
+                component_result, artifacts, warnings
+            )
+
         # 7g. thesis coverage reporting (#354): verify each claim / equation the
         # reconstructed thesis references is still present in the final claim /
         # equation sets and is reachable from a main-layer graph node. Coverage
@@ -1807,6 +1819,107 @@ class ExportValidationGate:
                     path=f"$.claims[{claim_id}].atomicity",
                     source_stage="export_validation",
                 ))
+
+    def _check_claim_equation_link_symmetry(
+        self,
+        claim_objects,
+        artifacts: dict,
+        warnings: list,
+    ) -> None:
+        """Report one-way claim↔equation links (issue #358).
+
+        ``claim.equation_ids`` and ``equation.linked_claim_ids`` are maintained
+        by different stages and can drift apart. A one-way link is downgraded
+        to review metadata (warning) — the link itself is kept, never dropped.
+        """
+        equation_index = self._equation_index_from_artifacts(artifacts)
+        if not equation_index:
+            return
+        claims = list(getattr(claim_objects, "claims", []) or [])
+        claim_to_eq: dict[str, set[str]] = {}
+        for claim in claims:
+            claim_id = str(getattr(claim, "claim_id", "") or "")
+            if claim_id:
+                claim_to_eq[claim_id] = {
+                    str(v) for v in (getattr(claim, "equation_ids", []) or []) if v
+                }
+        eq_to_claim: dict[str, set[str]] = {}
+        for eq_id, eq in equation_index.items():
+            eq_to_claim[eq_id] = {
+                str(v) for v in (eq.get("linked_claim_ids") or []) if v
+            }
+
+        for claim_id, eq_ids in claim_to_eq.items():
+            for eq_id in eq_ids:
+                if eq_id in eq_to_claim and claim_id not in eq_to_claim[eq_id]:
+                    warnings.append(ValidationEntry(
+                        code="CLAIM_EQUATION_LINK_ASYMMETRY",
+                        message=(
+                            f"claim {claim_id!r} links equation {eq_id!r} but the "
+                            "equation does not link the claim back; treat the link "
+                            "as inferred until reviewed"
+                        ),
+                        artifact="claim_object_builder",
+                        path=f"$.claims[{claim_id}].equation_ids",
+                        source_stage="export_validation",
+                    ))
+        for eq_id, claim_ids in eq_to_claim.items():
+            for claim_id in claim_ids:
+                if claim_id in claim_to_eq and eq_id not in claim_to_eq[claim_id]:
+                    warnings.append(ValidationEntry(
+                        code="CLAIM_EQUATION_LINK_ASYMMETRY",
+                        message=(
+                            f"equation {eq_id!r} links claim {claim_id!r} but the "
+                            "claim does not link the equation back; treat the link "
+                            "as inferred until reviewed"
+                        ),
+                        artifact="equation_semantics",
+                        path=f"$.equations[{eq_id}].linked_claim_ids",
+                        source_stage="export_validation",
+                    ))
+
+    # Equation-semantics types whose equations must not appear in conflicting
+    # component role lists (issue #358). equation_semantics is the source of
+    # truth for an equation's type.
+    _EQUATION_ROLE_CONFLICTS = {
+        "definition": ("output_equation_ids",),
+        "result": ("definition_equation_ids",),
+    }
+
+    def _check_equation_role_conflicts(
+        self,
+        component_result,
+        artifacts: dict,
+        warnings: list,
+    ) -> None:
+        """Report stage-to-stage equation role conflicts (issue #358)."""
+        equation_index = self._equation_index_from_artifacts(artifacts)
+        if not equation_index:
+            return
+        eq_type_by_id = {}
+        for eq_id, eq in equation_index.items():
+            semantics = eq.get("semantics") if isinstance(eq.get("semantics"), dict) else {}
+            eq_type = str(eq.get("role") or semantics.get("equation_type") or "")
+            if eq_type:
+                eq_type_by_id[eq_id] = eq_type
+        for component in getattr(component_result, "components", []) or []:
+            comp_id = getattr(component, "component_id", "?")
+            for eq_type, conflicting_fields in self._EQUATION_ROLE_CONFLICTS.items():
+                for field_name in conflicting_fields:
+                    for eq_id in getattr(component, field_name, []) or []:
+                        if eq_type_by_id.get(str(eq_id)) != eq_type:
+                            continue
+                        warnings.append(ValidationEntry(
+                            code="EQUATION_ROLE_CONFLICT",
+                            message=(
+                                f"component {comp_id!r} classifies equation "
+                                f"{eq_id!r} as {field_name} but "
+                                f"equation_semantics types it as {eq_type!r}"
+                            ),
+                            artifact="component_assembly",
+                            path=f"$.components[{comp_id}].{field_name}",
+                            source_stage="export_validation",
+                        ))
 
     def _check_thesis_coverage(
         self,

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -1952,9 +1952,11 @@ class ExportValidationGate:
             if getattr(c, "claim_id", None)
         }
         known_equation_ids = set(self._equation_index_from_artifacts(artifacts))
-        main_claim_ids, main_equation_ids = self._main_graph_backing_ids(
-            artifacts, component_result
-        )
+        backing = self._main_graph_backing_ids(artifacts, component_result)
+        main_claim_ids = backing["claims"]
+        main_equation_ids = backing["equations"]
+        weak_claim_ids = backing["weak_claims"]
+        weak_equation_ids = backing["weak_equations"]
 
         sections: list[tuple[str, list[dict]]] = [("central_thesis", [central])]
         support = thesis.get("support_structure")
@@ -1971,11 +1973,11 @@ class ExportValidationGate:
             for entry in entries:
                 ref_groups = (
                     ("claim", entry.get("claim_ids") or [],
-                     final_claim_ids, main_claim_ids),
+                     final_claim_ids, main_claim_ids, weak_claim_ids),
                     ("equation", entry.get("equation_ids") or [],
-                     known_equation_ids, main_equation_ids),
+                     known_equation_ids, main_equation_ids, weak_equation_ids),
                 )
-                for ref_type, refs, known_ids, covered_ids in ref_groups:
+                for ref_type, refs, known_ids, covered_ids, weak_ids in ref_groups:
                     for ref in refs:
                         ref_id = str(ref or "")
                         if not ref_id:
@@ -1983,11 +1985,15 @@ class ExportValidationGate:
                         section_total += 1
                         if known_ids and ref_id not in known_ids:
                             reason = f"missing_{ref_type}"
-                        elif ref_id not in covered_ids:
-                            reason = "not_linked_to_main_graph"
-                        else:
+                        elif ref_id in covered_ids:
                             section_reachable += 1
                             continue
+                        elif ref_id in weak_ids:
+                            # Reachable only through inferred / review_required
+                            # main nodes — that is not support (#354 review fix).
+                            reason = "main_node_backing_insufficient"
+                        else:
+                            reason = "not_linked_to_main_graph"
                         result["unreachable_refs"].append({
                             "ref_id": ref_id,
                             "ref_type": ref_type,
@@ -2016,19 +2022,26 @@ class ExportValidationGate:
                 result["reachable_refs"] += section_reachable
         return result
 
+    # Main-node backing statuses that do NOT count as thesis support (#354):
+    # an inferred / review_required node is itself unconfirmed structure.
+    _WEAK_MAIN_NODE_BACKING = {"inferred", "review_required"}
+
     @staticmethod
-    def _main_graph_backing_ids(
-        artifacts: dict, component_result
-    ) -> tuple[set[str], set[str]]:
+    def _main_graph_backing_ids(artifacts: dict, component_result) -> dict:
         """Claim / equation ids backed by main-layer graph nodes (issue #354).
 
         A main node covers its own linked ids plus those of the equation_detail
-        members it aggregates. When the component_graph artifact is absent the
-        assembled components stand in as reachability targets so the report
-        degrades instead of marking everything unreachable.
+        members it aggregates. Nodes whose ``source_backing_status`` is
+        inferred / review_required collect into the ``weak_*`` sets instead —
+        coverage through them is reported as insufficient backing, not support.
+        When the component_graph artifact is absent the assembled components
+        stand in as reachability targets so the report degrades instead of
+        marking everything unreachable.
         """
-        claim_ids: set[str] = set()
-        equation_ids: set[str] = set()
+        result = {
+            "claims": set(), "equations": set(),
+            "weak_claims": set(), "weak_equations": set(),
+        }
         node_claim_keys = (
             "linked_claim_ids", "supports_claim_ids", "input_claim_ids",
             "output_claim_ids", "required_claim_ids",
@@ -2051,6 +2064,10 @@ class ExportValidationGate:
                     continue
                 if str(node.get("graph_layer") or "main") != "main":
                     continue
+                backing = str(node.get("source_backing_status") or "")
+                weak = backing in ExportValidationGate._WEAK_MAIN_NODE_BACKING
+                claim_key = "weak_claims" if weak else "claims"
+                equation_key = "weak_equations" if weak else "equations"
                 members = [node] + [
                     node_by_id.get(str(m))
                     for m in node.get("member_component_ids") or []
@@ -2059,28 +2076,31 @@ class ExportValidationGate:
                     if not isinstance(member, dict):
                         continue
                     for key in node_claim_keys:
-                        claim_ids.update(
+                        result[claim_key].update(
                             str(v) for v in member.get(key) or [] if v
                         )
                     for key in node_equation_keys:
-                        equation_ids.update(
+                        result[equation_key].update(
                             str(v) for v in member.get(key) or [] if v
                         )
-            return claim_ids, equation_ids
+            # An id covered by both a strong and a weak node counts as strong.
+            result["weak_claims"] -= result["claims"]
+            result["weak_equations"] -= result["equations"]
+            return result
 
         for component in getattr(component_result, "components", []) or []:
             refs = getattr(component, "evidence_refs", {}) or {}
-            claim_ids.update(
+            result["claims"].update(
                 str(v) for v in (refs.get("claim_ids") or []) if v
             )
             for key in node_claim_keys:
-                claim_ids.update(
+                result["claims"].update(
                     str(v) for v in (getattr(component, key, []) or []) if v
                 )
-            equation_ids.update(
+            result["equations"].update(
                 ExportValidationGate._component_equation_refs(component, refs)
             )
-        return claim_ids, equation_ids
+        return result
 
     def _check_concepts(
         self,

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -203,6 +203,18 @@ _HARD_ERROR_STAGES = {
     "dsl_linking",
     "claim_object_builder",
     "evidence_registry",
+    # ComponentGraphValidator errors (dependency cycles, equation-id labels,
+    # fallback nodes marked source_backed, ...) are design-level hard errors
+    # and must stop persist (#358 review fix).
+    "component_graph",
+}
+
+# Rule IDs kept as warnings even when their stage is a hard-error stage.
+# component_graph_failed marks the orchestrator's non-fatal stage fallback
+# (the agent crashed and an empty graph was substituted); escalating it would
+# turn a designed-to-be-non-fatal stage failure into a pipeline abort.
+_SOFT_ERROR_RULE_IDS = {
+    "component_graph_failed",
 }
 
 # Claim types representing the paper's main result / central conclusion (#312).
@@ -472,8 +484,9 @@ class ExportValidationGate:
         )
 
         # 7g-0. graph health checks (#358): claim↔equation link symmetry and
-        # equation role conflicts across stages. Warnings only — the links are
-        # kept, never dropped.
+        # equation role conflicts across stages. Warnings only — the demotion
+        # itself (primary link → inferred_*) happens upstream in the pipeline;
+        # the gate keeps both demoted and still-asymmetric links visible.
         if claim_objects is not None:
             self._check_claim_equation_link_symmetry(
                 claim_objects, artifacts, warnings
@@ -571,7 +584,7 @@ class ExportValidationGate:
                     review_items.append(entry)
                 elif code in _FORCED_ERROR_RULE_IDS:
                     errors.append(entry)
-                elif severity == _SEVERITY_ERROR and (
+                elif severity == _SEVERITY_ERROR and code not in _SOFT_ERROR_RULE_IDS and (
                     stage in _HARD_ERROR_STAGES or code in _HARD_ERROR_RULE_IDS
                 ):
                     errors.append(entry)
@@ -1829,8 +1842,11 @@ class ExportValidationGate:
         """Report one-way claim↔equation links (issue #358).
 
         ``claim.equation_ids`` and ``equation.linked_claim_ids`` are maintained
-        by different stages and can drift apart. A one-way link is downgraded
-        to review metadata (warning) — the link itself is kept, never dropped.
+        by different stages and can drift apart. The pipeline demotes one-way
+        links into ``inferred_equation_ids`` / ``inferred_claim_ids`` (see
+        ``annotate_claim_equation_link_asymmetries``); this check reports both
+        already-demoted links and any asymmetry still present in the primary
+        fields (artifacts that never went through the annotation step).
         """
         equation_index = self._equation_index_from_artifacts(artifacts)
         if not equation_index:
@@ -1877,6 +1893,39 @@ class ExportValidationGate:
                         path=f"$.equations[{eq_id}].linked_claim_ids",
                         source_stage="export_validation",
                     ))
+
+        # Links already demoted by the annotation step stay visible in the
+        # gate report (#358 review fix).
+        for claim in claims:
+            claim_id = str(getattr(claim, "claim_id", "") or "")
+            for eq_id in getattr(claim, "inferred_equation_ids", []) or []:
+                warnings.append(ValidationEntry(
+                    code="CLAIM_EQUATION_LINK_ASYMMETRY",
+                    message=(
+                        f"claim {claim_id!r} → equation {eq_id!r} link was "
+                        "demoted to inferred (one-way link); review before "
+                        "treating it as a confirmed link"
+                    ),
+                    artifact="claim_object_builder",
+                    path=f"$.claims[{claim_id}].inferred_equation_ids",
+                    source_stage="export_validation",
+                ))
+        for eq_id, eq in equation_index.items():
+            sem = eq.get("semantics") if isinstance(eq.get("semantics"), dict) else {}
+            for claim_id in (
+                eq.get("inferred_claim_ids") or sem.get("inferred_claim_ids") or []
+            ):
+                warnings.append(ValidationEntry(
+                    code="CLAIM_EQUATION_LINK_ASYMMETRY",
+                    message=(
+                        f"equation {eq_id!r} → claim {claim_id!r} link was "
+                        "demoted to inferred (one-way link); review before "
+                        "treating it as a confirmed link"
+                    ),
+                    artifact="equation_semantics",
+                    path=f"$.equations[{eq_id}].inferred_claim_ids",
+                    source_stage="export_validation",
+                ))
 
     # Equation-semantics types whose equations must not appear in conflicting
     # component role lists (issue #358). equation_semantics is the source of
@@ -2022,17 +2071,20 @@ class ExportValidationGate:
                 result["reachable_refs"] += section_reachable
         return result
 
-    # Main-node backing statuses that do NOT count as thesis support (#354):
-    # an inferred / review_required node is itself unconfirmed structure.
-    _WEAK_MAIN_NODE_BACKING = {"inferred", "review_required"}
+    # Main-node backing statuses that count as thesis support (#354): only a
+    # confirmed source_backed node. partially_source_backed / inferred /
+    # review_required / unknown backing is itself unconfirmed structure, so
+    # coverage through such nodes is reported as insufficient backing.
+    _STRONG_MAIN_NODE_BACKING = {"source_backed"}
 
     @staticmethod
     def _main_graph_backing_ids(artifacts: dict, component_result) -> dict:
         """Claim / equation ids backed by main-layer graph nodes (issue #354).
 
         A main node covers its own linked ids plus those of the equation_detail
-        members it aggregates. Nodes whose ``source_backing_status`` is
-        inferred / review_required collect into the ``weak_*`` sets instead —
+        members it aggregates. Only ``source_backed`` nodes count as strong
+        support; any other ``source_backing_status`` (partially_source_backed,
+        inferred, review_required, unknown) collects into the ``weak_*`` sets —
         coverage through them is reported as insufficient backing, not support.
         When the component_graph artifact is absent the assembled components
         stand in as reachability targets so the report degrades instead of
@@ -2065,7 +2117,7 @@ class ExportValidationGate:
                 if str(node.get("graph_layer") or "main") != "main":
                     continue
                 backing = str(node.get("source_backing_status") or "")
-                weak = backing in ExportValidationGate._WEAK_MAIN_NODE_BACKING
+                weak = backing not in ExportValidationGate._STRONG_MAIN_NODE_BACKING
                 claim_key = "weak_claims" if weak else "claims"
                 equation_key = "weak_equations" if weak else "equations"
                 members = [node] + [

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -54,6 +54,7 @@ PIPELINE_STAGES = [
     "dsl_embedding",
     "component_assembly",
     "component_graph",
+    "narrative_annotator",
     "course_mapping",
     "blueprint",
     "export_validation",
@@ -887,6 +888,42 @@ def run_document_pipeline(
         if finish_target_stage("component_graph", {"nodes": len(getattr(component_graph_result, "nodes", []) or []), "edges": len(getattr(component_graph_result, "edges", []) or []), "total": 1, "processed": 1}):
             return result
 
+        # ── Stage 12a.1: narrative_annotator (reading layer for main graph, #360) ─
+        # Annotation-only LLM stage: graph_summary / narrative_role /
+        # transition_text are stored as a separate artifact and never modify the
+        # graph. Non-fatal: downstream stages do not depend on it.
+        narrative_artifact = artifact("narrative_annotator")
+        if should_use_artifact("narrative_annotator"):
+            narrative = _from_agent_dict("narrative_annotator", narrative_artifact)
+            logger.info("Resuming document pipeline: loaded narrative_annotator artifact for document %s", document_id)
+        else:
+            report_start("narrative_annotator", total=1, unit="llm_call")
+            narrative = None
+            try:
+                from episteme_graph.agents.narrative_annotator.agent import NarrativeAnnotator
+
+                narrative = NarrativeAnnotator().run(
+                    component_graph_result,
+                    thesis=thesis,
+                    derivations=derivations,
+                    cartridge_id=cartridge_id,
+                )
+                save_artifact("narrative_annotator", narrative)
+            except Exception as exc:
+                logger.warning(
+                    "narrative_annotator stage failed (non-fatal): document=%s error=%s",
+                    document_id, exc, exc_info=True,
+                )
+        narrative_counts = {
+            "node_narratives": len(getattr(narrative, "node_narratives", []) or []),
+            "edge_narratives": len(getattr(narrative, "edge_narratives", []) or []),
+            "total": 1,
+            "processed": 1,
+        }
+        report_done("narrative_annotator", narrative_counts)
+        if finish_target_stage("narrative_annotator", narrative_counts):
+            return result
+
         # ── Stage 12b: course_mapping (deterministic component → topic map) ─
         course_mapping_artifact = artifact("course_mapping")
         if should_use_artifact("course_mapping"):
@@ -1051,6 +1088,7 @@ def run_document_pipeline(
                     course_id=course_id,
                     component_graph_result=component_graph_result,
                     claim_id_map=claim_id_map,
+                    narrative_result=narrative,
                 )
                 save_artifact("persist_claims_components_graph", {
                     "claims": result.claim_count,
@@ -1251,6 +1289,9 @@ def _from_agent_dict(stage: str, value: dict) -> Any:
     if stage == "component_graph":
         from episteme_graph.agents.component_graph.schema import ComponentGraphResult
         return ComponentGraphResult.from_dict(value)
+    if stage == "narrative_annotator":
+        from episteme_graph.agents.narrative_annotator.schema import NarrativeAnnotationResult
+        return NarrativeAnnotationResult.from_dict(value)
     if stage == "evidence_registry":
         from episteme_graph.agents.evidence_registry.schema import EvidenceRegistryResult
         return EvidenceRegistryResult.from_dict(value)

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -46,6 +46,7 @@ PIPELINE_STAGES = [
     "equation_semantics",
     "evidence_registry",
     "claim_object_builder",
+    "symbol_registry",
     "derivation_chain",
     "figure_table_semantics",
     "thesis_reconstruction",
@@ -616,6 +617,37 @@ def run_document_pipeline(
                 "equation claim-link canonicalization failed (non-fatal): document=%s",
                 document_id, exc_info=True,
             )
+
+        # ── Stage 8c.2: symbol_registry (deterministic from equations, #355) ─
+        # Aggregates defined/used symbols into a document-wide registry and
+        # annotates DefinedSymbol.symbol_id on the equations in place. Non-fatal:
+        # downstream stages do not depend on it yet.
+        symbol_registry_artifact = artifact("symbol_registry")
+        if should_use_artifact("symbol_registry"):
+            symbol_registry = _from_agent_dict("symbol_registry", symbol_registry_artifact)
+            logger.info("Resuming document pipeline: loaded symbol_registry artifact for document %s", document_id)
+        else:
+            report_start("symbol_registry", total=1, unit="builder")
+            symbol_registry = None
+            try:
+                from episteme_graph.agents.symbol_registry.builder import SymbolRegistryBuilder
+
+                symbol_registry = SymbolRegistryBuilder().run(
+                    equations, cartridge_id=cartridge_id
+                )
+                # The builder set DefinedSymbol.symbol_id in place; persist the
+                # annotated equations so resumes keep the registry references.
+                save_artifact("equation_semantics", equations)
+                save_artifact("symbol_registry", symbol_registry)
+            except Exception as exc:
+                logger.warning(
+                    "symbol_registry stage failed (non-fatal): document=%s error=%s",
+                    document_id, exc, exc_info=True,
+                )
+        symbol_count = len(getattr(symbol_registry, "records", []) or [])
+        report_done("symbol_registry", {"symbols": symbol_count, "total": 1, "processed": 1})
+        if finish_target_stage("symbol_registry", {"symbols": symbol_count, "total": 1, "processed": 1}):
+            return result
 
         # ── Stage 8d: derivation_chain (deterministic from equation links) ─
         derivation_artifact = artifact("derivation_chain")
@@ -1225,6 +1257,9 @@ def _from_agent_dict(stage: str, value: dict) -> Any:
     if stage == "claim_object_builder":
         from episteme_graph.agents.claim_object_builder.schema import ClaimObjectBuildResult
         return ClaimObjectBuildResult.from_dict(value)
+    if stage == "symbol_registry":
+        from episteme_graph.agents.symbol_registry.schema import SymbolRegistryResult
+        return SymbolRegistryResult.from_dict(value)
     if stage == "derivation_chain":
         from episteme_graph.agents.derivation_chain.schema import DerivationChainResult
         return DerivationChainResult.from_dict(value)

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -622,8 +622,9 @@ def run_document_pipeline(
             )
 
         # ── Stage 8c.1b: claim↔equation link symmetry (issue #358) ─────────
-        # One-way links are kept but explicitly demoted to review metadata on
-        # both artifacts (equation review flag / claim review note).
+        # One-way links are demoted to inferred: moved out of the primary link
+        # fields into inferred_equation_ids / inferred_claim_ids (kept, never
+        # dropped) plus review metadata on both artifacts.
         try:
             from episteme_graph.agents.id_canonicalization import (
                 annotate_claim_equation_link_asymmetries,

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -1358,11 +1358,17 @@ def _build_evidence_registry(
         qual = getattr(span, "qualification", {}) or {}
         if isinstance(qual, dict) and qual.get("status") not in (None, "accepted"):
             continue
-        builder.add_for_block(
+        parent_evidence_id = builder.add_for_block(
             block_id,
             evidence_role="source_quote",
             review_note=getattr(span, "reason", "") or "",
         )
+        # Sentence-level records (issue #363) so atomic claims can cite the
+        # exact supporting sentence instead of the whole block.
+        if parent_evidence_id:
+            builder.add_sentences_for_block(
+                block_id, parent_evidence_id=parent_evidence_id
+            )
         seen_block_ids.add(block_id)
 
     # Register evidence for each equation block.

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -552,6 +552,7 @@ def run_document_pipeline(
                     structure=structure,
                     qualified=qualified,
                     equations=equations,
+                    roles=roles,
                 )
             except Exception as exc:
                 logger.exception(
@@ -617,6 +618,30 @@ def run_document_pipeline(
         except Exception:
             logger.warning(
                 "equation claim-link canonicalization failed (non-fatal): document=%s",
+                document_id, exc_info=True,
+            )
+
+        # ── Stage 8c.1b: claim↔equation link symmetry (issue #358) ─────────
+        # One-way links are kept but explicitly demoted to review metadata on
+        # both artifacts (equation review flag / claim review note).
+        try:
+            from episteme_graph.agents.id_canonicalization import (
+                annotate_claim_equation_link_asymmetries,
+            )
+
+            asymmetries = annotate_claim_equation_link_asymmetries(
+                claim_objects, equations
+            )
+            if asymmetries:
+                save_artifact("claim_object_builder", claim_objects)
+                save_artifact("equation_semantics", equations)
+                logger.info(
+                    "Annotated %d one-way claim↔equation link(s) for document %s",
+                    asymmetries, document_id,
+                )
+        except Exception:
+            logger.warning(
+                "claim-equation link symmetry annotation failed (non-fatal): document=%s",
                 document_id, exc_info=True,
             )
 
@@ -1342,6 +1367,7 @@ def _build_evidence_registry(
     structure: Any,
     qualified: Any,
     equations: Any,
+    roles: Any = None,
 ):
     from episteme_graph.agents.evidence_registry.builder import EvidenceRegistryBuilder
 
@@ -1394,7 +1420,13 @@ def _build_evidence_registry(
             builder.add_for_block(block_id, evidence_role="table_caption_quote")
             seen_block_ids.add(block_id)
 
-    return builder.build(document_id=document_id, cartridge_id=cartridge_id)
+    registry = builder.build(document_id=document_id, cartridge_id=cartridge_id)
+    # RhetoricalRole span offsets vs evidence spans (issue #363).
+    if roles is not None:
+        from episteme_graph.agents.evidence_registry.builder import check_span_alignment
+
+        check_span_alignment(roles, registry)
+    return registry
 
 
 def _empty_evidence_registry(document_id: str, cartridge_id: str | None):

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -583,6 +583,7 @@ def run_document_pipeline(
                     qualified=qualified,
                     equations=equations,
                     evidence=evidence,
+                    document_structure=structure,
                 )
             except Exception as exc:
                 logger.exception(
@@ -1409,6 +1410,7 @@ def _build_claim_objects(
     qualified: Any,
     equations: Any,
     evidence: Any,
+    document_structure: Any = None,
 ):
     from episteme_graph.agents.claim_object_builder.builder import ClaimObjectBuilder
 
@@ -1424,6 +1426,7 @@ def _build_claim_objects(
         equation_index=equation_index,
         cartridge_ontology=None,
         equation_semantics_result=equations,
+        document_structure=document_structure,
     )
     spans = list(getattr(qualified, "qualified_spans", []) or [])
     return builder.build(

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -699,6 +699,44 @@ def _split_main_label(label: str) -> tuple[str, str]:
     return split_main_label(label)
 
 
+def _narrative_payload(narrative_result, component_id_map: dict[str, str]) -> dict:
+    """NarrativeAnnotator output keyed by stored DB component ids (issue #360)."""
+    if narrative_result is None:
+        return {}
+    node_map: dict[str, dict] = {}
+    for narrative in getattr(narrative_result, "node_narratives", []) or []:
+        agent_id = str(getattr(narrative, "component_id", "") or "")
+        if not agent_id:
+            continue
+        db_id = component_id_map.get(agent_id, agent_id)
+        node_map[db_id] = {
+            "narrative_role": str(getattr(narrative, "narrative_role", "") or ""),
+            "reason": str(getattr(narrative, "reason", "") or ""),
+            "confidence": float(getattr(narrative, "confidence", 0.0) or 0.0),
+        }
+    edge_map: dict[str, dict] = {}
+    for narrative in getattr(narrative_result, "edge_narratives", []) or []:
+        edge_id = str(getattr(narrative, "edge_id", "") or "")
+        if not edge_id:
+            continue
+        edge_map[edge_id] = {
+            "transition_text": str(getattr(narrative, "transition_text", "") or ""),
+            "reason": str(getattr(narrative, "reason", "") or ""),
+            "confidence": float(getattr(narrative, "confidence", 0.0) or 0.0),
+        }
+    graph_summary = str(getattr(narrative_result, "graph_summary", "") or "")
+    if not graph_summary and not node_map and not edge_map:
+        return {}
+    return {
+        "graph_summary": graph_summary,
+        "maturity_source": str(
+            getattr(narrative_result, "maturity_source", "") or "llm_proposed"
+        ),
+        "node_narratives": node_map,
+        "edge_narratives": edge_map,
+    }
+
+
 def _normalize_graph_payload_for_persist(graph: dict) -> dict:
     """Guarantee the persisted graph satisfies the stored-graph invariants (issue #319).
 
@@ -765,6 +803,7 @@ def persist_component_graph(
     course_id: str | None = None,
     component_graph_result=None,
     claim_id_map: dict[str, str] | None = None,
+    narrative_result=None,
 ) -> str | None:
     """document scope の component graph を `theory_component_graphs` に保存。
 
@@ -900,6 +939,11 @@ def persist_component_graph(
         "dsl": {"nodes": dsl_nodes, "edges": dsl_edges},
         "validation_results": validation_issues,
     })
+    # Reading layer from NarrativeAnnotator (issue #360): stored as a sibling
+    # block, never merged into nodes/edges, always provisional.
+    narrative_payload = _narrative_payload(narrative_result, component_id_map)
+    if narrative_payload:
+        graph["narrative"] = narrative_payload
 
     session = _pg_session()
     try:

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -4169,3 +4169,38 @@ body {
   border-left: 3px solid #E24B4A;
   padding-left: 8px;
 }
+
+/* Narrative reading layer from NarrativeAnnotator (issue #360) */
+.ls-graph-narrative-summary {
+  margin: 0 0 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: 8px;
+  background: var(--color-bg-secondary);
+  font-size: 12px;
+  line-height: 1.6;
+}
+.ls-graph-narrative-summary p {
+  margin: 6px 0 0;
+}
+.ls-graph-narrative-title {
+  font-weight: 600;
+  font-size: 12px;
+}
+.ls-graph-narrative-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font-size: 9px;
+  font-weight: 500;
+  vertical-align: middle;
+}
+.ls-graph-detail-edge-narrative {
+  margin-top: 4px;
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -244,6 +244,7 @@
       stages: [
         ["evidence_registry", "EvidenceRegistryBuilder"],
         ["claim_object_builder", "ClaimObjectBuilder"],
+        ["symbol_registry", "SymbolRegistryBuilder"],
         ["derivation_chain", "DerivationChainAgent"],
         ["figure_table_semantics", "FigureTableSemanticsAgent"],
       ],
@@ -6879,6 +6880,7 @@
     equation_semantics: "EquationSemanticsAgent",
     evidence_registry: "EvidenceRegistryBuilder",
     claim_object_builder: "ClaimObjectBuilder",
+    symbol_registry: "SymbolRegistryBuilder",
     derivation_chain: "DerivationChainAgent",
     figure_table_semantics: "FigureTableSemanticsAgent",
     thesis_reconstruction: "ThesisReconstructionAgent",

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -256,6 +256,7 @@
         ["dsl_linking", "DSLLinkingAgent"],
         ["component_assembly", "ComponentAssemblyAgent"],
         ["component_graph", "ComponentGraphAgent"],
+        ["narrative_annotator", "NarrativeAnnotator"],
       ],
     },
     {
@@ -5290,6 +5291,7 @@
 
     var view = lsGraphForCurrentLayer(graph);
     var html =
+      lsGraphNarrativeSummaryHtml(graph) +
       '<div class="ls-component-graph-shell">' +
         '<div class="ls-component-graph-main">' +
           lsGraphLayerToolbarHtml(nodes) +
@@ -5320,6 +5322,19 @@
     }
 
     lsInitComponentGraphNetwork(view);
+  }
+
+  // Issue #360: NarrativeAnnotator の graph_summary をグラフ上部に表示する。
+  // 注釈は LLM 提案 (provisional) なのでラベルで明示する。
+  function lsGraphNarrativeSummaryHtml(graph) {
+    var narrative = (graph && graph.narrative) || {};
+    var summary = String(narrative.graph_summary || "").trim();
+    if (!summary) return "";
+    return '<div class="ls-graph-narrative-summary">' +
+      '<div class="ls-graph-narrative-title">この論文のグラフの読み方' +
+      '<span class="ls-graph-narrative-badge">AI提案</span></div>' +
+      '<p>' + escHtml(summary) + '</p>' +
+    '</div>';
   }
 
   // Issue #306: グラフは main（上位理論構成）と equation_detail（式単位）の
@@ -5552,6 +5567,14 @@
       html += '<div class="ls-graph-detail-section"><b>このノードの意味</b><p>' + escHtml(node.description) + '</p></div>';
     }
 
+    // 1a. 論文の議論での役割（NarrativeAnnotator, issue #360。LLM 提案）
+    var graphNarrative = (graph && graph.narrative) || {};
+    var nodeNarrative = (graphNarrative.node_narratives || {})[nodeId];
+    if (nodeNarrative && String(nodeNarrative.narrative_role || "").trim()) {
+      html += '<div class="ls-graph-detail-section"><b>議論での役割 <span class="ls-graph-narrative-badge">AI提案</span></b>' +
+        '<p>' + escHtml(nodeNarrative.narrative_role) + '</p></div>';
+    }
+
     // 1b. 抽出メモ（review_reason — step.reason からの抽出/検証メモ）
     var reviewReason = String(node.review_reason || "").trim();
     if (reviewReason) {
@@ -5605,6 +5628,12 @@
         var reason = String(evidence.reason || "").trim();
         if (reason) {
           html += '<div class="ls-graph-detail-edge-reason">' + escHtml(reason) + '</div>';
+        }
+        // 遷移の説明（NarrativeAnnotator, issue #360。LLM 提案）
+        var edgeNarrative = (graphNarrative.edge_narratives || {})[edge.edge_id];
+        var transition = edgeNarrative ? String(edgeNarrative.transition_text || "").trim() : "";
+        if (transition) {
+          html += '<div class="ls-graph-detail-edge-narrative">' + escHtml(transition) + ' <span class="ls-graph-narrative-badge">AI提案</span></div>';
         }
         html += '</li>';
       });
@@ -6887,6 +6916,7 @@
     dsl_linking: "DSLLinkingAgent",
     component_assembly: "ComponentAssemblyAgent",
     component_graph: "ComponentGraphAgent",
+    narrative_annotator: "NarrativeAnnotator",
     course_mapping: "CourseMappingAgent",
     blueprint: "BlueprintAgent",
     export_validation: "ExportValidationGate",

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -19,6 +19,11 @@ import re
 from dataclasses import dataclass, field as _dc_field
 from typing import Callable, Iterable, Optional
 
+from episteme_graph.agents.content_normalization import (
+    CONTENT_HASH_VERSION,
+    claim_content_hash,
+)
+
 from .schema import (
     CLAIM_TYPE_ONTOLOGY,
     ClaimConcept,
@@ -305,6 +310,9 @@ class ClaimObjectBuilder:
             )
             claims.append(record)
 
+        # Deterministic content hashes for cross-paper matching (issue #362).
+        self._apply_content_hashes(claims)
+        self._report_duplicate_content_hashes(claims, issues)
         self._validate_claim_set(claims, issues)
 
         return ClaimObjectBuildResult(
@@ -313,6 +321,36 @@ class ClaimObjectBuilder:
             claims=claims,
             validation_issues=issues,
         )
+
+    @staticmethod
+    def _apply_content_hashes(claims: list[ClaimObjectRecord]) -> None:
+        for claim in claims:
+            claim.content_hash = claim_content_hash(
+                claim.normalized_text or claim.text
+            )
+            claim.content_hash_version = CONTENT_HASH_VERSION
+
+    @staticmethod
+    def _report_duplicate_content_hashes(
+        claims: list[ClaimObjectRecord],
+        issues: list[ValidationIssue],
+    ) -> None:
+        """Within-document hash collisions are reported, never auto-merged (#362)."""
+        by_hash: dict[str, list[str]] = {}
+        for claim in claims:
+            if claim.content_hash:
+                by_hash.setdefault(claim.content_hash, []).append(claim.claim_id)
+        for hash_value, claim_ids in by_hash.items():
+            if len(claim_ids) > 1:
+                issues.append(ValidationIssue(
+                    rule_id="duplicate_claim_content_hash",
+                    severity="warning",
+                    message=(
+                        f"claims {', '.join(claim_ids)} share content_hash "
+                        f"{hash_value}; review for duplication (not auto-merged)"
+                    ),
+                    field=claim_ids[0],
+                ))
 
     def _add_issues_for_record(
         self,

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -29,6 +29,8 @@ from .schema import (
     REVIEW_STATUSES,
     SUPPORT_STATUSES,
     ValidationIssue,
+    derive_support_status,
+    normalize_atomicity,
 )
 
 
@@ -68,6 +70,9 @@ class _BuildCtx:
     review_status: str = "teacher_review_required"
     claim_type: str = "unknown"
     text: str = ""
+    section_title: str | None = None
+    # Canonical support_status from evidence presence + adequacy (issue #359).
+    support_status_base: str = "inferred"
 
 
 class ClaimObjectBuilder:
@@ -95,6 +100,7 @@ class ClaimObjectBuilder:
         concept_resolver: Optional[Callable] = None,
         cartridge_ontology: dict | None = None,
         equation_semantics_result: object | None = None,
+        document_structure: object | None = None,
     ) -> None:
         self._evidence_registry = evidence_registry
         self._equation_index = equation_index or {}
@@ -102,6 +108,13 @@ class ClaimObjectBuilder:
         self._cartridge_ontology = cartridge_ontology or {}
         self._span_to_evidence: dict[str, list[str]] = {}
         self._known_evidence_ids: set[str] = set()
+        # section_id → human-readable title (issue #359).
+        self._section_titles: dict[str, str] = {}
+        for section in getattr(document_structure, "sections", None) or []:
+            sid = getattr(section, "section_id", None)
+            title = getattr(section, "title", None)
+            if sid and title:
+                self._section_titles[str(sid)] = str(title)
         if evidence_registry is not None:
             for r in getattr(evidence_registry, "records", []) or []:
                 eid = getattr(r, "evidence_id", None)
@@ -157,6 +170,10 @@ class ClaimObjectBuilder:
             evidence_ids = self._resolve_evidence_ids(block_id)
             review_note = self._extract_review_note(span)
             review_status = self._derive_review_status(qual)
+            support_status_base = derive_support_status(
+                bool(evidence_ids), qual.get("evidence_adequacy")
+            )
+            section_title = self._section_titles.get(str(section_id or "")) or None
 
             ctx = _BuildCtx(
                 document_id=document_id,
@@ -171,6 +188,8 @@ class ClaimObjectBuilder:
                 review_status=review_status,
                 claim_type=claim_type,
                 text=text,
+                section_title=section_title,
+                support_status_base=support_status_base,
             )
 
             # Atomic rewrite responsibility (issue #317): the LLM atomic rewrite is
@@ -254,7 +273,7 @@ class ClaimObjectBuilder:
 
             # Single, already-atomic claim (non-atomic spans were routed to the
             # LLM-atomic or deterministic-fallback paths above, issue #317).
-            single_support_status = "source_backed" if evidence_ids else "inferred"
+            single_support_status = support_status_base
             record = ClaimObjectRecord(
                 claim_id=claim_id,
                 document_id=document_id,
@@ -270,6 +289,7 @@ class ClaimObjectBuilder:
                 review_status=review_status,
                 review_note=review_note,
                 section_id=section_id,
+                section_title=section_title,
                 confidence=confidence,
                 normalized_text=text,
                 atomicity="atomic",
@@ -366,9 +386,7 @@ class ClaimObjectBuilder:
             text = str(cand.get("text", "")).strip()
             if not text:
                 continue
-            atomicity = str(cand.get("atomicity", "atomic")).strip().lower()
-            if atomicity in {"non_atomic", "split_pending"}:
-                atomicity = "split_required"
+            atomicity = normalize_atomicity(cand.get("atomicity", "atomic"))
             if atomicity not in ("atomic", "split_required"):
                 atomicity = "atomic"
             status = str(cand.get("status", "")).strip().lower()
@@ -471,10 +489,11 @@ class ClaimObjectBuilder:
             equation_ids=parent_eqs,
             figure_ids=[],
             table_ids=[],
-            support_status="source_backed" if ctx.evidence_ids else "inferred",
+            support_status=ctx.support_status_base,
             review_status=ctx.review_status,
             review_note=ctx.review_note,
             section_id=ctx.section_id,
+            section_title=ctx.section_title,
             confidence=ctx.confidence,
             normalized_text=ctx.text,
             atomicity="composite",
@@ -485,7 +504,7 @@ class ClaimObjectBuilder:
             split_suggestions=split_suggestions,
             concept_assignment_status=self._concept_assignment_status(
                 is_atomic=False,
-                support_status="source_backed" if ctx.evidence_ids else "inferred",
+                support_status=ctx.support_status_base,
                 concepts=parent_concepts,
             ),
         ))
@@ -513,7 +532,7 @@ class ClaimObjectBuilder:
         if cand["atomicity"] == "atomic" and cand["status"] == "accepted":
             atomicity = "atomic"
             is_atomic = True
-            support_status = "source_backed" if ctx.evidence_ids else "inferred"
+            support_status = ctx.support_status_base
             qualification_reason = None
         else:
             # The agent flagged this piece as not confidently atomized.
@@ -549,6 +568,7 @@ class ClaimObjectBuilder:
             review_status=ctx.review_status,
             review_note=ctx.review_note,
             section_id=ctx.section_id,
+            section_title=ctx.section_title,
             confidence=ctx.confidence,
             normalized_text=text,
             atomicity=atomicity,
@@ -613,6 +633,7 @@ class ClaimObjectBuilder:
                 review_status=ctx.review_status,
                 review_note=ctx.review_note,
                 section_id=ctx.section_id,
+                section_title=ctx.section_title,
                 confidence=ctx.confidence,
                 normalized_text=part,
                 atomicity="split_required",
@@ -646,6 +667,7 @@ class ClaimObjectBuilder:
             review_status=ctx.review_status,
             review_note=ctx.review_note,
             section_id=ctx.section_id,
+            section_title=ctx.section_title,
             confidence=ctx.confidence,
             normalized_text=ctx.text,
             atomicity="split_required",

--- a/src/episteme_graph/agents/claim_object_builder/builder.py
+++ b/src/episteme_graph/agents/claim_object_builder/builder.py
@@ -22,6 +22,7 @@ from typing import Callable, Iterable, Optional
 from episteme_graph.agents.content_normalization import (
     CONTENT_HASH_VERSION,
     claim_content_hash,
+    normalize_text_for_hash,
 )
 
 from .schema import (
@@ -113,6 +114,8 @@ class ClaimObjectBuilder:
         self._cartridge_ontology = cartridge_ontology or {}
         self._span_to_evidence: dict[str, list[str]] = {}
         self._known_evidence_ids: set[str] = set()
+        # block_id → [(normalized sentence text, evidence_id)] (issue #363).
+        self._sentence_evidence_by_block: dict[str, list[tuple[str, str]]] = {}
         # section_id → human-readable title (issue #359).
         self._section_titles: dict[str, str] = {}
         for section in getattr(document_structure, "sections", None) or []:
@@ -126,7 +129,17 @@ class ClaimObjectBuilder:
                 if eid:
                     self._known_evidence_ids.add(eid)
                 bid = getattr(r.source, "block_id", None)
-                if bid:
+                if not bid:
+                    continue
+                if getattr(r, "evidence_role", "") == "sentence_quote":
+                    normalized = normalize_text_for_hash(
+                        getattr(r, "evidence_text", "") or ""
+                    )
+                    if normalized:
+                        self._sentence_evidence_by_block.setdefault(bid, []).append(
+                            (normalized, r.evidence_id)
+                        )
+                else:
                     self._span_to_evidence.setdefault(bid, []).append(r.evidence_id)
 
         # Build proximity index: block_id → [equation_id], section_id → [equation_id]
@@ -442,6 +455,7 @@ class ClaimObjectBuilder:
                 "status": status,
                 "qualification_reason": str(cand.get("qualification_reason", "") or ""),
                 "source_span_id": str(cand.get("source_span_id", "") or ""),
+                "evidence_quote": str(cand.get("evidence_quote", "") or ""),
             })
         if normalized:
             return normalized
@@ -466,6 +480,38 @@ class ClaimObjectBuilder:
                 "source_span_id": "",
             })
         return normalized
+
+    def _refine_evidence_ids(
+        self,
+        block_id: str | None,
+        evidence_quote: str,
+        fallback_ids: list[str],
+        claim_id: str,
+        issues: list[ValidationIssue],
+    ) -> list[str]:
+        """Narrow block-level evidence to the matching sentence (issue #363)."""
+        quote = normalize_text_for_hash(evidence_quote or "")
+        if not quote or not block_id:
+            return list(fallback_ids)
+        sentences = self._sentence_evidence_by_block.get(str(block_id)) or []
+        if not sentences:
+            return list(fallback_ids)
+        for normalized, evidence_id in sentences:
+            if normalized == quote:
+                return [evidence_id]
+        for normalized, evidence_id in sentences:
+            if quote in normalized or normalized in quote:
+                return [evidence_id]
+        issues.append(ValidationIssue(
+            rule_id="evidence_quote_unmatched",
+            severity="warning",
+            message=(
+                f"claim {claim_id} evidence_quote does not match any sentence "
+                f"of block {block_id}; keeping block-level evidence"
+            ),
+            field=claim_id,
+        ))
+        return list(fallback_ids)
 
     @staticmethod
     def _dedup_id(base: str, counter: int, seen: set[str]) -> str:
@@ -566,6 +612,14 @@ class ClaimObjectBuilder:
             text, claim_type, ctx.role_labels, ctx.block_id, ctx.section_id
         )
         source_span_id = cand.get("source_span_id") or ctx.span_id
+        # Sentence-level evidence refinement (issue #363): when the atomic
+        # claim's evidence_quote matches a sentence record, cite that sentence
+        # instead of the whole block. On no match the block-level evidence is
+        # kept and the mismatch is reported — never dropped.
+        evidence_ids = self._refine_evidence_ids(
+            ctx.block_id, cand.get("evidence_quote", ""), ctx.evidence_ids,
+            claim_id, issues,
+        )
 
         if cand["atomicity"] == "atomic" and cand["status"] == "accepted":
             atomicity = "atomic"
@@ -596,7 +650,7 @@ class ClaimObjectBuilder:
             document_id=ctx.document_id,
             claim_type=claim_type,
             text=text,
-            source_evidence_ids=ctx.evidence_ids,
+            source_evidence_ids=evidence_ids,
             source_span_ids=[source_span_id] if source_span_id else [],
             concepts=concepts,
             equation_ids=equation_ids,
@@ -621,7 +675,7 @@ class ClaimObjectBuilder:
             ),
         ))
         self._add_issues_for_record(
-            claim_id, ctx.evidence_ids, concepts, claim_type, equation_ids, issues
+            claim_id, evidence_ids, concepts, claim_type, equation_ids, issues
         )
 
     def _emit_fallback_split(

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -192,6 +192,10 @@ class ClaimObjectRecord:
     # confirmed source_backed so the graph / course mapping do not treat their
     # concepts as strong backing.
     concept_assignment_status: str = "review_required"
+    # Deterministic content hash for cross-paper matching (issue #362).
+    # "" / 0 on legacy artifacts that predate hashing.
+    content_hash: str = ""
+    content_hash_version: int = 0
 
 
 @dataclass
@@ -261,6 +265,8 @@ class ClaimObjectBuildResult:
                 concept_assignment_status=raw.get(
                     "concept_assignment_status", "review_required"
                 ),
+                content_hash=str(raw.get("content_hash", "") or ""),
+                content_hash_version=int(raw.get("content_hash_version", 0) or 0),
             ))
         issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
         return cls(

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -162,6 +162,10 @@ class ClaimObjectRecord:
     source_span_ids: list[str]
     concepts: list[ClaimConcept]
     equation_ids: list[str] = field(default_factory=list)
+    # Equation links demoted to inferred (#358): the equation does not link
+    # this claim back, so downstream stages must not consume the link as a
+    # confirmed one. The id is kept here, never dropped.
+    inferred_equation_ids: list[str] = field(default_factory=list)
     figure_ids: list[str] = field(default_factory=list)
     table_ids: list[str] = field(default_factory=list)
     support_status: str = "source_backed"
@@ -244,6 +248,7 @@ class ClaimObjectBuildResult:
                 source_span_ids=list(raw.get("source_span_ids", [])),
                 concepts=concepts,
                 equation_ids=list(raw.get("equation_ids", [])),
+                inferred_equation_ids=list(raw.get("inferred_equation_ids", [])),
                 figure_ids=list(raw.get("figure_ids", [])),
                 table_ids=list(raw.get("table_ids", [])),
                 support_status=raw.get("support_status", "source_backed"),

--- a/src/episteme_graph/agents/claim_object_builder/schema.py
+++ b/src/episteme_graph/agents/claim_object_builder/schema.py
@@ -14,25 +14,66 @@ SUPPORT_STATUSES = [
     "unknown",
 ]
 
-# Atomicity vocabulary:
+# Atomicity vocabulary (issue #359: single source of truth):
 #   atomic         — single minimal proposition
 #   composite      — parent claim split into atomic children
 #   split_required — multiple propositions, not usable as component backing
-# Legacy aliases accepted on read/export validation: compound, non_atomic, split_pending.
-ATOMICITY_VALUES = [
+# Legacy aliases are converted to the canonical values at read time via
+# normalize_atomicity(); freshly built artifacts only ever emit canonical values.
+CANONICAL_ATOMICITY_VALUES = [
     "atomic",
     "composite",
     "split_required",
-    "compound",
-    "non_atomic",
-    "split_pending",
 ]
+
+# legacy value (older artifacts / ClaimQualification vocabulary) → canonical.
+ATOMICITY_ALIASES = {
+    "compound": "composite",
+    "non_atomic": "split_required",
+    "split_pending": "split_required",
+}
+
+# Accepted on read / export validation: canonical + legacy aliases.
+ATOMICITY_VALUES = CANONICAL_ATOMICITY_VALUES + list(ATOMICITY_ALIASES)
+
+
+def normalize_atomicity(value: object) -> str:
+    """Map any accepted atomicity value to the canonical vocabulary (issue #359)."""
+    raw = str(value or "atomic").strip().lower()
+    if raw in CANONICAL_ATOMICITY_VALUES:
+        return raw
+    return ATOMICITY_ALIASES.get(raw, "atomic")
+
 
 REVIEW_STATUSES = [
     "auto_accepted",
     "teacher_review_required",
     "rejected",
 ]
+
+# ClaimQualificationAgent's evidence_adequacy is a qualification-stage
+# intermediate signal; ClaimObjectRecord.support_status is the canonical
+# downstream vocabulary (issue #359). This is the single mapping between the
+# two — do not re-derive it inline.
+EVIDENCE_ADEQUACY_TO_SUPPORT_STATUS = {
+    "sufficient": "source_backed",
+    "weak": "partially_source_backed",
+    "broken": "review_required",
+}
+
+
+def derive_support_status(has_evidence: bool, evidence_adequacy: object = None) -> str:
+    """Canonical support_status from qualification-stage evidence signals.
+
+    Without an evidence link the claim is at most ``inferred`` regardless of
+    adequacy. With evidence, adequacy caps the strength: sufficient →
+    source_backed / weak → partially_source_backed / broken → review_required.
+    Missing adequacy keeps the historical default (source_backed).
+    """
+    if not has_evidence:
+        return "inferred"
+    key = str(evidence_adequacy or "").strip().lower()
+    return EVIDENCE_ADEQUACY_TO_SUPPORT_STATUS.get(key, "source_backed")
 
 # Concept assignment status vocabulary (issue #8):
 #   source_backed    — atomic, source-backed claim with concepts from the cartridge
@@ -127,6 +168,9 @@ class ClaimObjectRecord:
     review_status: str = "teacher_review_required"
     review_note: str = ""
     section_id: str | None = None
+    # Human-readable section title (issue #359) so a claim can be read on its
+    # own ("in the methods" resolves without the DocumentStructure artifact).
+    section_title: str | None = None
     confidence: float = 0.0
     # Normalized single-proposition phrasing (issue #312). Mirrors `text` when no
     # separate normalization is available.
@@ -202,9 +246,12 @@ class ClaimObjectBuildResult:
                 review_status=raw.get("review_status", "teacher_review_required"),
                 review_note=raw.get("review_note", ""),
                 section_id=raw.get("section_id"),
+                section_title=raw.get("section_title"),
                 confidence=float(raw.get("confidence", 0.0)),
                 normalized_text=raw.get("normalized_text", "") or raw.get("text", ""),
-                atomicity=raw.get("atomicity", "atomic"),
+                # Legacy aliases (compound / non_atomic / split_pending) are
+                # converted to canonical values on read (issue #359).
+                atomicity=normalize_atomicity(raw.get("atomicity", "atomic")),
                 is_atomic=bool(raw.get("is_atomic", raw.get("atomicity", "atomic") == "atomic")),
                 qualification_reason=raw.get("qualification_reason"),
                 parent_claim_id=raw.get("parent_claim_id"),

--- a/src/episteme_graph/agents/claim_qualification/agent.py
+++ b/src/episteme_graph/agents/claim_qualification/agent.py
@@ -8,6 +8,7 @@ from episteme_graph.agents.paper_skeleton.schema import PaperSkeletonResult
 from episteme_graph.agents.rhetorical_role.schema import RhetoricalRoleResult
 
 from .cartridge_loader import CartridgeLoader
+from .context_lint import unresolved_fragments
 from .input_builder import ClaimQualificationInputBuilder
 from .llm_client import ClaimQualificationLLMClient
 from .prompt import ClaimQualificationPromptFactory
@@ -75,6 +76,9 @@ class ClaimQualificationAgent:
                 continue
 
             record = _parse_record(raw_output, llm_input)
+            record, raw_output = self._retry_unresolved_references(
+                record, raw_output, llm_input, cartridge
+            )
             partial = self._build_result(
                 document_id=roles.document_id,
                 cartridge_id=llm_input.cartridge_id,
@@ -109,6 +113,39 @@ class ClaimQualificationAgent:
         )
         result.validation_issues = self._validator.validate(result, cartridge)
         return result
+
+    def _retry_unresolved_references(
+        self,
+        record: QualifiedSpanRecord,
+        raw_output: dict,
+        llm_input,
+        cartridge: CartridgeContext | None,
+    ):
+        """Single targeted retry when the context lint demoted claims (#357).
+
+        The lint in _parse_record demoted accepted atomic claims with
+        unresolved anaphora; ask the LLM once to name the concrete referent.
+        If the retry still leaves unresolved references (or fails), keep the
+        demoted record — review_required, never silently accepted.
+        """
+        fragments = unresolved_fragments(record.atomic_claims)
+        if not fragments:
+            return record, raw_output
+        try:
+            retry_messages = self._prompt_factory.build_reference_repair_messages(
+                llm_input, raw_output, fragments, cartridge
+            )
+            retry_raw = self._llm_client.generate(retry_messages)
+        except Exception as exc:
+            logger.warning(
+                "Unresolved-reference retry failed for span_id=%s: %s",
+                llm_input.span_id, exc,
+            )
+            return record, raw_output
+        retry_record = _parse_record(retry_raw, llm_input)
+        if unresolved_fragments(retry_record.atomic_claims):
+            return record, raw_output
+        return retry_record, retry_raw
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
         if not cartridge_id:

--- a/src/episteme_graph/agents/claim_qualification/agent.py
+++ b/src/episteme_graph/agents/claim_qualification/agent.py
@@ -145,6 +145,17 @@ class ClaimQualificationAgent:
         retry_record = _parse_record(retry_raw, llm_input)
         if unresolved_fragments(retry_record.atomic_claims):
             return record, raw_output
+        # Information must never be lost (#357): a retry that silently drops
+        # atomic claims is not a fix — keep the demoted original instead.
+        if len(retry_record.atomic_claims) < len(record.atomic_claims):
+            logger.warning(
+                "Unresolved-reference retry for span_id=%s dropped atomic claims "
+                "(%d -> %d); keeping the demoted original",
+                llm_input.span_id,
+                len(record.atomic_claims),
+                len(retry_record.atomic_claims),
+            )
+            return record, raw_output
         return retry_record, retry_raw
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:

--- a/src/episteme_graph/agents/claim_qualification/context_lint.py
+++ b/src/episteme_graph/agents/claim_qualification/context_lint.py
@@ -1,0 +1,161 @@
+"""Deterministic context-dependency lint for atomic claims (issue #357).
+
+The atomic-rewrite prompt instructs the LLM to resolve pronouns and
+"this result"-style anaphora, but nothing verified the model actually did.
+This lint enforces it deterministically:
+
+- an *accepted atomic* claim whose text still leads with an unresolved
+  anaphoric subject is demoted to ``status="review_required"`` with
+  ``unresolved_reference`` recorded in its ``qualification_reason``
+  (information is kept, never dropped);
+- intra-document references ("Section 3", "Fig. 2", "Eq. (2.7)") are NOT
+  treated as unresolved — they are extracted into the structured
+  ``context_refs`` list (equation labels normalised to ``eq_*`` ids) so the
+  claim stays reusable with its context made explicit.
+
+Self-references to the paper itself ("This paper", "This work", …) are not
+flagged: they are reviewable paper-level subjects, and paper-level claims are
+already handled by the atomicity machinery.
+"""
+from __future__ import annotations
+
+import re
+
+UNRESOLVED_REFERENCE_MARKER = "unresolved_reference"
+
+# Nouns that, after a leading demonstrative, still point back at unstated
+# context ("This result shows…"). Domain-neutral discourse nouns only.
+_ANAPHORIC_NOUNS = (
+    "result|results|finding|findings|observation|observations|value|values|"
+    "quantity|quantities|expression|expressions|relation|relations|term|terms|"
+    "effect|effects|case|cases|procedure|behavior|behaviour|approach|approaches|"
+    "argument|claim|statement|fact|property|properties|feature|features|"
+    "consequence|consequences|condition|conditions|situation|scenario"
+)
+
+# Verbs that expose a bare demonstrative subject ("This shows…", "These are…").
+_LEADING_VERBS = (
+    "is|are|was|were|shows|show|showed|implies|imply|means|mean|leads|lead|"
+    "gives|give|yields|yield|holds|hold|suggests|suggest|demonstrates|"
+    "demonstrate|indicates|indicate|confirms|confirm|corresponds|correspond|"
+    "provides|provide|results|result|follows|follow|allows|allow|requires|"
+    "require|becomes|become|reduces|reduce|depends|depend|can|cannot|may|"
+    "might|will|would|should|must|does|do|did|has|have|had"
+)
+
+# Paper self-reference subjects that are allowed (not anaphora to be resolved).
+_ALLOWED_SELF_REFERENCE = (
+    "paper|work|study|article|letter|manuscript|analysis|section"
+)
+
+_UNRESOLVED_LEAD_PATTERNS = [
+    # Bare demonstrative subject: "This shows…", "Those were…"
+    re.compile(
+        r"^(this|that|these|those)\s+(?:also\s+)?(?:" + _LEADING_VERBS + r")\b",
+        re.IGNORECASE,
+    ),
+    # Demonstrative + generic discourse noun: "This result…", "These findings…"
+    re.compile(
+        r"^(this|that|these|those)\s+(?:" + _ANAPHORIC_NOUNS + r")\b",
+        re.IGNORECASE,
+    ),
+    # Bare pronoun subject: "It implies…", "They are…"
+    re.compile(r"^(it|they)\s+(?:also\s+)?(?:" + _LEADING_VERBS + r")\b", re.IGNORECASE),
+    # "The former/latter/above/aforementioned …"
+    re.compile(r"^the\s+(former|latter|above|aforementioned)\b", re.IGNORECASE),
+    # "As shown/mentioned/discussed above/earlier/before, …"
+    re.compile(r"^as\s+(shown|mentioned|discussed|described|noted)\s+(above|earlier|before)\b", re.IGNORECASE),
+    # Japanese leading anaphora: この/その/これら/それら/上記/前述/同様の
+    re.compile(r"^(この|その|これら|それら|上記の?|前述の?|同様の)"),
+]
+
+_SELF_REFERENCE_PATTERN = re.compile(
+    r"^(this|the present)\s+(?:" + _ALLOWED_SELF_REFERENCE + r")\b", re.IGNORECASE
+)
+
+# Intra-document references extracted into context_refs (not flagged).
+_CONTEXT_REF_PATTERNS = [
+    ("equation", re.compile(
+        r"\b(?:Eq|Eqs|Equation|Equations)\.?\s*\(?([A-Za-z0-9][A-Za-z0-9.\-]*)\)?",
+    )),
+    ("section", re.compile(r"\b(Section|Sec\.|Appendix)\s+([A-Za-z0-9][A-Za-z0-9.\-]*)")),
+    ("figure", re.compile(r"\b(Figure|Fig\.)\s*([A-Za-z0-9][A-Za-z0-9.\-]*)")),
+    ("table", re.compile(r"\b(Table|Tab\.)\s*([A-Za-z0-9][A-Za-z0-9.\-]*)")),
+    ("reference", re.compile(r"\bRefs?\.\s*\[([0-9,\s\-]+)\]")),
+]
+
+
+def find_unresolved_reference(text: str) -> str | None:
+    """Return the unresolved leading fragment, or None when self-contained."""
+    candidate = str(text or "").strip()
+    if not candidate:
+        return None
+    if _SELF_REFERENCE_PATTERN.match(candidate):
+        return None
+    for pattern in _UNRESOLVED_LEAD_PATTERNS:
+        match = pattern.match(candidate)
+        if match:
+            return match.group(0)
+    return None
+
+
+def extract_context_refs(text: str) -> list[str]:
+    """Structured intra-document references mentioned by the claim text.
+
+    Equation labels are normalised to registry-style ids ("Eq. (2.7)" →
+    "eq_2_7"); other refs keep a readable "<Kind> <label>" form.
+    """
+    refs: list[str] = []
+    candidate = str(text or "")
+    for kind, pattern in _CONTEXT_REF_PATTERNS:
+        for match in pattern.finditer(candidate):
+            if kind == "equation":
+                label = match.group(1).rstrip(".-")
+                normalized = re.sub(r"[^A-Za-z0-9]+", "_", label).strip("_")
+                ref = f"eq_{normalized}" if normalized else ""
+            elif kind == "reference":
+                ref = f"Ref. [{match.group(1).strip()}]"
+            else:
+                ref = f"{match.group(1).rstrip('.')} {match.group(2).rstrip('.-')}"
+            if ref and ref not in refs:
+                refs.append(ref)
+    return refs
+
+
+def apply_context_lint(atomic_claims: list[dict]) -> list[str]:
+    """Lint atomic claim entries in place (issue #357).
+
+    Fills ``context_refs`` on every entry and demotes accepted atomic claims
+    with an unresolved leading reference. Returns the unresolved fragments so
+    the agent can run a single targeted repair retry.
+    """
+    fragments: list[str] = []
+    for claim in atomic_claims or []:
+        if not isinstance(claim, dict):
+            continue
+        text = str(claim.get("normalized_text") or claim.get("text") or "")
+        claim["context_refs"] = extract_context_refs(text)
+        if claim.get("atomicity") != "atomic" or claim.get("status") != "accepted":
+            continue
+        fragment = find_unresolved_reference(text)
+        if not fragment:
+            continue
+        claim["status"] = "review_required"
+        reason = str(claim.get("qualification_reason") or "")
+        note = f"{UNRESOLVED_REFERENCE_MARKER}: leading {fragment!r} is not resolved"
+        claim["qualification_reason"] = f"{reason}; {note}" if reason else note
+        fragments.append(fragment)
+    return fragments
+
+
+def unresolved_fragments(atomic_claims: list[dict]) -> list[str]:
+    """Fragments of claims demoted by this lint (marker-based, idempotent)."""
+    fragments: list[str] = []
+    for claim in atomic_claims or []:
+        if not isinstance(claim, dict):
+            continue
+        if claim.get("status") == "review_required" and UNRESOLVED_REFERENCE_MARKER in str(
+            claim.get("qualification_reason") or ""
+        ):
+            fragments.append(str(claim.get("text") or "")[:80])
+    return fragments

--- a/src/episteme_graph/agents/claim_qualification/prompt.py
+++ b/src/episteme_graph/agents/claim_qualification/prompt.py
@@ -131,6 +131,33 @@ class ClaimQualificationPromptFactory:
             {"role": "user", "content": content},
         ]
 
+    def build_reference_repair_messages(
+        self,
+        llm_input: QualificationLLMInput,
+        previous_output: dict,
+        unresolved_fragments: list[str],
+        cartridge: CartridgeContext | None = None,
+    ) -> list[dict]:
+        """Single targeted retry for unresolved anaphora (issue #357)."""
+        fragments = "\n".join(f"- {f!r}" for f in unresolved_fragments)
+        content = (
+            self._build_user_content(llm_input, cartridge)
+            + "\n\n## Previous Output\n"
+            + json.dumps(previous_output, ensure_ascii=False, indent=2)
+            + "\n\n## Unresolved References\n"
+            + "The following atomic claims still begin with an unresolved "
+            + "pronoun / demonstrative and cannot stand alone:\n"
+            + fragments
+            + "\n\nRewrite each flagged atomic claim so its subject names the "
+            + "concrete referent from the span or source block (e.g. replace "
+            + "\"This result shows\" with \"<the actual quantity/relation> shows\"). "
+            + "Keep every other field unchanged. Return corrected JSON for this same span."
+        )
+        return [
+            {"role": "system", "content": _SYSTEM_CONTENT},
+            {"role": "user", "content": content},
+        ]
+
     def _build_user_content(
         self,
         llm_input: QualificationLLMInput,

--- a/src/episteme_graph/agents/claim_qualification/repair.py
+++ b/src/episteme_graph/agents/claim_qualification/repair.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 
+from .context_lint import apply_context_lint
 from .llm_client import ClaimQualificationLLMClient
 from .prompt import ClaimQualificationPromptFactory
 from .schema import (
@@ -79,6 +80,10 @@ def _parse_record(raw: dict, llm_input: QualificationLLMInput) -> QualifiedSpanR
         confidence = 0.5
 
     atomic_claims = _normalize_atomic_claims(raw, edit_suggestions, llm_input)
+    # Deterministic context-dependency lint (issue #357): demote accepted
+    # atomic claims whose text still leads with unresolved anaphora, and fill
+    # the structured context_refs list.
+    apply_context_lint(atomic_claims)
 
     return QualifiedSpanRecord(
         span_id=raw.get("span_id", llm_input.span_id),
@@ -148,6 +153,9 @@ def _normalize_atomic_claims(
                 entry.get("qualification_reason", "")
                 or ("legacy split_claims candidate" if legacy else "")
             ),
+            # Structured intra-document references (issue #357); filled by the
+            # context lint after normalization.
+            "context_refs": list(entry.get("context_refs") or []),
             "confidence": max(0.0, min(1.0, conf)),
         })
     return normalized

--- a/src/episteme_graph/agents/claim_qualification/schema.py
+++ b/src/episteme_graph/agents/claim_qualification/schema.py
@@ -115,6 +115,7 @@ class QualifiedSpanRecord:
     # Atomic claim candidates produced by the LLM atomic-rewrite step (issue #317).
     # Each entry is a dict with: text, normalized_text, claim_type_candidate,
     # atomicity, status, source_span_id, evidence_quote, qualification_reason,
+    # context_refs (structured intra-document references, issue #357),
     # confidence. Empty when the span is already atomic or no rewrite was needed.
     atomic_claims: list[dict] = field(default_factory=list)
 

--- a/src/episteme_graph/agents/claim_qualification/validator.py
+++ b/src/episteme_graph/agents/claim_qualification/validator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import re
 
+from .context_lint import find_unresolved_reference
 from .schema import (
     ATOMIC_CLAIM_ATOMICITY,
     ATOMIC_CLAIM_LEADING_CONNECTORS,
@@ -288,6 +289,23 @@ class ClaimQualificationValidator:
                                 "it cannot be traced back to the source"
                             ),
                             field=path,
+                        ))
+                    # issue #357: an accepted atomic claim must be context-free.
+                    # The parse-time lint demotes these; this is the safety net
+                    # for reloaded artifacts that bypassed the lint.
+                    fragment = find_unresolved_reference(
+                        str(claim.get("normalized_text") or text)
+                    )
+                    if fragment:
+                        issues.append(ValidationIssue(
+                            rule_id="atomic_claim_unresolved_reference",
+                            severity="warning",
+                            message=(
+                                f"{path} starts with unresolved reference "
+                                f"{fragment!r}; it cannot stand alone outside "
+                                "its original context"
+                            ),
+                            field=f"{path}.text",
                         ))
         return issues
 

--- a/src/episteme_graph/agents/claim_selection.py
+++ b/src/episteme_graph/agents/claim_selection.py
@@ -1,0 +1,153 @@
+"""Shared claim input selection policy for downstream LLM input builders (issue #356).
+
+thesis_reconstruction / dsl_linking / component_assembly each cap how many
+claims they expose to the LLM. Before this module each builder truncated its
+own list in document order, so the visible claim set differed per stage and
+claims silently disappeared. This module centralises the ordering policy and
+makes every drop explicit:
+
+- importance order: claim_tier (paper_core first) → confidence (desc) →
+  original document order as the stable tie-break
+- claims cut by the limit are returned as ``excluded`` entries
+  ({claim_id, span_id, excluded_at_stage, reason, referenced_by_thesis}) so
+  agents can persist them on their results instead of dropping silently.
+
+Selected rows keep their original relative (document) order — only membership
+is decided by importance — so prompts remain stable for the LLM.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Lower value = selected first. Unknown tiers rank with background.
+TIER_PRIORITY = {
+    "paper_core": 0,
+    "paper_supporting": 1,
+    "background": 2,
+    "prior_work": 3,
+    "meta": 4,
+}
+_DEFAULT_TIER_PRIORITY = TIER_PRIORITY["background"]
+
+EXCLUSION_REASON_LIMIT = "max_claims_exceeded"
+
+# Validation rule ids surfaced by agents when the limit drops claims.
+RULE_CLAIM_INPUT_LIMIT_EXCEEDED = "claim_input_limit_exceeded"
+RULE_THESIS_REFERENCED_CLAIM_EXCLUDED = "thesis_referenced_claim_excluded"
+
+
+@dataclass
+class ClaimSelection:
+    selected: list[dict]
+    excluded: list[dict] = field(default_factory=list)
+
+
+def select_claim_rows(
+    rows: list[dict],
+    limit: int,
+    *,
+    stage: str,
+    thesis_claim_ids: set[str] | None = None,
+) -> ClaimSelection:
+    """Apply the shared importance-based limit to claim input rows.
+
+    ``rows`` are the fully built claim input dicts (must carry ``claim_id``;
+    ``claim_tier`` and ``confidence`` are used for ranking when present).
+    """
+    rows = list(rows or [])
+    if limit <= 0 or len(rows) <= limit:
+        return ClaimSelection(selected=rows)
+
+    def _priority(index: int) -> tuple:
+        row = rows[index]
+        tier = str(row.get("claim_tier") or "")
+        try:
+            confidence = float(row.get("confidence") or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        return (
+            TIER_PRIORITY.get(tier, _DEFAULT_TIER_PRIORITY),
+            -confidence,
+            index,
+        )
+
+    ranked = sorted(range(len(rows)), key=_priority)
+    keep = set(ranked[:limit])
+    selected = [rows[i] for i in range(len(rows)) if i in keep]
+
+    thesis_ids = {str(v) for v in (thesis_claim_ids or set()) if v}
+    excluded: list[dict] = []
+    for i in range(len(rows)):
+        if i in keep:
+            continue
+        row = rows[i]
+        claim_id = str(row.get("claim_id") or "")
+        excluded.append({
+            "claim_id": claim_id,
+            "span_id": str(row.get("span_id") or ""),
+            "claim_tier": str(row.get("claim_tier") or ""),
+            "excluded_at_stage": stage,
+            "reason": EXCLUSION_REASON_LIMIT,
+            "referenced_by_thesis": bool(claim_id and claim_id in thesis_ids),
+        })
+    return ClaimSelection(selected=selected, excluded=excluded)
+
+
+def thesis_claim_id_set(thesis) -> set[str]:
+    """Claim ids referenced by central_thesis / support_structure (issue #356)."""
+    ids: set[str] = set()
+    if thesis is None:
+        return ids
+    central = getattr(thesis, "central_thesis", None)
+    if isinstance(central, dict):
+        ids.update(str(v) for v in (central.get("claim_ids") or []) if v)
+    support = getattr(thesis, "support_structure", None)
+    if isinstance(support, dict):
+        for entries in support.values():
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if isinstance(entry, dict):
+                    ids.update(str(v) for v in (entry.get("claim_ids") or []) if v)
+    return ids
+
+
+def selection_issue_payloads(excluded: list[dict], *, stage: str) -> list[dict]:
+    """Warning payloads ({rule_id, severity, message, field}) for dropped claims.
+
+    Agents wrap these in their module-local ValidationIssue dataclass so the
+    drops show up in export_validation review metadata (issue #356).
+    """
+    excluded = [e for e in (excluded or []) if isinstance(e, dict)]
+    if not excluded:
+        return []
+    payloads = [{
+        "rule_id": RULE_CLAIM_INPUT_LIMIT_EXCEEDED,
+        "severity": "warning",
+        "message": (
+            f"{stage} input limit dropped {len(excluded)} claim(s): "
+            + ", ".join(
+                e.get("claim_id") or e.get("span_id") or "?"
+                for e in excluded[:8]
+            )
+            + ("…" if len(excluded) > 8 else "")
+        ),
+        "field": "accepted_claims",
+    }]
+    thesis_referenced = [
+        e for e in excluded if e.get("referenced_by_thesis")
+    ]
+    if thesis_referenced:
+        payloads.append({
+            "rule_id": RULE_THESIS_REFERENCED_CLAIM_EXCLUDED,
+            "severity": "warning",
+            "message": (
+                f"{stage} input limit dropped thesis-referenced claim(s): "
+                + ", ".join(
+                    e.get("claim_id") or "?" for e in thesis_referenced[:8]
+                )
+                + ("…" if len(thesis_referenced) > 8 else "")
+            ),
+            "field": "accepted_claims",
+        })
+    return payloads

--- a/src/episteme_graph/agents/claim_selection.py
+++ b/src/episteme_graph/agents/claim_selection.py
@@ -6,8 +6,9 @@ own list in document order, so the visible claim set differed per stage and
 claims silently disappeared. This module centralises the ordering policy and
 makes every drop explicit:
 
-- importance order: claim_tier (paper_core first) → confidence (desc) →
-  original document order as the stable tie-break
+- importance order: claim_tier (paper_core first) → relevance to the headline
+  claim (desc) → confidence (desc) → original document order as the stable
+  tie-break
 - claims cut by the limit are returned as ``excluded`` entries
   ({claim_id, span_id, excluded_at_stage, reason, referenced_by_thesis}) so
   agents can persist them on their results instead of dropping silently.
@@ -17,6 +18,7 @@ is decided by importance — so prompts remain stable for the LLM.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 
 # Lower value = selected first. Unknown tiers rank with background.
@@ -42,21 +44,45 @@ class ClaimSelection:
     excluded: list[dict] = field(default_factory=list)
 
 
+def _relevance_tokens(text: str) -> set[str]:
+    """Lowercased content tokens (length >= 3) for headline-relevance overlap."""
+    return {
+        token
+        for token in re.findall(r"[A-Za-z0-9_]+", str(text or "").lower())
+        if len(token) >= 3
+    }
+
+
+def headline_text_for_selection(*, skeleton=None, thesis=None) -> str:
+    """Headline claim text from the available upstream artifact (issue #356)."""
+    headline = getattr(skeleton, "headline_claim", None)
+    if isinstance(headline, dict) and str(headline.get("text") or "").strip():
+        return str(headline["text"])
+    central = getattr(thesis, "central_thesis", None)
+    if isinstance(central, dict):
+        return str(central.get("text") or "")
+    return ""
+
+
 def select_claim_rows(
     rows: list[dict],
     limit: int,
     *,
     stage: str,
     thesis_claim_ids: set[str] | None = None,
+    headline_text: str | None = None,
 ) -> ClaimSelection:
     """Apply the shared importance-based limit to claim input rows.
 
     ``rows`` are the fully built claim input dicts (must carry ``claim_id``;
-    ``claim_tier`` and ``confidence`` are used for ranking when present).
+    ``claim_tier``, ``confidence``, and token overlap with ``headline_text``
+    are used for ranking when present).
     """
     rows = list(rows or [])
     if limit <= 0 or len(rows) <= limit:
         return ClaimSelection(selected=rows)
+
+    headline_tokens = _relevance_tokens(headline_text or "")
 
     def _priority(index: int) -> tuple:
         row = rows[index]
@@ -65,8 +91,12 @@ def select_claim_rows(
             confidence = float(row.get("confidence") or 0.0)
         except (TypeError, ValueError):
             confidence = 0.0
+        relevance = 0
+        if headline_tokens:
+            relevance = len(headline_tokens & _relevance_tokens(row.get("text")))
         return (
             TIER_PRIORITY.get(tier, _DEFAULT_TIER_PRIORITY),
+            -relevance,
             -confidence,
             index,
         )

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -7,6 +7,7 @@ from episteme_graph.agents.claim_qualification.schema import ClaimQualificationR
 from episteme_graph.agents.dsl_linking.schema import DSLLinkingResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
+from episteme_graph.agents.claim_selection import selection_issue_payloads
 from episteme_graph.agents.id_canonicalization import (
     canonicalize_claim_refs,
     claim_aliases_from_accepted_claims,
@@ -98,6 +99,7 @@ class ComponentAssemblyAgent:
                 issue["code"] for issue in diagnostics["component_assembly_input_validation"]["issues"]
             ]
             result.diagnostics = diagnostics
+            self._record_claim_exclusions(result, llm_input)
             return result
 
         messages = self._prompt_factory.build_messages(llm_input)
@@ -110,6 +112,7 @@ class ComponentAssemblyAgent:
             diagnostics["fallback_reason"] = str(exc)
             diagnostics["original_failure_codes"] = ["initial_llm_exception"]
             result.diagnostics = diagnostics
+            self._record_claim_exclusions(result, llm_input)
             return result
         diagnostics["initial_llm_raw_output"] = _llm_capture(self._llm_client, raw_output)
         diagnostics["initial_llm_output_component_count"] = diagnostics["initial_llm_raw_output"]["component_count"]
@@ -182,7 +185,22 @@ class ComponentAssemblyAgent:
         merged_diagnostics = dict(diagnostics)
         merged_diagnostics.update(result.diagnostics or {})
         result.diagnostics = merged_diagnostics
+        self._record_claim_exclusions(result, llm_input)
         return result
+
+    @staticmethod
+    def _record_claim_exclusions(result, llm_input) -> None:
+        """Persist limit-dropped claims and surface them as warnings (#356)."""
+        excluded = list(getattr(llm_input, "excluded_from_pipeline_input", []) or [])
+        if not excluded:
+            return
+        result.excluded_from_pipeline_input = excluded
+        result.validation_issues = list(result.validation_issues or []) + [
+            ValidationIssue(**payload)
+            for payload in selection_issue_payloads(
+                excluded, stage="component_assembly"
+            )
+        ]
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
         if not cartridge_id:

--- a/src/episteme_graph/agents/component_assembly/enrichment.py
+++ b/src/episteme_graph/agents/component_assembly/enrichment.py
@@ -37,6 +37,7 @@ def enrich_component_assembly(
     for component in result.components:
         _normalize_component_lists(component)
         _fill_equation_roles(component, eq_index, review_required)
+        _flag_equation_role_conflicts(component, eq_index)
         _fill_equation_confidence_summary(component, eq_index, review_required)
         _fill_confidence_gate(component, eq_index)
         _fill_claim_support_metadata(component, llm_input)
@@ -110,6 +111,44 @@ def _fill_equation_roles(
             component.output_equation_ids = [linked_eqs[-1]]
         if not component.input_equation_ids:
             component.input_equation_ids = [eq_id for eq_id in linked_eqs if eq_id not in component.output_equation_ids]
+
+
+# equation_semantics の equation_type を正本とし、矛盾する component 側 role を
+# 検出する対応表 (issue #358)。
+_EQUATION_ROLE_CONFLICTS = {
+    "definition": ("output_equation_ids",),
+    "result": ("definition_equation_ids",),
+}
+
+
+def _flag_equation_role_conflicts(
+    component: ComponentRecord,
+    eq_index: dict[str, dict],
+) -> None:
+    """Mark stage-to-stage equation role conflicts on the component (issue #358).
+
+    The conflict is recorded in ``review_notes`` (components carry no
+    review_reasons field) and the component is demoted out of auto_accepted so
+    a teacher confirms the classification. Links are kept, never dropped.
+    """
+    conflicts: list[str] = []
+    for eq_type, conflicting_fields in _EQUATION_ROLE_CONFLICTS.items():
+        for field_name in conflicting_fields:
+            for eq_id in getattr(component, field_name, []) or []:
+                eq = eq_index.get(str(eq_id)) or {}
+                if str(eq.get("role") or "").lower() != eq_type:
+                    continue
+                conflicts.append(
+                    f"equation_role_conflict: {eq_id} listed in {field_name} "
+                    f"but equation_semantics types it as {eq_type}"
+                )
+    if not conflicts:
+        return
+    for note in conflicts:
+        if note not in component.review_notes:
+            component.review_notes.append(note)
+    if component.review_status == "auto_accepted":
+        component.review_status = "teacher_review_required"
 
 
 def _fill_equation_confidence_summary(

--- a/src/episteme_graph/agents/component_assembly/enrichment.py
+++ b/src/episteme_graph/agents/component_assembly/enrichment.py
@@ -40,6 +40,7 @@ def enrich_component_assembly(
         _fill_equation_confidence_summary(component, eq_index, review_required)
         _fill_confidence_gate(component, eq_index)
         _fill_claim_support_metadata(component, llm_input)
+        _fill_thesis_support_refs(component, llm_input)
         _fill_concepts(component, claim_index, eq_symbol_index, concept_vocab)
         _propagate_review_status(component)
         _fill_internal_flow(component)
@@ -180,6 +181,37 @@ def _fill_claim_support_metadata(
     component.support_distance_to_headline_claim = metadata["support_distance_to_headline_claim"]
     if component.supports_claim_ids:
         component.linked_claim_ids = _unique(list(component.linked_claim_ids or []) + component.supports_claim_ids)
+
+
+def _fill_thesis_support_refs(
+    component: ComponentRecord,
+    llm_input: ComponentAssemblyLLMInput,
+) -> None:
+    """Derive supports_thesis_node_ids from claim/equation overlap (issue #354).
+
+    A component backs a thesis node (central_thesis or support:<section>:<idx>)
+    when it shares at least one claim or equation reference with that node. No
+    LLM re-judgement: only IDs already present in both artifacts are used.
+    """
+    nodes = llm_input.thesis_nodes or []
+    if not nodes:
+        return
+    claim_ids = set(_component_claim_ids(component))
+    equation_ids = set(_all_component_equation_ids(component))
+    refs: list[str] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        thesis_ref = str(node.get("thesis_ref") or "")
+        if not thesis_ref:
+            continue
+        node_claims = {str(v) for v in (node.get("claim_ids") or []) if v}
+        node_equations = {str(v) for v in (node.get("equation_ids") or []) if v}
+        if (claim_ids & node_claims) or (equation_ids & node_equations):
+            refs.append(thesis_ref)
+    component.supports_thesis_node_ids = _unique(
+        list(component.supports_thesis_node_ids or []) + refs
+    )
 
 
 def _fill_concepts(

--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -6,6 +6,7 @@ from episteme_graph.agents.dsl_linking.schema import DSLLinkingResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
 from episteme_graph.agents.claim_selection import (
+    headline_text_for_selection,
     select_claim_rows,
     thesis_claim_id_set,
 )
@@ -176,6 +177,7 @@ class ComponentAssemblyInputBuilder:
             limit,
             stage="component_assembly",
             thesis_claim_ids=thesis_claim_id_set(thesis),
+            headline_text=headline_text_for_selection(thesis=thesis),
         )
 
     @staticmethod

--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -5,6 +5,10 @@ from episteme_graph.agents.claim_qualification.schema import ClaimQualificationR
 from episteme_graph.agents.dsl_linking.schema import DSLLinkingResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
+from episteme_graph.agents.claim_selection import (
+    select_claim_rows,
+    thesis_claim_id_set,
+)
 from episteme_graph.agents.id_canonicalization import (
     canonical_claim_id_for_span,
     canonicalize_claim_refs,
@@ -43,11 +47,13 @@ class ComponentAssemblyInputBuilder:
         derivations=None,
     ) -> ComponentAssemblyLLMInput:
         cfg = config or {}
-        accepted_claims = self._accepted_claims(
+        claim_selection = self._accepted_claims(
             qualified_claims,
             int(cfg.get("max_claims", _MAX_CLAIMS)),
             claim_objects=claim_objects,
+            thesis=thesis,
         )
+        accepted_claims = claim_selection.selected
         claim_aliases = {
             c["legacy_claim_id"]: c["claim_id"]
             for c in accepted_claims
@@ -91,6 +97,7 @@ class ComponentAssemblyInputBuilder:
             available_dsl_edges=self._available_dsl_edges(dsl),
             available_derivation_ids=self._available_derivation_ids(derivations),
             claim_centered_plan=claim_centered_plan,
+            excluded_from_pipeline_input=claim_selection.excluded,
         )
 
     @staticmethod
@@ -122,7 +129,8 @@ class ComponentAssemblyInputBuilder:
         result: ClaimQualificationResult,
         limit: int,
         claim_objects=None,
-    ) -> list[dict]:
+        thesis=None,
+    ):
         claims = []
         seen_claim_ids: set[str] = set()
         claim_index = _claim_object_index(claim_objects)
@@ -157,17 +165,18 @@ class ComponentAssemblyInputBuilder:
             claims.append(row)
             if claim_id:
                 seen_claim_ids.add(claim_id)
-            if len(claims) >= limit:
-                return claims
         for claim_obj in list(getattr(claim_objects, "claims", []) or []):
             claim_id = str(getattr(claim_obj, "claim_id", "") or "")
             if not claim_id or claim_id in seen_claim_ids or _claim_is_non_atomic(claim_obj):
                 continue
             claims.append(_claim_object_row(claim_obj))
             seen_claim_ids.add(claim_id)
-            if len(claims) >= limit:
-                break
-        return claims
+        return select_claim_rows(
+            claims,
+            limit,
+            stage="component_assembly",
+            thesis_claim_ids=thesis_claim_id_set(thesis),
+        )
 
     @staticmethod
     def _equations(equations: EquationSemanticsResult | None, limit: int) -> list[dict]:

--- a/src/episteme_graph/agents/component_assembly/input_builder.py
+++ b/src/episteme_graph/agents/component_assembly/input_builder.py
@@ -476,6 +476,9 @@ def _attach_claim_object_metadata(row: dict, claim: object) -> None:
         "concept_assignment_status": str(
             getattr(claim, "concept_assignment_status", "review_required") or "review_required"
         ),
+        # Human-readable section title (issue #359) so downstream prompts can
+        # show where the claim came from without the structure artifact.
+        "section_title": getattr(claim, "section_title", None),
     })
     if getattr(claim, "qualification_reason", None):
         row["reason"] = str(getattr(claim, "qualification_reason"))

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -94,6 +94,8 @@ class ComponentAssemblyLLMInput:
     available_dsl_edges: list[dict] = field(default_factory=list)
     available_derivation_ids: list[str] = field(default_factory=list)
     claim_centered_plan: dict = field(default_factory=dict)
+    # Claims dropped by the shared input limit (issue #356).
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -229,6 +231,8 @@ class ComponentAssemblyResult:
     # {theory_bundle, course_mapping, blueprint_updates, theory_bundle_validation,
     #  teaching_output_validation}.
     theory_bundle: dict = field(default_factory=dict)
+    # Claims dropped from the LLM input by the shared selection policy (issue #356).
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
     diagnostics: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
@@ -319,6 +323,7 @@ class ComponentAssemblyResult:
             component_refinement=d.get("component_refinement") or {},
             derivation_graph_alignment=d.get("derivation_graph_alignment") or {},
             theory_bundle=d.get("theory_bundle") or {},
+            excluded_from_pipeline_input=d.get("excluded_from_pipeline_input") or [],
             diagnostics=d.get("diagnostics") or {},
         )
 

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -172,6 +172,9 @@ class ComponentRecord:
     supports_claim_ids: list[str] = field(default_factory=list)
     support_distance_to_headline_claim: int = 0
     support_kind: str = ""
+    # Thesis nodes (central_thesis / support:<section>:<idx>) this component
+    # backs, derived deterministically from claim/equation overlap (issue #354).
+    supports_thesis_node_ids: list[str] = field(default_factory=list)
     # Concept tags required for component graph / course mapping (issue #8).
     # Derived deterministically from linked atomic-claim concepts, equation
     # symbols, and cartridge normalized terms.
@@ -290,6 +293,7 @@ class ComponentAssemblyResult:
                 supports_claim_ids=list(c.get("supports_claim_ids") or []),
                 support_distance_to_headline_claim=int(c.get("support_distance_to_headline_claim", 0) or 0),
                 support_kind=c.get("support_kind", ""),
+                supports_thesis_node_ids=list(c.get("supports_thesis_node_ids") or []),
                 concepts=list(c.get("concepts") or []),
                 prerequisite_concepts=list(c.get("prerequisite_concepts") or []),
                 introduced_concepts=list(c.get("introduced_concepts") or []),

--- a/src/episteme_graph/agents/component_assembly/validator.py
+++ b/src/episteme_graph/agents/component_assembly/validator.py
@@ -102,6 +102,7 @@ class ComponentAssemblyValidator:
                 issues += self._check_id_references(component, available)
         issues += self._check_hints(result, component_ids)
         issues += self._check_duplicates(result)
+        issues += self._check_dependency_cycles(result.components)
         if not (0.0 <= result.confidence <= 1.0):
             issues.append(ValidationIssue("confidence_out_of_range", "error", "result confidence out of range", "confidence"))
         # deterministic-fallback component の存在は再 validate でも必ず報告する
@@ -119,6 +120,64 @@ class ComponentAssemblyValidator:
                 "LLM component assembly failed and must be rerun before publish",
                 "components",
             ))
+        return issues
+
+    @staticmethod
+    def _check_dependency_cycles(
+        components: list[ComponentRecord],
+    ) -> list[ValidationIssue]:
+        """Detect requires / depends_on cycles (issue #358, hard error).
+
+        Every downstream consumer (graph layering, course ordering) assumes the
+        component dependency graph is a DAG; a cycle would loop forever or be
+        silently mis-ordered, so it blocks export with the cycle path named.
+        """
+        known = {c.component_id for c in components}
+        adjacency: dict[str, list[str]] = {}
+        for component in components:
+            targets: list[str] = []
+            for dep in component.dependencies or []:
+                if not isinstance(dep, dict):
+                    continue
+                dep_type = normalize_dependency_type(dep.get("dependency_type"))
+                if dep_type not in ("requires", "depends_on"):
+                    continue
+                targets.extend(
+                    str(ref) for ref in dep.get("component_refs") or []
+                    if str(ref) in known
+                )
+            adjacency[component.component_id] = targets
+
+        issues: list[ValidationIssue] = []
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = {cid: WHITE for cid in adjacency}
+        stack: list[str] = []
+        reported: set[frozenset] = set()
+
+        def visit(cid: str) -> None:
+            color[cid] = GRAY
+            stack.append(cid)
+            for nxt in adjacency.get(cid, []):
+                state = color.get(nxt, WHITE)
+                if state == GRAY:
+                    cycle = stack[stack.index(nxt):] + [nxt]
+                    key = frozenset(cycle)
+                    if key not in reported:
+                        reported.add(key)
+                        issues.append(ValidationIssue(
+                            "component_dependency_cycle",
+                            "error",
+                            "dependency cycle detected: " + " -> ".join(cycle),
+                            f"components[{nxt}].dependencies",
+                        ))
+                elif state == WHITE and nxt in color:
+                    visit(nxt)
+            stack.pop()
+            color[cid] = BLACK
+
+        for cid in adjacency:
+            if color[cid] == WHITE:
+                visit(cid)
         return issues
 
     def _check_component(

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -86,6 +86,7 @@ class ComponentGraphNormalizer:
             derivations, claim_index, components
         )
         theory_nodes = main_nodes + detail_nodes
+        _annotate_layer_linkage_gaps(theory_nodes)
         if len(theory_nodes) >= _MIN_THEORY_NODES:
             return replace(
                 result,
@@ -579,6 +580,39 @@ def _fallback_sequential_edges(groups: list[dict]) -> list[ComponentGraphEdge]:
             review_reasons=["edge_not_source_backed"],
         ))
     return edges
+
+
+def _annotate_layer_linkage_gaps(nodes: list) -> None:
+    """Record layer-linkage gaps on the nodes themselves (issue #358).
+
+    A detail node without a main parent, or a main TheoryOperationNode without
+    members, breaks the two-layer invariant (#306); the gap is written into the
+    node's ``review_reasons`` so reviewers see it on the node, not only in the
+    validator report.
+    """
+    main_ids = {
+        n.component_id for n in nodes
+        if str(getattr(n, "graph_layer", "main") or "main") == "main"
+    }
+    if not main_ids:
+        return
+    for node in nodes:
+        layer = str(getattr(node, "graph_layer", "main") or "main")
+        if layer == "equation_detail":
+            parent = str(getattr(node, "parent_component_id", "") or "")
+            if (not parent or parent not in main_ids) and \
+                    "orphan_detail_node" not in node.review_reasons:
+                node.review_reasons = _ordered_unique(
+                    list(node.review_reasons) + ["orphan_detail_node"]
+                )
+        elif layer == "main" and str(
+            getattr(node, "component_type", "") or ""
+        ) == THEORY_OPERATION_NODE:
+            if not list(getattr(node, "member_component_ids", []) or []) and \
+                    "empty_main_node" not in node.review_reasons:
+                node.review_reasons = _ordered_unique(
+                    list(node.review_reasons) + ["empty_main_node"]
+                )
 
 
 def _attach_kept_generic_parents(

--- a/src/episteme_graph/agents/component_graph/normalizer.py
+++ b/src/episteme_graph/agents/component_graph/normalizer.py
@@ -132,6 +132,11 @@ class ComponentGraphNormalizer:
             for group in groups
             for rec in group["records"]
         }
+        # Issue #361: kept-generic steps (generic operation but equation-backed
+        # on both ends) never form or strengthen a stage group, but they still
+        # need a parent so the layer-linkage invariant holds. Attach each to
+        # the nearest non-generic step's main node in derivation order.
+        _attach_kept_generic_parents(records, parent_by_record, main_nodes)
         detail_nodes = [
             _detail_node_from_record(rec, parent_by_record.get(rec["detail_id"], ""), claim_index)
             for rec in records
@@ -576,6 +581,44 @@ def _fallback_sequential_edges(groups: list[dict]) -> list[ComponentGraphEdge]:
     return edges
 
 
+def _attach_kept_generic_parents(
+    records: list[dict],
+    parent_by_record: dict[str, str],
+    main_nodes: list,
+) -> None:
+    """Give equation-backed generic steps a parent main node (issue #361).
+
+    The parent is the nearest preceding non-generic step's main node (falling
+    back to the nearest following one). The generic record is appended to the
+    main node's member_component_ids only — it never contributes equations,
+    claims, or backing to the main node itself.
+    """
+    main_by_id = {node.component_id: node for node in main_nodes}
+    last_parent = ""
+    pending: list[str] = []
+    for rec in records:
+        detail_id = rec["detail_id"]
+        if not rec["is_generic"]:
+            last_parent = parent_by_record.get(detail_id, last_parent)
+            for deferred in pending:
+                if last_parent:
+                    parent_by_record[deferred] = last_parent
+                    node = main_by_id.get(last_parent)
+                    if node is not None and deferred not in node.member_component_ids:
+                        node.member_component_ids.append(deferred)
+            pending = []
+            continue
+        if not (rec["inputs"] and rec["outputs"]):
+            continue  # debug-bound generic step keeps no parent
+        if last_parent:
+            parent_by_record[detail_id] = last_parent
+            node = main_by_id.get(last_parent)
+            if node is not None and detail_id not in node.member_component_ids:
+                node.member_component_ids.append(detail_id)
+        else:
+            pending.append(detail_id)
+
+
 # ---------------------------------------------------------------------- #
 # Equation-detail layer (one node / edge per derivation step)
 # ---------------------------------------------------------------------- #
@@ -596,19 +639,32 @@ def _detail_node_from_record(
     linked_evidence_ids = _ordered_unique(getattr(step, "source_evidence_ids", []) or [])
     atomic_claim_ids = _atomic_claim_ids(linked_claim_ids, claim_index)
 
+    # Issue #361: a generic step whose input AND output equations are present
+    # still carries usable derivation structure. Keep it in the
+    # equation_detail layer as partially_source_backed (never stronger)
+    # instead of dropping the whole trace to debug; only generic steps without
+    # equation backing on both ends fall back to the debug layer.
+    generic_kept = rec["is_generic"] and bool(inputs) and bool(outputs)
     status, reasons = _node_backing(
         linked_equation_ids=linked_equation_ids,
         linked_derivation_ids=linked_derivation_ids,
         atomic_claim_ids=atomic_claim_ids,
         linked_claim_ids=linked_claim_ids,
         linked_evidence_ids=linked_evidence_ids,
-        is_generic=rec["is_generic"],
+        is_generic=rec["is_generic"] and not generic_kept,
     )
+    if generic_kept:
+        status = "partially_source_backed"
+        reasons = _ordered_unique(list(reasons) + ["generic_operation"])
 
     definitions = outputs if edge_type == "defines" else []
     constraints = outputs if edge_type in ("constrains", "derives", "diagnoses") else []
     # Generic / inferred steps are kept for traceability but never confirmed.
-    layer = GRAPH_LAYER_DEBUG if rec["is_generic"] else GRAPH_LAYER_EQUATION_DETAIL
+    layer = (
+        GRAPH_LAYER_EQUATION_DETAIL
+        if (not rec["is_generic"] or generic_kept)
+        else GRAPH_LAYER_DEBUG
+    )
 
     detail_label = _build_detail_label(rec["verb"], step, inputs, outputs)
     step_reason = str(getattr(step, "reason", "") or "").strip()

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -66,6 +66,9 @@ REVIEW_REASONS = [
     "edge_not_source_backed",
     "fallback_or_inferred_node",
     "source_span_missing",
+    # Issue #361: generic-operation step kept in the equation_detail layer
+    # because its input/output equations still back it.
+    "generic_operation",
 ]
 
 # Edge types that are too generic to publish as confirmed theory structure.

--- a/src/episteme_graph/agents/component_graph/schema.py
+++ b/src/episteme_graph/agents/component_graph/schema.py
@@ -69,6 +69,9 @@ REVIEW_REASONS = [
     # Issue #361: generic-operation step kept in the equation_detail layer
     # because its input/output equations still back it.
     "generic_operation",
+    # Issue #358: two-layer linkage gaps recorded on the node itself.
+    "orphan_detail_node",
+    "empty_main_node",
 ]
 
 # Edge types that are too generic to publish as confirmed theory structure.

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -138,7 +138,46 @@ class ComponentGraphValidator:
                 "confidence",
             ))
 
+        issues += self._check_main_graph_coverage(result)
+
         return issues
+
+    @staticmethod
+    def _check_main_graph_coverage(result: ComponentGraphResult) -> list[ValidationIssue]:
+        """Explain WHY the main graph is empty (issue #361).
+
+        When derivation quality is too low every step lands in the
+        equation_detail / debug layer and learners see nothing. Report the
+        generic-operation rate and weak-backing rate so the cause is visible
+        in export_validation instead of a silently empty graph.
+        """
+        nodes = list(result.nodes or [])
+        if not nodes:
+            return []
+        if any(
+            str(getattr(n, "graph_layer", "main") or "main") == "main" for n in nodes
+        ):
+            return []
+        total = len(nodes)
+        generic = sum(
+            1 for n in nodes
+            if classify_operation(str(getattr(n, "operation", "") or ""))[2]
+        )
+        weak_backing = sum(
+            1 for n in nodes
+            if str(getattr(n, "source_backing_status", "") or "")
+            in ("inferred", "review_required", "")
+        )
+        return [ValidationIssue(
+            "main_graph_empty_derivation_quality",
+            "warning",
+            (
+                "main graph is empty — derivation quality insufficient: "
+                f"generic operations {generic}/{total}, "
+                f"weak source backing {weak_backing}/{total}"
+            ),
+            "nodes",
+        )]
 
     @staticmethod
     def _check_node_source_backing(node: ComponentGraphNode, is_main: bool) -> list[ValidationIssue]:

--- a/src/episteme_graph/agents/component_graph/validator.py
+++ b/src/episteme_graph/agents/component_graph/validator.py
@@ -139,7 +139,93 @@ class ComponentGraphValidator:
             ))
 
         issues += self._check_main_graph_coverage(result)
+        issues += self._check_layer_linkage(result)
+        issues += self._check_dependency_edge_cycles(result)
 
+        return issues
+
+    @staticmethod
+    def _check_layer_linkage(result: ComponentGraphResult) -> list[ValidationIssue]:
+        """Detect orphan detail nodes and member-less main nodes (issue #358).
+
+        The two-layer invariant (#306) requires equation_detail nodes to point
+        at a main parent and main nodes to aggregate at least one member;
+        breaking it leaves nodes the UI layer toggle can never reach.
+        """
+        issues: list[ValidationIssue] = []
+        main_ids = {
+            n.component_id for n in result.nodes
+            if str(getattr(n, "graph_layer", "main") or "main") == "main"
+        }
+        if not main_ids:
+            return issues  # empty main graph is reported by coverage check
+        for node in result.nodes:
+            layer = str(getattr(node, "graph_layer", "main") or "main")
+            cid = node.component_id
+            if layer == "equation_detail":
+                parent = str(getattr(node, "parent_component_id", "") or "")
+                if not parent or parent not in main_ids:
+                    issues.append(ValidationIssue(
+                        "orphan_detail_node",
+                        "warning",
+                        f"equation_detail node {cid!r} has no main-layer parent",
+                        f"nodes[{cid}].parent_component_id",
+                    ))
+            elif layer == "main" and str(
+                getattr(node, "component_type", "") or ""
+            ) == "TheoryOperationNode":
+                if not list(getattr(node, "member_component_ids", []) or []):
+                    issues.append(ValidationIssue(
+                        "empty_main_node",
+                        "warning",
+                        f"main node {cid!r} aggregates no equation_detail members",
+                        f"nodes[{cid}].member_component_ids",
+                    ))
+        return issues
+
+    @staticmethod
+    def _check_dependency_edge_cycles(result: ComponentGraphResult) -> list[ValidationIssue]:
+        """Detect cycles over dependency-like edges (issue #358, hard error)."""
+        dependency_types = {"requires", "depends_on"}
+        adjacency: dict[str, list[str]] = {}
+        for edge in result.edges:
+            if str(edge.edge_type or "").lower() not in dependency_types:
+                continue
+            if edge.source and edge.target:
+                adjacency.setdefault(edge.source, []).append(edge.target)
+        if not adjacency:
+            return []
+
+        issues: list[ValidationIssue] = []
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color: dict[str, int] = {}
+        stack: list[str] = []
+        reported: set[frozenset] = set()
+
+        def visit(cid: str) -> None:
+            color[cid] = GRAY
+            stack.append(cid)
+            for nxt in adjacency.get(cid, []):
+                state = color.get(nxt, WHITE)
+                if state == GRAY:
+                    cycle = stack[stack.index(nxt):] + [nxt]
+                    key = frozenset(cycle)
+                    if key not in reported:
+                        reported.add(key)
+                        issues.append(ValidationIssue(
+                            "component_graph_dependency_cycle",
+                            "error",
+                            "dependency edge cycle detected: " + " -> ".join(cycle),
+                            f"edges[{nxt}]",
+                        ))
+                elif state == WHITE:
+                    visit(nxt)
+            stack.pop()
+            color[cid] = BLACK
+
+        for cid in list(adjacency):
+            if color.get(cid, WHITE) == WHITE:
+                visit(cid)
         return issues
 
     @staticmethod

--- a/src/episteme_graph/agents/content_normalization.py
+++ b/src/episteme_graph/agents/content_normalization.py
@@ -18,7 +18,10 @@ import re
 import unicodedata
 
 # Bump when any normalisation rule below changes.
-CONTENT_HASH_VERSION = 1
+# v1: full-text lowercasing. v2: prose-token casefolding only — math-like
+# tokens (R_D, DHOST, single capitals) keep their case (#362 review fix), so
+# v1 hashes are not comparable and must be recomputed.
+CONTENT_HASH_VERSION = 2
 
 _TRAILING_PUNCTUATION = ".,;:。、"
 

--- a/src/episteme_graph/agents/content_normalization.py
+++ b/src/episteme_graph/agents/content_normalization.py
@@ -1,0 +1,60 @@
+"""Deterministic content normalization + hashing (issue #362).
+
+claim_id / equation_id are document-scoped, so the same definition or
+standard assumption in two papers can never be matched automatically. As the
+first step toward cross-paper reuse, every claim / equation gets a
+``content_hash`` computed from a deterministically normalised form of its
+text. Hashing is versioned: when the normalisation rules change,
+``CONTENT_HASH_VERSION`` is bumped so stale hashes are recognisable and can
+be recomputed instead of silently mismatching.
+
+This module only normalises and hashes — similarity search / merge proposals
+are a separate, teacher-reviewed concern.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+
+# Bump when any normalisation rule below changes.
+CONTENT_HASH_VERSION = 1
+
+_TRAILING_PUNCTUATION = ".,;:。、"
+
+
+def normalize_text_for_hash(text: str) -> str:
+    """Canonical claim-text form: NFKC, collapsed whitespace, no trailing
+    punctuation, case-folded prose (math symbols keep their case via NFKC)."""
+    value = unicodedata.normalize("NFKC", str(text or ""))
+    value = re.sub(r"\s+", " ", value).strip()
+    value = value.rstrip(_TRAILING_PUNCTUATION).strip()
+    return value.lower()
+
+
+def normalize_equation_for_hash(latex: str | None, plain_text: str | None = None) -> str:
+    """Canonical equation form: prefer LaTeX, strip math-mode wrappers and all
+    whitespace (LaTeX ignores it), normalise brace spacing. Case is preserved —
+    b and B are different symbols."""
+    source = str(latex or "").strip() or str(plain_text or "").strip()
+    value = unicodedata.normalize("NFKC", source)
+    value = value.strip()
+    for wrapper in ("$$", "$", r"\[", r"\]", r"\(", r"\)"):
+        value = value.replace(wrapper, "")
+    value = re.sub(r"\s+", "", value)
+    return value
+
+
+def content_hash(normalized: str) -> str:
+    """Stable 16-hex-digit digest of a normalised content string ('' stays '')."""
+    if not normalized:
+        return ""
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def claim_content_hash(text: str) -> str:
+    return content_hash(normalize_text_for_hash(text))
+
+
+def equation_content_hash(latex: str | None, plain_text: str | None = None) -> str:
+    return content_hash(normalize_equation_for_hash(latex, plain_text))

--- a/src/episteme_graph/agents/content_normalization.py
+++ b/src/episteme_graph/agents/content_normalization.py
@@ -22,14 +22,28 @@ CONTENT_HASH_VERSION = 1
 
 _TRAILING_PUNCTUATION = ".,;:。、"
 
+# A token is lowercased only when it looks like prose: an alphabetic word of
+# length >= 2 whose only capital (if any) is the first letter, optionally with
+# trailing punctuation. Math-like tokens (R_D, DHOST, \beta, b_1, single
+# capitals) keep their case — b and B are different symbols (issue #362).
+_PROSE_TOKEN = re.compile(r"([A-Za-z][a-z]+)([.,;:!?)\]\"']*)$")
+
+
+def _casefold_prose_tokens(value: str) -> str:
+    tokens = []
+    for token in value.split(" "):
+        match = _PROSE_TOKEN.fullmatch(token)
+        tokens.append(match.group(1).lower() + match.group(2) if match else token)
+    return " ".join(tokens)
+
 
 def normalize_text_for_hash(text: str) -> str:
     """Canonical claim-text form: NFKC, collapsed whitespace, no trailing
-    punctuation, case-folded prose (math symbols keep their case via NFKC)."""
+    punctuation, prose words case-folded while math-like tokens keep case."""
     value = unicodedata.normalize("NFKC", str(text or ""))
     value = re.sub(r"\s+", " ", value).strip()
     value = value.rstrip(_TRAILING_PUNCTUATION).strip()
-    return value.lower()
+    return _casefold_prose_tokens(value)
 
 
 def normalize_equation_for_hash(latex: str | None, plain_text: str | None = None) -> str:

--- a/src/episteme_graph/agents/derivation_chain/agent.py
+++ b/src/episteme_graph/agents/derivation_chain/agent.py
@@ -49,6 +49,20 @@ _CLAIM_TYPE_TO_OPERATION: dict[str, str] = {
     "limitation": "flag_limitation",
 }
 
+# Generic operations that name no concrete theory operation (issue #361).
+# Mirrors component_graph.schema.GENERIC_OPERATIONS so steps the graph layer
+# would flag are reclassified here first.
+_GENERIC_OPERATIONS = {"transform", "relate", "connect", "support", "associate", ""}
+
+# Secondary equation roles → concrete OPERATION_ONTOLOGY verb (issue #361).
+_SECONDARY_TYPE_TO_OPERATION = {
+    "definition": "apply_definition",
+    "result": "derive_result",
+    "constraint": "apply_constraint",
+    "approximation": "approximate",
+    "transformation": "substitute",
+}
+
 
 class DerivationChainAgent:
     """EquationSemanticsResult (and optionally ClaimObjectBuildResult) から DerivationChain を組み立てる。"""
@@ -306,6 +320,7 @@ class DerivationChainAgent:
                 assumptions = list(current_record.semantics.assumptions)
 
             operation = self._infer_operation(current_record)
+            operation = self._refine_generic_operation(operation, current_record)
             linked_claims = list(claim_link_index.get(current, []))
             sem_claims = list(current_record.semantics.linked_claim_ids) if current_record else []
             all_claim_ids = sorted(set(linked_claims + sem_claims))
@@ -481,6 +496,31 @@ class DerivationChainAgent:
             "constraint": "apply_constraint",
         }
         return mapping.get(primary, DEFAULT_OPERATION)
+
+    @staticmethod
+    def _refine_generic_operation(operation: str, record: Optional[EquationRecord]) -> str:
+        """Single deterministic reclassification of a generic operation (#361).
+
+        Before a step is emitted with a generic operation (which the graph
+        layer would push toward the debug layer), try once to pick a concrete
+        OPERATION_ONTOLOGY verb from the equation's own signals: secondary
+        roles first, then defined symbols. When no signal supports a concrete
+        verb the operation stays generic — review keeps it honest.
+        """
+        if record is None or str(operation or "").strip().lower() not in _GENERIC_OPERATIONS:
+            return operation
+        sem = record.semantics
+        for secondary in sem.secondary_types or []:
+            mapped = _SECONDARY_TYPE_TO_OPERATION.get(str(secondary).strip().lower())
+            if mapped:
+                return mapped
+        has_definition = any(
+            str(getattr(s, "definition_status", "") or "") in ("defined", "redefined")
+            for s in (sem.defined_symbols or [])
+        )
+        if has_definition:
+            return "apply_definition"
+        return operation
 
 
 def _confidence_gate(blocked_eqs: list[str]) -> dict:

--- a/src/episteme_graph/agents/dsl_linking/agent.py
+++ b/src/episteme_graph/agents/dsl_linking/agent.py
@@ -6,6 +6,7 @@ import logging
 from episteme_graph.agents.claim_qualification.schema import ClaimQualificationResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
+from episteme_graph.agents.claim_selection import selection_issue_payloads
 from episteme_graph.agents.id_canonicalization import (
     canonicalize_claim_refs,
     claim_aliases_from_accepted_claims,
@@ -16,7 +17,7 @@ from .input_builder import DSLLinkingInputBuilder
 from .llm_client import DSLLinkingLLMClient
 from .prompt import DSLLinkingPromptFactory
 from .repair import DSLLinkingRepairer, _parse_raw, make_deterministic_fallback
-from .schema import DSLLinkingResult
+from .schema import DSLLinkingResult, ValidationIssue
 from .validator import DSLLinkingValidator
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,9 @@ class DSLLinkingAgent:
             raw_output = self._llm_client.generate(messages)
         except Exception as exc:
             logger.error("DSL linking failed: %s", exc)
-            return make_deterministic_fallback(llm_input, str(exc))
+            result = make_deterministic_fallback(llm_input, str(exc))
+            self._record_claim_exclusions(result, llm_input)
+            return result
 
         raw_output = canonicalize_claim_refs(
             raw_output,
@@ -71,4 +74,17 @@ class DSLLinkingAgent:
             )
         else:
             result.validation_issues = issues
+        self._record_claim_exclusions(result, llm_input)
         return result
+
+    @staticmethod
+    def _record_claim_exclusions(result, llm_input) -> None:
+        """Persist limit-dropped claims and surface them as warnings (#356)."""
+        excluded = list(getattr(llm_input, "excluded_from_pipeline_input", []) or [])
+        if not excluded:
+            return
+        result.excluded_from_pipeline_input = excluded
+        result.validation_issues = list(result.validation_issues or []) + [
+            ValidationIssue(**payload)
+            for payload in selection_issue_payloads(excluded, stage="dsl_linking")
+        ]

--- a/src/episteme_graph/agents/dsl_linking/input_builder.py
+++ b/src/episteme_graph/agents/dsl_linking/input_builder.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 from episteme_graph.agents.claim_qualification.schema import ClaimQualificationResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
+from episteme_graph.agents.claim_selection import (
+    select_claim_rows,
+    thesis_claim_id_set,
+)
 from episteme_graph.agents.id_canonicalization import (
     canonical_claim_id_for_span,
     canonicalize_claim_refs,
@@ -27,11 +31,13 @@ class DSLLinkingInputBuilder:
         claim_objects=None,
     ) -> DSLLLMInput:
         cfg = config or {}
-        accepted_claims = self._accepted_claims(
+        claim_selection = self._accepted_claims(
             qualified_claims,
             int(cfg.get("max_claims", _MAX_CLAIMS)),
             claim_objects=claim_objects,
+            thesis=thesis,
         )
+        accepted_claims = claim_selection.selected
         aliases = {
             c["legacy_claim_id"]: c["claim_id"]
             for c in accepted_claims
@@ -54,6 +60,7 @@ class DSLLinkingInputBuilder:
                 claim_objects,
                 aliases,
             ),
+            excluded_from_pipeline_input=claim_selection.excluded,
         )
 
     @staticmethod
@@ -61,7 +68,8 @@ class DSLLinkingInputBuilder:
         qualified_claims: ClaimQualificationResult,
         limit: int,
         claim_objects=None,
-    ) -> list[dict]:
+        thesis=None,
+    ):
         result = []
         seen_claim_ids: set[str] = set()
         claim_index = _claim_object_index(claim_objects)
@@ -89,17 +97,18 @@ class DSLLinkingInputBuilder:
             result.append(row)
             if claim_id:
                 seen_claim_ids.add(claim_id)
-            if len(result) >= limit:
-                return result
         for claim_obj in list(getattr(claim_objects, "claims", []) or []):
             claim_id = str(getattr(claim_obj, "claim_id", "") or "")
             if not claim_id or claim_id in seen_claim_ids or _claim_is_non_atomic(claim_obj):
                 continue
             result.append(_claim_object_row(claim_obj))
             seen_claim_ids.add(claim_id)
-            if len(result) >= limit:
-                break
-        return result
+        return select_claim_rows(
+            result,
+            limit,
+            stage="dsl_linking",
+            thesis_claim_ids=thesis_claim_id_set(thesis),
+        )
 
     @staticmethod
     def _equations(

--- a/src/episteme_graph/agents/dsl_linking/input_builder.py
+++ b/src/episteme_graph/agents/dsl_linking/input_builder.py
@@ -217,6 +217,9 @@ def _attach_claim_object_metadata(row: dict, claim: object) -> None:
         "is_atomic": bool(getattr(claim, "is_atomic", True)),
         "split_suggestions": list(getattr(claim, "split_suggestions", []) or []),
         "source_evidence_ids": list(getattr(claim, "source_evidence_ids", []) or []),
+        # Human-readable section title (issue #359) so downstream prompts can
+        # show where the claim came from without the structure artifact.
+        "section_title": getattr(claim, "section_title", None),
     })
     if getattr(claim, "qualification_reason", None):
         row["reason"] = str(getattr(claim, "qualification_reason"))

--- a/src/episteme_graph/agents/dsl_linking/input_builder.py
+++ b/src/episteme_graph/agents/dsl_linking/input_builder.py
@@ -5,6 +5,7 @@ from episteme_graph.agents.claim_qualification.schema import ClaimQualificationR
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.thesis_reconstruction.schema import ThesisReconstructionResult
 from episteme_graph.agents.claim_selection import (
+    headline_text_for_selection,
     select_claim_rows,
     thesis_claim_id_set,
 )
@@ -108,6 +109,7 @@ class DSLLinkingInputBuilder:
             limit,
             stage="dsl_linking",
             thesis_claim_ids=thesis_claim_id_set(thesis),
+            headline_text=headline_text_for_selection(thesis=thesis),
         )
 
     @staticmethod

--- a/src/episteme_graph/agents/dsl_linking/schema.py
+++ b/src/episteme_graph/agents/dsl_linking/schema.py
@@ -113,6 +113,8 @@ class DSLLLMInput:
     equations: list[dict]
     thesis_nodes: list[dict]
     excluded_from_core: list[dict]
+    # Claims dropped by the shared input limit (issue #356).
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -157,6 +159,8 @@ class DSLLinkingResult:
     review_notes: list[str]
     confidence: float
     validation_issues: list[ValidationIssue] = field(default_factory=list)
+    # Claims dropped from the LLM input by the shared selection policy (issue #356).
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -178,6 +182,7 @@ class DSLLinkingResult:
             review_notes=d.get("review_notes", []),
             confidence=float(d.get("confidence", 0.0)),
             validation_issues=issues,
+            excluded_from_pipeline_input=d.get("excluded_from_pipeline_input", []),
         )
 
     @classmethod

--- a/src/episteme_graph/agents/equation_semantics/agent.py
+++ b/src/episteme_graph/agents/equation_semantics/agent.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 import logging
 
+from episteme_graph.agents.content_normalization import (
+    CONTENT_HASH_VERSION,
+    equation_content_hash,
+)
 from episteme_graph.agents.document_structure.schema import DocumentStructureResult
 from episteme_graph.agents.paper_skeleton.schema import PaperSkeletonResult
 from episteme_graph.agents.rhetorical_role.schema import RhetoricalRoleResult
@@ -247,6 +251,7 @@ class EquationSemanticsAgent:
             if progress_callback:
                 progress_callback(idx, total)
 
+        _apply_content_hashes(records)
         result = EquationSemanticsResult(
             document_id=structure.document_id,
             cartridge_id=cartridge.cartridge_id if cartridge else cartridge_id,
@@ -266,6 +271,20 @@ class EquationSemanticsAgent:
                 "Cartridge '%s' not found; proceeding without cartridge", cartridge_id
             )
             return None
+
+
+def _apply_content_hashes(records: list[EquationRecord]) -> None:
+    """Deterministic content hashes for cross-paper matching (issue #362)."""
+    for record in records:
+        src = record.source_extraction
+        latex = src.latex
+        plain = src.plain_text
+        if not (latex or plain):
+            rec = record.reconstruction
+            latex = rec.latex
+            plain = rec.plain_text
+        record.content_hash = equation_content_hash(latex, plain)
+        record.content_hash_version = CONTENT_HASH_VERSION
 
 
 def _attach_source_image(record: EquationRecord, image: object | None) -> None:

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -366,6 +366,10 @@ class EquationSemantics:
     linked_claim_ids: list[str]
     summary: str
     review_flags: list[str]
+    # Claim links demoted to inferred (#358): the claim does not link this
+    # equation back, so the link is moved out of linked_claim_ids and kept
+    # here instead of being consumed downstream as a confirmed link.
+    inferred_claim_ids: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -591,6 +595,7 @@ class EquationSemanticsResult:
                 "input_equation_ids": list(sem.input_equation_ids),
                 "output_equation_ids": list(sem.output_equation_ids),
                 "linked_claim_ids": sorted(set(sem.linked_claim_ids) | set(claim_index.get(r.equation_id, []))),
+                "inferred_claim_ids": sorted(set(sem.inferred_claim_ids)),
                 "source_evidence_ids": sorted(set(sem.source_evidence_ids) | set(evidence_index.get(block_id, []))),
                 "review_flags": list(sem.review_flags),
                 "section_id": section_id,
@@ -707,6 +712,7 @@ def _record_from_dict(d: dict) -> EquationRecord:
         linked_claim_ids=list(sem_raw.get("linked_claim_ids", [])),
         summary=str(sem_raw.get("summary", "")),
         review_flags=list(sem_raw.get("review_flags", [])),
+        inferred_claim_ids=list(sem_raw.get("inferred_claim_ids", [])),
     )
     cp_raw = d.get("confidence_policy", {})
     confidence_policy = EquationConfidencePolicy(

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -75,6 +75,8 @@ REVIEW_FLAGS = [
     "needs_reconstruction",
     "reconstruction_only",
     "partial_extraction",
+    # Issue #358: equation links a claim that does not link the equation back.
+    "claim_link_asymmetry",
 ]
 
 CANDIDATE_REVIEW_REASONS = [

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -473,6 +473,10 @@ class EquationRecord:
         review_required=False,
         review_reason=["equation_consistency_not_computed"],
     ))
+    # Deterministic content hash for cross-paper matching (issue #362).
+    # "" / 0 on legacy artifacts that predate hashing.
+    content_hash: str = ""
+    content_hash_version: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -753,6 +757,8 @@ def _record_from_dict(d: dict) -> EquationRecord:
         semantics=semantics,
         confidence_policy=confidence_policy,
         equation_consistency=equation_consistency,
+        content_hash=str(d.get("content_hash", "") or ""),
+        content_hash_version=int(d.get("content_hash_version", 0) or 0),
     )
 
 

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -337,6 +337,9 @@ class DefinedSymbol:
     symbol: str
     definition_status: str
     evidence_text: str | None = None
+    # Reference into the document SymbolRegistry (issue #355). Optional for
+    # backward compatibility; set by SymbolRegistryBuilder when it annotates.
+    symbol_id: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/episteme_graph/agents/equation_semantics/validator.py
+++ b/src/episteme_graph/agents/equation_semantics/validator.py
@@ -49,6 +49,30 @@ class EquationSemanticsValidator:
             issues += self._check_equation_consistency(record)
             issues += self._check_cartridge_terms(record, cartridge)
 
+        issues += self._check_duplicate_content_hashes(result.equations)
+
+        return issues
+
+    @staticmethod
+    def _check_duplicate_content_hashes(records: list) -> list[ValidationIssue]:
+        """Within-document hash collisions are reported, never auto-merged (#362)."""
+        by_hash: dict[str, list[str]] = {}
+        for record in records:
+            hash_value = str(getattr(record, "content_hash", "") or "")
+            if hash_value:
+                by_hash.setdefault(hash_value, []).append(record.equation_id)
+        issues: list[ValidationIssue] = []
+        for hash_value, equation_ids in by_hash.items():
+            if len(equation_ids) > 1:
+                issues.append(ValidationIssue(
+                    rule_id="duplicate_equation_content_hash",
+                    severity="warning",
+                    message=(
+                        f"equations {', '.join(equation_ids)} share content_hash "
+                        f"{hash_value}; review for duplication (not auto-merged)"
+                    ),
+                    field=equation_ids[0],
+                ))
         return issues
 
     # ------------------------------------------------------------------

--- a/src/episteme_graph/agents/evidence_registry/builder.py
+++ b/src/episteme_graph/agents/evidence_registry/builder.py
@@ -142,8 +142,8 @@ class EvidenceRegistryBuilder:
         Deterministic sentence splitting only (no LLM). Each sentence record
         carries ``evidence_role="sentence_quote"`` and points back at the
         block-level record via ``parent_evidence_id`` so atomic claims can cite
-        the exact supporting sentence. A single-sentence block adds nothing the
-        block record doesn't already cover, so it is skipped.
+        the exact supporting sentence — also for single-sentence blocks, so
+        sentence-level citation works uniformly (issue #363 review fix).
         """
         block = self._block_index.get(block_id)
         if block is None:
@@ -156,7 +156,7 @@ class EvidenceRegistryBuilder:
             return []
         text = getattr(block, "text", "") or ""
         spans = split_sentences_with_offsets(text)
-        if len(spans) < 2:
+        if not spans:
             return []
         parent = None
         if parent_evidence_id:
@@ -341,3 +341,47 @@ def split_sentences_with_offsets(text: str) -> list[tuple[int, int]]:
             stripped_start += 1
         spans.append((stripped_start, len(text)))
     return spans
+
+
+def check_span_alignment(roles_result, registry_result) -> list[ValidationIssue]:
+    """RhetoricalRole span offsets vs evidence spans (issue #363).
+
+    A span annotation whose char range falls outside its block's block-level
+    evidence span indicates the two artifacts disagree about the block text;
+    the mismatch is reported as a warning on the registry result.
+    """
+    block_spans: dict[str, tuple[int, int]] = {}
+    for record in getattr(registry_result, "records", []) or []:
+        if getattr(record, "evidence_role", "") == "sentence_quote":
+            continue
+        block_id = getattr(record.source, "block_id", None)
+        if block_id and block_id not in block_spans:
+            block_spans[str(block_id)] = (
+                int(getattr(record.source, "span_start", 0) or 0),
+                int(getattr(record.source, "span_end", 0) or 0),
+            )
+
+    issues: list[ValidationIssue] = []
+    for annotation in getattr(roles_result, "role_annotations", []) or []:
+        block_id = str(getattr(annotation, "block_id", "") or "")
+        bounds = block_spans.get(block_id)
+        if bounds is None:
+            continue
+        for span in getattr(annotation, "span_annotations", []) or []:
+            char_start = int(getattr(span, "char_start", 0) or 0)
+            char_end = int(getattr(span, "char_end", 0) or 0)
+            if char_start < bounds[0] or char_end > bounds[1]:
+                issues.append(ValidationIssue(
+                    rule_id="evidence_span_alignment_mismatch",
+                    severity="warning",
+                    message=(
+                        f"span {getattr(span, 'span_id', '?')} chars "
+                        f"[{char_start}, {char_end}] fall outside block "
+                        f"{block_id} evidence span {list(bounds)}"
+                    ),
+                    field=block_id,
+                ))
+    registry_result.validation_issues = (
+        list(getattr(registry_result, "validation_issues", []) or []) + issues
+    )
+    return issues

--- a/src/episteme_graph/agents/evidence_registry/builder.py
+++ b/src/episteme_graph/agents/evidence_registry/builder.py
@@ -9,6 +9,8 @@ DocumentStructureResult の block.text の原文範囲のみを採用する。
 """
 from __future__ import annotations
 
+import re
+
 from .schema import (
     EVIDENCE_ROLES,
     EvidenceRecord,
@@ -127,6 +129,61 @@ class EvidenceRegistryBuilder:
             review_note=review_note,
         )
 
+    def add_sentences_for_block(
+        self,
+        block_id: str,
+        *,
+        parent_evidence_id: str | None = None,
+        public_export_policy: str | None = None,
+        review_note: str = "",
+    ) -> list[str]:
+        """Register sentence-level evidence for a block (issue #363).
+
+        Deterministic sentence splitting only (no LLM). Each sentence record
+        carries ``evidence_role="sentence_quote"`` and points back at the
+        block-level record via ``parent_evidence_id`` so atomic claims can cite
+        the exact supporting sentence. A single-sentence block adds nothing the
+        block record doesn't already cover, so it is skipped.
+        """
+        block = self._block_index.get(block_id)
+        if block is None:
+            self._issues.append(ValidationIssue(
+                rule_id="evidence_block_missing",
+                severity="error",
+                message=f"block not found: {block_id}",
+                field=block_id,
+            ))
+            return []
+        text = getattr(block, "text", "") or ""
+        spans = split_sentences_with_offsets(text)
+        if len(spans) < 2:
+            return []
+        parent = None
+        if parent_evidence_id:
+            parent = next(
+                (r for r in self._records if r.evidence_id == parent_evidence_id),
+                None,
+            )
+        policy = public_export_policy or (
+            parent.public_export_policy if parent else "location_only"
+        )
+        evidence_ids: list[str] = []
+        for start, end in spans:
+            evidence_id = self._add(
+                block_id=block_id,
+                section_id=getattr(block, "section_id", None),
+                page=getattr(block, "page", None),
+                span_start=start,
+                span_end=end,
+                evidence_text=text[start:end],
+                evidence_role="sentence_quote",
+                public_export_policy=policy,
+                review_note=review_note,
+                parent_evidence_id=parent_evidence_id,
+            )
+            evidence_ids.append(evidence_id)
+        return evidence_ids
+
     def attach_review_note(self, evidence_id: str, review_note: str) -> bool:
         """既存 evidence にレビューコメントを追記する。
         evidence_text を汚染しないことを保証する。
@@ -173,6 +230,7 @@ class EvidenceRegistryBuilder:
         evidence_role: str,
         public_export_policy: str,
         review_note: str,
+        parent_evidence_id: str | None = None,
     ) -> str:
         if evidence_role not in EVIDENCE_ROLES:
             self._issues.append(ValidationIssue(
@@ -208,6 +266,7 @@ class EvidenceRegistryBuilder:
             evidence_role=evidence_role,
             public_export_policy=public_export_policy,
             review_note=review_note,
+            parent_evidence_id=parent_evidence_id,
         )
         self._records.append(record)
         self._dedup_key_to_id[key] = evidence_id
@@ -240,3 +299,45 @@ class EvidenceRegistryBuilder:
                     message=f"evidence {r.evidence_id} has no block_id",
                     field=r.evidence_id,
                 ))
+
+
+# ---------------------------------------------------------------------------
+# Sentence splitting (issue #363) — deterministic, no LLM.
+# ---------------------------------------------------------------------------
+
+# Abbreviations that end with a period but do not end a sentence. General
+# scholarly notation only — no field-specific vocabulary.
+_NON_TERMINAL_ABBREVIATIONS = (
+    "eq", "eqs", "fig", "figs", "tab", "ref", "refs", "sec", "secs",
+    "e.g", "i.e", "cf", "vs", "et al", "al", "no", "dr", "prof", "etc",
+)
+
+_SENTENCE_BOUNDARY = re.compile(r"[.!?。！？]")
+
+
+def split_sentences_with_offsets(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) character offsets of the sentences in ``text``."""
+    text = str(text or "")
+    spans: list[tuple[int, int]] = []
+    start = 0
+    for match in _SENTENCE_BOUNDARY.finditer(text):
+        end = match.end()
+        if end < len(text) and not text[end].isspace():
+            continue  # mid-token period like "3.14" or "v2.0"
+        prefix = text[start:match.start()].rstrip()
+        last_token = prefix.split()[-1].lower().rstrip(".") if prefix.split() else ""
+        if match.group() == "." and last_token in _NON_TERMINAL_ABBREVIATIONS:
+            continue
+        stripped_start = start
+        while stripped_start < end and text[stripped_start].isspace():
+            stripped_start += 1
+        if end > stripped_start and text[stripped_start:end].strip():
+            spans.append((stripped_start, end))
+        start = end
+    rest = text[start:].strip()
+    if rest:
+        stripped_start = start
+        while stripped_start < len(text) and text[stripped_start].isspace():
+            stripped_start += 1
+        spans.append((stripped_start, len(text)))
+    return spans

--- a/src/episteme_graph/agents/evidence_registry/schema.py
+++ b/src/episteme_graph/agents/evidence_registry/schema.py
@@ -15,6 +15,7 @@ EVIDENCE_ROLES = [
     "equation_quote",       # 式ブロックの引用
     "figure_caption_quote", # 図キャプションの引用
     "table_caption_quote",  # 表キャプションの引用
+    "sentence_quote",       # block 内の 1 文単位の引用 (issue #363)
 ]
 
 PUBLIC_EXPORT_POLICIES = [
@@ -48,6 +49,8 @@ class EvidenceRecord:
     public_export_policy: str = "location_only"
     review_note: str = ""
     cartridge_id: str | None = None
+    # Sentence-level records point back at their block-level record (issue #363).
+    parent_evidence_id: str | None = None
 
 
 @dataclass
@@ -88,6 +91,7 @@ class EvidenceRegistryResult:
                 public_export_policy=r.get("public_export_policy", "location_only"),
                 review_note=r.get("review_note", ""),
                 cartridge_id=r.get("cartridge_id"),
+                parent_evidence_id=r.get("parent_evidence_id"),
             ))
         issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
         return cls(

--- a/src/episteme_graph/agents/id_canonicalization.py
+++ b/src/episteme_graph/agents/id_canonicalization.py
@@ -321,14 +321,16 @@ def _unique(values: list[str]) -> list[str]:
 
 
 def annotate_claim_equation_link_asymmetries(claim_objects: Any, equations: Any) -> int:
-    """Explicitly demote one-way claim↔equation links to review metadata (#358).
+    """Demote one-way claim↔equation links to inferred (#358).
 
     ``claim.equation_ids`` and ``equation.semantics.linked_claim_ids`` are
-    maintained by different stages and can drift apart. Neither side carries a
-    per-link status, so the demotion is recorded where each artifact CAN carry
-    it: the equation gains the ``claim_link_asymmetry`` review flag, the claim
-    a review_note line. Links are kept, never dropped. Returns the number of
-    one-way links annotated.
+    maintained by different stages and can drift apart. A one-way link is
+    moved out of the primary link field into the corresponding ``inferred_*``
+    field (``claim.inferred_equation_ids`` / ``semantics.inferred_claim_ids``)
+    so downstream stages no longer consume it as a confirmed link. The id is
+    kept, never dropped, and the demotion is additionally recorded as review
+    metadata (a review_note line on the claim, the ``claim_link_asymmetry``
+    review flag on the equation). Returns the number of demoted links.
     """
     claims = list(getattr(claim_objects, "claims", []) or [])
     records = list(getattr(equations, "equations", []) or [])
@@ -343,40 +345,65 @@ def annotate_claim_equation_link_asymmetries(claim_objects: Any, equations: Any)
 
     count = 0
     for claim in claims:
+        kept: list[str] = []
         for eq_id in getattr(claim, "equation_ids", []) or []:
             record = eq_by_id.get(str(eq_id))
             if record is None:
+                # Unknown equation id: dangling-ref checks own this case.
+                kept.append(eq_id)
                 continue
             linked = [
                 str(v) for v in
                 (getattr(record.semantics, "linked_claim_ids", []) or [])
             ]
             if str(getattr(claim, "claim_id", "")) in linked:
+                kept.append(eq_id)
                 continue
+            inferred = [
+                str(v) for v in
+                (getattr(claim, "inferred_equation_ids", []) or [])
+            ]
+            if str(eq_id) not in inferred:
+                inferred.append(str(eq_id))
+            claim.inferred_equation_ids = inferred
             note = (
                 f"equation link {eq_id} is one-way (the equation does not link "
-                "this claim back); treat as inferred until reviewed"
+                "this claim back); demoted to inferred_equation_ids until reviewed"
             )
             existing = str(getattr(claim, "review_note", "") or "")
             if note not in existing:
                 claim.review_note = f"{existing}\n{note}".strip() if existing else note
             count += 1
+        if len(kept) != len(getattr(claim, "equation_ids", []) or []):
+            claim.equation_ids = kept
 
     for record in records:
         sem = getattr(record, "semantics", None)
         if sem is None:
             continue
+        kept = []
         for claim_id in getattr(sem, "linked_claim_ids", []) or []:
             claim = claim_by_id.get(str(claim_id))
             if claim is None:
+                # Unknown claim id: unresolved-claim-ref checks own this case.
+                kept.append(claim_id)
                 continue
             if str(getattr(record, "equation_id", "")) in [
                 str(v) for v in (getattr(claim, "equation_ids", []) or [])
             ]:
+                kept.append(claim_id)
                 continue
+            inferred = [
+                str(v) for v in (getattr(sem, "inferred_claim_ids", []) or [])
+            ]
+            if str(claim_id) not in inferred:
+                inferred.append(str(claim_id))
+            sem.inferred_claim_ids = inferred
             if "claim_link_asymmetry" not in (sem.review_flags or []):
                 sem.review_flags = list(sem.review_flags or []) + [
                     "claim_link_asymmetry"
                 ]
             count += 1
+        if len(kept) != len(getattr(sem, "linked_claim_ids", []) or []):
+            sem.linked_claim_ids = kept
     return count

--- a/src/episteme_graph/agents/id_canonicalization.py
+++ b/src/episteme_graph/agents/id_canonicalization.py
@@ -318,3 +318,65 @@ def _unique(values: list[str]) -> list[str]:
         if value not in result:
             result.append(value)
     return result
+
+
+def annotate_claim_equation_link_asymmetries(claim_objects: Any, equations: Any) -> int:
+    """Explicitly demote one-way claim↔equation links to review metadata (#358).
+
+    ``claim.equation_ids`` and ``equation.semantics.linked_claim_ids`` are
+    maintained by different stages and can drift apart. Neither side carries a
+    per-link status, so the demotion is recorded where each artifact CAN carry
+    it: the equation gains the ``claim_link_asymmetry`` review flag, the claim
+    a review_note line. Links are kept, never dropped. Returns the number of
+    one-way links annotated.
+    """
+    claims = list(getattr(claim_objects, "claims", []) or [])
+    records = list(getattr(equations, "equations", []) or [])
+    claim_by_id = {
+        str(getattr(c, "claim_id", "") or ""): c
+        for c in claims if getattr(c, "claim_id", None)
+    }
+    eq_by_id = {
+        str(getattr(r, "equation_id", "") or ""): r
+        for r in records if getattr(r, "equation_id", None)
+    }
+
+    count = 0
+    for claim in claims:
+        for eq_id in getattr(claim, "equation_ids", []) or []:
+            record = eq_by_id.get(str(eq_id))
+            if record is None:
+                continue
+            linked = [
+                str(v) for v in
+                (getattr(record.semantics, "linked_claim_ids", []) or [])
+            ]
+            if str(getattr(claim, "claim_id", "")) in linked:
+                continue
+            note = (
+                f"equation link {eq_id} is one-way (the equation does not link "
+                "this claim back); treat as inferred until reviewed"
+            )
+            existing = str(getattr(claim, "review_note", "") or "")
+            if note not in existing:
+                claim.review_note = f"{existing}\n{note}".strip() if existing else note
+            count += 1
+
+    for record in records:
+        sem = getattr(record, "semantics", None)
+        if sem is None:
+            continue
+        for claim_id in getattr(sem, "linked_claim_ids", []) or []:
+            claim = claim_by_id.get(str(claim_id))
+            if claim is None:
+                continue
+            if str(getattr(record, "equation_id", "")) in [
+                str(v) for v in (getattr(claim, "equation_ids", []) or [])
+            ]:
+                continue
+            if "claim_link_asymmetry" not in (sem.review_flags or []):
+                sem.review_flags = list(sem.review_flags or []) + [
+                    "claim_link_asymmetry"
+                ]
+            count += 1
+    return count

--- a/src/episteme_graph/agents/narrative_annotator/__init__.py
+++ b/src/episteme_graph/agents/narrative_annotator/__init__.py
@@ -1,0 +1,5 @@
+"""NarrativeAnnotator — reader-facing narrative for the main graph (issue #360)."""
+from .agent import NarrativeAnnotator
+from .schema import NarrativeAnnotationResult
+
+__all__ = ["NarrativeAnnotator", "NarrativeAnnotationResult"]

--- a/src/episteme_graph/agents/narrative_annotator/agent.py
+++ b/src/episteme_graph/agents/narrative_annotator/agent.py
@@ -1,0 +1,109 @@
+"""NarrativeAnnotator: reader-facing narrative for the main graph (issue #360).
+
+LLM-first, annotation-only: the agent reads the TheoryOperationGraph and adds
+``narrative_role`` / ``transition_text`` / ``graph_summary`` as a SEPARATE
+artifact. It never modifies the graph itself — that invariant is asserted by
+snapshot comparison and reported as a hard error if it ever breaks. All output
+is provisional (maturity_source="llm_proposed").
+"""
+from __future__ import annotations
+
+import logging
+
+from .cartridge_loader import CartridgeContext, CartridgeLoader
+from .input_builder import NarrativeInputBuilder
+from .llm_client import NarrativeLLMClient
+from .prompt import NarrativePromptFactory
+from .repair import NarrativeRepairer, _parse_raw
+from .schema import NarrativeAnnotationResult, ValidationIssue
+from .validator import NarrativeValidator, verify_graph_unchanged
+
+logger = logging.getLogger(__name__)
+
+
+class NarrativeAnnotator:
+    def __init__(
+        self,
+        cartridge_base_dir: str | None = None,
+        llm_model: str | None = None,
+    ) -> None:
+        self._cartridge_loader = CartridgeLoader(cartridge_base_dir)
+        self._input_builder = NarrativeInputBuilder()
+        self._prompt_factory = NarrativePromptFactory()
+        self._llm_client = NarrativeLLMClient(model=llm_model)
+        self._validator = NarrativeValidator()
+        self._repairer = NarrativeRepairer()
+
+    def run(
+        self,
+        graph,
+        thesis=None,
+        derivations=None,
+        cartridge_id: str | None = None,
+        config: dict | None = None,
+    ) -> NarrativeAnnotationResult:
+        cartridge = self._load_cartridge(cartridge_id)
+        document_id = str(getattr(graph, "document_id", "") or "")
+        graph_snapshot = graph.to_dict() if hasattr(graph, "to_dict") else None
+
+        llm_input = self._input_builder.build(
+            graph, thesis=thesis, derivations=derivations,
+            cartridge=cartridge, config=config,
+        )
+        if not llm_input.main_nodes:
+            return NarrativeAnnotationResult.make_fallback(
+                document_id, cartridge_id, "graph has no main-layer nodes"
+            )
+
+        messages = self._prompt_factory.build_messages(llm_input, cartridge)
+        try:
+            raw_output = self._llm_client.generate(messages)
+        except Exception as exc:
+            logger.error("Narrative annotation failed: %s", exc)
+            return NarrativeAnnotationResult.make_fallback(
+                document_id, cartridge_id, str(exc)
+            )
+
+        result = _parse_raw(raw_output, llm_input)
+        issues = self._validator.validate(result, llm_input)
+        if [i for i in issues if i.severity == "error"]:
+            result = self._repairer.repair(
+                llm_input=llm_input,
+                raw_output=raw_output,
+                validation_issues=issues,
+                cartridge=cartridge,
+                llm_client=self._llm_client,
+                prompt_factory=self._prompt_factory,
+                validator=self._validator,
+            )
+        else:
+            result.validation_issues = issues
+
+        self._assert_graph_unchanged(graph, graph_snapshot, result)
+        return result
+
+    @staticmethod
+    def _assert_graph_unchanged(graph, snapshot, result: NarrativeAnnotationResult) -> None:
+        if snapshot is None or not hasattr(graph, "to_dict"):
+            return
+        if verify_graph_unchanged(snapshot, graph.to_dict()):
+            return
+        result.validation_issues = list(result.validation_issues or []) + [
+            ValidationIssue(
+                rule_id="graph_mutated_by_annotator",
+                severity="error",
+                message="annotation must not modify the graph; structure changed",
+                field="graph",
+            )
+        ]
+
+    def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
+        if not cartridge_id:
+            return None
+        try:
+            return self._cartridge_loader.load(cartridge_id)
+        except FileNotFoundError:
+            logger.warning(
+                "Cartridge '%s' not found; proceeding without cartridge", cartridge_id
+            )
+            return None

--- a/src/episteme_graph/agents/narrative_annotator/cartridge_loader.py
+++ b/src/episteme_graph/agents/narrative_annotator/cartridge_loader.py
@@ -1,0 +1,59 @@
+"""Load cartridge context for NarrativeAnnotator (issue #360)."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+from episteme_graph.agents.cartridge_paths import resolve_cartridge_base_dir
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_CARTRIDGE_BASE = os.path.abspath(
+    os.path.join(_HERE, "..", "..", "..", "..", "backend", "cartridges")
+)
+
+
+@dataclass
+class CartridgeContext:
+    cartridge_id: str
+    ontology: dict
+    validation_rules: dict
+    aliases: dict | None = None
+    notation_patterns: list | None = None
+    normalization_rules: list | None = None
+    extraction_hints: list | None = None
+
+
+class CartridgeLoader:
+    def __init__(self, cartridge_base_dir: str | None = None) -> None:
+        self._base_dir = cartridge_base_dir or resolve_cartridge_base_dir(_DEFAULT_CARTRIDGE_BASE)
+
+    def load(self, cartridge_id: str) -> CartridgeContext:
+        cartridge_dir = os.path.join(self._base_dir, cartridge_id)
+        if not os.path.isdir(cartridge_dir):
+            raise FileNotFoundError(
+                f"Cartridge '{cartridge_id}' not found at {cartridge_dir}"
+            )
+        ontology = self._load_json(cartridge_dir, "ontology.json")
+        validation_rules = self._load_json(cartridge_dir, "validation_rules.json")
+        aliases = (
+            {a["canonical"]: a["aliases"] for a in ontology.get("aliases", [])}
+            if ontology
+            else None
+        )
+        return CartridgeContext(
+            cartridge_id=cartridge_id,
+            ontology=ontology,
+            validation_rules=validation_rules,
+            aliases=aliases,
+            notation_patterns=ontology.get("notation_patterns") if ontology else None,
+            normalization_rules=ontology.get("normalization_rules") if ontology else None,
+            extraction_hints=ontology.get("extraction_hints") if ontology else None,
+        )
+
+    def _load_json(self, directory: str, filename: str) -> dict:
+        path = os.path.join(directory, filename)
+        if not os.path.exists(path):
+            return {}
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)

--- a/src/episteme_graph/agents/narrative_annotator/examples/narrative_annotation_example.json
+++ b/src/episteme_graph/agents/narrative_annotator/examples/narrative_annotation_example.json
@@ -1,0 +1,26 @@
+{
+  "document_id": "doc_example",
+  "narrative_version": "v1",
+  "cartridge_id": "particle_physics",
+  "graph_summary": "The paper argues that a single consistency relation links the three measured decay ratios. The graph starts from the theory basis that defines the effective operators, builds the observable ratios, linearises the resulting equation system, and eliminates the unknown form-factor parameter. The final consistency relation is then used as a diagnostic against the measured values.",
+  "node_narratives": [
+    {
+      "component_id": "main_theory_basis",
+      "narrative_role": "Defines the effective operators and couplings that every later stage relies on.",
+      "reason": "node description and linked definition equations",
+      "confidence": 0.8
+    }
+  ],
+  "edge_narratives": [
+    {
+      "edge_id": "edge_basis_to_observable",
+      "transition_text": "The operator definitions are combined into the measurable decay ratios.",
+      "reason": "edge reasoning text",
+      "confidence": 0.75
+    }
+  ],
+  "review_notes": [],
+  "confidence": 0.8,
+  "maturity_source": "llm_proposed",
+  "validation_issues": []
+}

--- a/src/episteme_graph/agents/narrative_annotator/input_builder.py
+++ b/src/episteme_graph/agents/narrative_annotator/input_builder.py
@@ -1,0 +1,111 @@
+"""Build NarrativeAnnotator LLM input (issue #360).
+
+Packages the main-layer graph (nodes / edges), the reconstructed thesis text,
+and the teaching takeaways already produced by DerivationChain so the LLM can
+mostly quote and arrange existing material instead of inventing new content.
+"""
+from __future__ import annotations
+
+from .schema import NarrativeLLMInput
+
+_MAX_MAIN_NODES = 16
+_MAX_MAIN_EDGES = 24
+
+
+class NarrativeInputBuilder:
+    def build(
+        self,
+        graph,
+        thesis=None,
+        derivations=None,
+        cartridge=None,
+        config: dict | None = None,
+    ) -> NarrativeLLMInput:
+        cfg = config or {}
+        takeaways = self._takeaways_by_derivation(derivations)
+        main_nodes = self._main_nodes(
+            graph, takeaways, int(cfg.get("max_main_nodes", _MAX_MAIN_NODES))
+        )
+        main_node_ids = {n["component_id"] for n in main_nodes}
+        main_edges = self._main_edges(
+            graph, main_node_ids, int(cfg.get("max_main_edges", _MAX_MAIN_EDGES))
+        )
+        return NarrativeLLMInput(
+            document_id=str(getattr(graph, "document_id", "") or ""),
+            cartridge_id=cartridge.cartridge_id if cartridge else getattr(graph, "cartridge_id", None),
+            central_thesis_text=self._thesis_text(thesis),
+            main_nodes=main_nodes,
+            main_edges=main_edges,
+            normalized_terms=self._normalized_terms(cartridge) if cartridge else None,
+        )
+
+    @staticmethod
+    def _thesis_text(thesis) -> str:
+        central = getattr(thesis, "central_thesis", None)
+        if isinstance(central, dict):
+            return str(central.get("text") or "")
+        return ""
+
+    @staticmethod
+    def _takeaways_by_derivation(derivations) -> dict[str, str]:
+        takeaways: dict[str, str] = {}
+        for chain in getattr(derivations, "chains", []) or []:
+            derivation_id = str(getattr(chain, "derivation_id", "") or "")
+            takeaway = str(getattr(chain, "teaching_takeaway", "") or "")
+            if derivation_id and takeaway:
+                takeaways[derivation_id] = takeaway
+        return takeaways
+
+    @staticmethod
+    def _main_nodes(graph, takeaways: dict[str, str], limit: int) -> list[dict]:
+        nodes = []
+        for node in getattr(graph, "nodes", []) or []:
+            if str(getattr(node, "graph_layer", "main") or "main") != "main":
+                continue
+            node_takeaways = [
+                takeaways[d]
+                for d in (getattr(node, "linked_derivation_ids", []) or [])
+                if d in takeaways
+            ]
+            nodes.append({
+                "component_id": node.component_id,
+                "label": node.label,
+                "description": getattr(node, "description", ""),
+                "operation": getattr(node, "operation", ""),
+                "source_backing_status": getattr(node, "source_backing_status", ""),
+                "linked_equation_ids": list(getattr(node, "linked_equation_ids", []) or []),
+                "linked_claim_ids": list(getattr(node, "linked_claim_ids", []) or []),
+                "teaching_takeaways": node_takeaways,
+                "display_order": int(getattr(node, "display_order", 0) or 0),
+            })
+            if len(nodes) >= limit:
+                break
+        nodes.sort(key=lambda n: (n["display_order"], n["component_id"]))
+        return nodes
+
+    @staticmethod
+    def _main_edges(graph, main_node_ids: set[str], limit: int) -> list[dict]:
+        edges = []
+        for edge in getattr(graph, "edges", []) or []:
+            source = str(getattr(edge, "source", "") or "")
+            target = str(getattr(edge, "target", "") or "")
+            if source not in main_node_ids or target not in main_node_ids:
+                continue
+            edges.append({
+                "edge_id": edge.edge_id,
+                "source": source,
+                "target": target,
+                "edge_type": getattr(edge, "edge_type", ""),
+                "reasoning": getattr(edge, "reasoning", ""),
+            })
+            if len(edges) >= limit:
+                break
+        return edges
+
+    @staticmethod
+    def _normalized_terms(cartridge) -> list[dict]:
+        terms: list[dict] = []
+        if getattr(cartridge, "aliases", None):
+            for canonical, aliases in cartridge.aliases.items():
+                terms.append({"canonical": canonical, "aliases": aliases})
+        return terms

--- a/src/episteme_graph/agents/narrative_annotator/llm_client.py
+++ b/src/episteme_graph/agents/narrative_annotator/llm_client.py
@@ -1,0 +1,8 @@
+"""LLM client for NarrativeAnnotator (issue #360)."""
+from __future__ import annotations
+
+from episteme_graph.agents.llm_json_client import ProviderJSONLLMClient
+
+
+class NarrativeLLMClient(ProviderJSONLLMClient):
+    pass

--- a/src/episteme_graph/agents/narrative_annotator/prompt.py
+++ b/src/episteme_graph/agents/narrative_annotator/prompt.py
@@ -1,0 +1,120 @@
+"""Prompt construction for NarrativeAnnotator (issue #360)."""
+from __future__ import annotations
+
+import json
+
+from .schema import (
+    MAX_GRAPH_SUMMARY_CHARS,
+    MAX_NARRATIVE_ROLE_CHARS,
+    MAX_TRANSITION_TEXT_CHARS,
+    NarrativeLLMInput,
+)
+
+_SYSTEM_CONTENT = """\
+You are writing the reading layer for a theory-operation graph extracted from a
+scientific paper. The graph structure is FIXED — you never add, remove, merge,
+or reorder nodes or edges. You only write short reader-facing text:
+
+1. graph_summary — 3–5 sentences: the paper's central thesis and how the graph
+   stages support it, in reading order.
+2. node_narratives[] — for each main node: narrative_role (1–2 sentences) —
+   what this stage contributes to the paper's argument.
+3. edge_narratives[] — for each main edge: transition_text (1 sentence) —
+   what the source stage hands to the target stage.
+
+Rules:
+- Ground every sentence in the provided node descriptions, teaching takeaways,
+  and thesis text. Do not invent results that are not in the material.
+- Reuse the provided teaching takeaways where they fit; rephrase for flow.
+- Write for a graduate student reading the graph for the first time.
+- Plain declarative sentences. No marketing language, no "this amazing paper".
+- Every component_id / edge_id you mention must come from the input lists.
+- Give each annotation a short reason and a confidence between 0.0 and 1.0.
+- Return ONLY valid JSON matching the provided schema.
+"""
+
+_OUTPUT_SCHEMA = {
+    "graph_summary": "3-5 sentences (central thesis -> support structure)",
+    "node_narratives": [
+        {
+            "component_id": "main node component_id from the input",
+            "narrative_role": "1-2 sentences: role of this stage in the argument",
+            "reason": "which input material grounds this text",
+            "confidence": 0.0,
+        }
+    ],
+    "edge_narratives": [
+        {
+            "edge_id": "main edge edge_id from the input",
+            "transition_text": "1 sentence: what this edge hands to the next stage",
+            "reason": "which input material grounds this text",
+            "confidence": 0.0,
+        }
+    ],
+    "review_notes": ["optional short notes for the teacher"],
+    "confidence": 0.0,
+}
+
+
+class NarrativePromptFactory:
+    def build_messages(self, llm_input: NarrativeLLMInput, cartridge=None) -> list[dict]:
+        return [
+            {"role": "system", "content": _SYSTEM_CONTENT},
+            {"role": "user", "content": self._build_user_content(llm_input)},
+        ]
+
+    def build_repair_messages(
+        self,
+        llm_input: NarrativeLLMInput,
+        previous_output: dict,
+        issues: list,
+        cartridge=None,
+    ) -> list[dict]:
+        issue_text = "\n".join(
+            f"- [{i.severity}] {i.rule_id}: {i.message}" for i in issues
+        )
+        content = (
+            self._build_user_content(llm_input)
+            + "\n\n## Previous Output\n"
+            + json.dumps(previous_output, ensure_ascii=False, indent=2)
+            + "\n\n## Validation Issues\n"
+            + issue_text
+            + "\nReturn corrected JSON for the same graph."
+        )
+        return [
+            {"role": "system", "content": _SYSTEM_CONTENT},
+            {"role": "user", "content": content},
+        ]
+
+    @staticmethod
+    def _build_user_content(llm_input: NarrativeLLMInput) -> str:
+        parts: list[str] = []
+        parts.append("## Task")
+        parts.append(
+            "Write graph_summary, node_narratives, and edge_narratives for the "
+            "main theory-operation graph below. Return ONLY JSON."
+        )
+        parts.append(f"\ndocument_id: {llm_input.document_id}")
+        if llm_input.central_thesis_text:
+            parts.append("\n## Central Thesis")
+            parts.append(llm_input.central_thesis_text)
+        parts.append("\n## Main Nodes (fixed; annotate each)")
+        parts.append(json.dumps(llm_input.main_nodes, ensure_ascii=False, indent=2))
+        parts.append("\n## Main Edges (fixed; annotate each)")
+        parts.append(json.dumps(llm_input.main_edges, ensure_ascii=False, indent=2))
+        if llm_input.normalized_terms:
+            parts.append("\n## Cartridge Normalized Terms")
+            for term in llm_input.normalized_terms[:20]:
+                parts.append(f"- {term.get('canonical', '')}")
+        parts.append("\n## Output Schema")
+        parts.append(json.dumps(_OUTPUT_SCHEMA, ensure_ascii=False, indent=2))
+        parts.append("\n## Constraints")
+        parts.append(
+            f"- graph_summary <= {MAX_GRAPH_SUMMARY_CHARS} characters\n"
+            f"- narrative_role <= {MAX_NARRATIVE_ROLE_CHARS} characters\n"
+            f"- transition_text <= {MAX_TRANSITION_TEXT_CHARS} characters\n"
+            "- one node_narratives entry per main node, one edge_narratives entry per main edge\n"
+            "- component_id / edge_id must exist in the inputs\n"
+            "- Return ONLY valid JSON, no markdown fences"
+        )
+        return "\n".join(parts)

--- a/src/episteme_graph/agents/narrative_annotator/repair.py
+++ b/src/episteme_graph/agents/narrative_annotator/repair.py
@@ -1,0 +1,94 @@
+"""Repair helpers for NarrativeAnnotator (issue #360)."""
+from __future__ import annotations
+
+import logging
+
+from .schema import (
+    EdgeNarrative,
+    NARRATIVE_VERSION,
+    NarrativeAnnotationResult,
+    NarrativeLLMInput,
+    NodeNarrative,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_REPAIR_ATTEMPTS = 2
+
+
+def _parse_raw(raw: dict, llm_input: NarrativeLLMInput) -> NarrativeAnnotationResult:
+    nodes: list[NodeNarrative] = []
+    for entry in raw.get("node_narratives") or []:
+        if not isinstance(entry, dict):
+            continue
+        nodes.append(NodeNarrative(
+            component_id=str(entry.get("component_id") or ""),
+            narrative_role=str(entry.get("narrative_role") or "").strip(),
+            reason=str(entry.get("reason") or ""),
+            confidence=_clamp(entry.get("confidence")),
+        ))
+    edges: list[EdgeNarrative] = []
+    for entry in raw.get("edge_narratives") or []:
+        if not isinstance(entry, dict):
+            continue
+        edges.append(EdgeNarrative(
+            edge_id=str(entry.get("edge_id") or ""),
+            transition_text=str(entry.get("transition_text") or "").strip(),
+            reason=str(entry.get("reason") or ""),
+            confidence=_clamp(entry.get("confidence")),
+        ))
+    return NarrativeAnnotationResult(
+        document_id=llm_input.document_id,
+        narrative_version=NARRATIVE_VERSION,
+        cartridge_id=llm_input.cartridge_id,
+        graph_summary=str(raw.get("graph_summary") or "").strip(),
+        node_narratives=nodes,
+        edge_narratives=edges,
+        review_notes=[str(n) for n in (raw.get("review_notes") or []) if n],
+        confidence=_clamp(raw.get("confidence")),
+        maturity_source="llm_proposed",
+    )
+
+
+def _clamp(value) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+class NarrativeRepairer:
+    def repair(
+        self,
+        *,
+        llm_input: NarrativeLLMInput,
+        raw_output: dict,
+        validation_issues: list,
+        cartridge,
+        llm_client,
+        prompt_factory,
+        validator,
+    ) -> NarrativeAnnotationResult:
+        for attempt in range(1, _MAX_REPAIR_ATTEMPTS + 1):
+            logger.info(
+                "Narrative annotation repair attempt %d/%d", attempt, _MAX_REPAIR_ATTEMPTS
+            )
+            messages = prompt_factory.build_repair_messages(
+                llm_input, raw_output, validation_issues, cartridge
+            )
+            try:
+                raw_output = llm_client.generate(messages)
+            except Exception as exc:
+                logger.warning("Narrative repair LLM call failed: %s", exc)
+                break
+            result = _parse_raw(raw_output, llm_input)
+            remaining = validator.validate(result, llm_input)
+            if not [i for i in remaining if i.severity == "error"]:
+                result.validation_issues = remaining
+                return result
+            validation_issues = remaining
+        return NarrativeAnnotationResult.make_fallback(
+            llm_input.document_id,
+            llm_input.cartridge_id,
+            "Repair failed after max attempts",
+        )

--- a/src/episteme_graph/agents/narrative_annotator/schema.py
+++ b/src/episteme_graph/agents/narrative_annotator/schema.py
@@ -1,0 +1,123 @@
+"""NarrativeAnnotator data models (issue #360).
+
+The annotator adds a reading layer on top of the TheoryOperationGraph:
+- per main node: ``narrative_role`` — what this stage contributes to the
+  paper's argument (1–2 sentences)
+- per main edge: ``transition_text`` — what the edge hands from one stage to
+  the next (1 sentence)
+- per graph: ``graph_summary`` — central thesis → support structure in 3–5
+  sentences
+
+Annotations NEVER modify the graph itself (nodes / edges / layers / backing
+status stay untouched) and are always provisional (maturity_source =
+"llm_proposed"); a teacher confirms them later.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+NARRATIVE_VERSION = "v1"
+
+# Length caps keep the annotations display-sized; the validator enforces them.
+MAX_NARRATIVE_ROLE_CHARS = 400
+MAX_TRANSITION_TEXT_CHARS = 300
+MAX_GRAPH_SUMMARY_CHARS = 1500
+
+MATURITY_SOURCES = ["llm_proposed", "teacher_approved"]
+
+
+@dataclass
+class NodeNarrative:
+    component_id: str
+    narrative_role: str
+    reason: str = ""
+    confidence: float = 0.0
+
+
+@dataclass
+class EdgeNarrative:
+    edge_id: str
+    transition_text: str
+    reason: str = ""
+    confidence: float = 0.0
+
+
+@dataclass
+class ValidationIssue:
+    rule_id: str
+    severity: str
+    message: str
+    field: str | None = None
+
+
+@dataclass
+class NarrativeAnnotationResult:
+    document_id: str
+    narrative_version: str
+    cartridge_id: str | None
+    graph_summary: str
+    node_narratives: list[NodeNarrative]
+    edge_narratives: list[EdgeNarrative]
+    review_notes: list[str]
+    confidence: float
+    maturity_source: str = "llm_proposed"
+    validation_issues: list[ValidationIssue] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NarrativeAnnotationResult":
+        nodes = [NodeNarrative(**n) for n in d.get("node_narratives", [])]
+        edges = [EdgeNarrative(**e) for e in d.get("edge_narratives", [])]
+        issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
+        return cls(
+            document_id=d["document_id"],
+            narrative_version=d.get("narrative_version", NARRATIVE_VERSION),
+            cartridge_id=d.get("cartridge_id"),
+            graph_summary=d.get("graph_summary", ""),
+            node_narratives=nodes,
+            edge_narratives=edges,
+            review_notes=list(d.get("review_notes", [])),
+            confidence=float(d.get("confidence", 0.0)),
+            maturity_source=d.get("maturity_source", "llm_proposed"),
+            validation_issues=issues,
+        )
+
+    @classmethod
+    def make_fallback(
+        cls,
+        document_id: str,
+        cartridge_id: str | None,
+        reason: str,
+    ) -> "NarrativeAnnotationResult":
+        return cls(
+            document_id=document_id,
+            narrative_version=NARRATIVE_VERSION,
+            cartridge_id=cartridge_id,
+            graph_summary="",
+            node_narratives=[],
+            edge_narratives=[],
+            review_notes=[f"Narrative annotation failed: {reason}"],
+            confidence=0.0,
+            validation_issues=[ValidationIssue(
+                rule_id="narrative_annotation_failed",
+                severity="error",
+                message=reason,
+                field="graph_summary",
+            )],
+        )
+
+
+@dataclass
+class NarrativeLLMInput:
+    document_id: str
+    cartridge_id: str | None
+    central_thesis_text: str
+    main_nodes: list[dict]
+    main_edges: list[dict]
+    normalized_terms: list[dict] | None = None

--- a/src/episteme_graph/agents/narrative_annotator/validator.py
+++ b/src/episteme_graph/agents/narrative_annotator/validator.py
@@ -1,0 +1,135 @@
+"""Validation for NarrativeAnnotator outputs (issue #360)."""
+from __future__ import annotations
+
+from .schema import (
+    MATURITY_SOURCES,
+    MAX_GRAPH_SUMMARY_CHARS,
+    MAX_NARRATIVE_ROLE_CHARS,
+    MAX_TRANSITION_TEXT_CHARS,
+    NarrativeAnnotationResult,
+    NarrativeLLMInput,
+    ValidationIssue,
+)
+
+
+def verify_graph_unchanged(before: dict, after: dict) -> bool:
+    """The annotator must never modify the graph (issue #360 hard guarantee)."""
+    return before == after
+
+
+class NarrativeValidator:
+    def validate(
+        self,
+        result: NarrativeAnnotationResult,
+        llm_input: NarrativeLLMInput | None = None,
+    ) -> list[ValidationIssue]:
+        issues: list[ValidationIssue] = []
+        known_node_ids = {
+            str(n.get("component_id") or "")
+            for n in (llm_input.main_nodes if llm_input else [])
+        }
+        known_edge_ids = {
+            str(e.get("edge_id") or "")
+            for e in (llm_input.main_edges if llm_input else [])
+        }
+
+        if result.maturity_source not in MATURITY_SOURCES:
+            issues.append(ValidationIssue(
+                "invalid_maturity_source", "error",
+                f"maturity_source {result.maturity_source!r} is not allowed",
+                "maturity_source",
+            ))
+        if len(result.graph_summary or "") > MAX_GRAPH_SUMMARY_CHARS:
+            issues.append(ValidationIssue(
+                "graph_summary_too_long", "error",
+                f"graph_summary exceeds {MAX_GRAPH_SUMMARY_CHARS} characters",
+                "graph_summary",
+            ))
+        if not (0.0 <= float(result.confidence) <= 1.0):
+            issues.append(ValidationIssue(
+                "confidence_out_of_range", "error",
+                f"confidence {result.confidence} out of [0,1]",
+                "confidence",
+            ))
+
+        seen_nodes: set[str] = set()
+        for narrative in result.node_narratives or []:
+            field = f"node_narratives[{narrative.component_id}]"
+            if known_node_ids and narrative.component_id not in known_node_ids:
+                issues.append(ValidationIssue(
+                    "unknown_component_id", "error",
+                    f"{field} references unknown main node",
+                    field,
+                ))
+            if narrative.component_id in seen_nodes:
+                issues.append(ValidationIssue(
+                    "duplicate_node_narrative", "error",
+                    f"{field} is annotated more than once",
+                    field,
+                ))
+            seen_nodes.add(narrative.component_id)
+            if not str(narrative.narrative_role or "").strip():
+                issues.append(ValidationIssue(
+                    "empty_narrative_role", "error",
+                    f"{field} has empty narrative_role",
+                    field,
+                ))
+            if len(narrative.narrative_role or "") > MAX_NARRATIVE_ROLE_CHARS:
+                issues.append(ValidationIssue(
+                    "narrative_role_too_long", "error",
+                    f"{field} exceeds {MAX_NARRATIVE_ROLE_CHARS} characters",
+                    field,
+                ))
+            if not (0.0 <= float(narrative.confidence) <= 1.0):
+                issues.append(ValidationIssue(
+                    "confidence_out_of_range", "error",
+                    f"{field} confidence out of [0,1]",
+                    field,
+                ))
+
+        seen_edges: set[str] = set()
+        for narrative in result.edge_narratives or []:
+            field = f"edge_narratives[{narrative.edge_id}]"
+            if known_edge_ids and narrative.edge_id not in known_edge_ids:
+                issues.append(ValidationIssue(
+                    "unknown_edge_id", "error",
+                    f"{field} references unknown main edge",
+                    field,
+                ))
+            if narrative.edge_id in seen_edges:
+                issues.append(ValidationIssue(
+                    "duplicate_edge_narrative", "error",
+                    f"{field} is annotated more than once",
+                    field,
+                ))
+            seen_edges.add(narrative.edge_id)
+            if not str(narrative.transition_text or "").strip():
+                issues.append(ValidationIssue(
+                    "empty_transition_text", "error",
+                    f"{field} has empty transition_text",
+                    field,
+                ))
+            if len(narrative.transition_text or "") > MAX_TRANSITION_TEXT_CHARS:
+                issues.append(ValidationIssue(
+                    "transition_text_too_long", "error",
+                    f"{field} exceeds {MAX_TRANSITION_TEXT_CHARS} characters",
+                    field,
+                ))
+
+        # Coverage warnings (not hard errors): unannotated nodes / edges keep
+        # the artifact usable but visible for review.
+        for node_id in sorted(known_node_ids - seen_nodes):
+            if node_id:
+                issues.append(ValidationIssue(
+                    "node_without_narrative", "warning",
+                    f"main node {node_id!r} has no narrative_role",
+                    f"node_narratives[{node_id}]",
+                ))
+        for edge_id in sorted(known_edge_ids - seen_edges):
+            if edge_id:
+                issues.append(ValidationIssue(
+                    "edge_without_narrative", "warning",
+                    f"main edge {edge_id!r} has no transition_text",
+                    f"edge_narratives[{edge_id}]",
+                ))
+        return issues

--- a/src/episteme_graph/agents/symbol_registry/__init__.py
+++ b/src/episteme_graph/agents/symbol_registry/__init__.py
@@ -1,0 +1,5 @@
+"""SymbolRegistryBuilder — document-wide math symbol registry (issue #355)."""
+from .builder import SymbolRegistryBuilder
+from .schema import SymbolRecord, SymbolRegistryResult
+
+__all__ = ["SymbolRegistryBuilder", "SymbolRecord", "SymbolRegistryResult"]

--- a/src/episteme_graph/agents/symbol_registry/builder.py
+++ b/src/episteme_graph/agents/symbol_registry/builder.py
@@ -1,0 +1,347 @@
+"""SymbolRegistryBuilder (issue #355).
+
+EquationSemanticsResult の defined_symbols / used_symbols を走査し、文書単位の
+SymbolRegistryResult を決定論的に構築する非LLMビルダー。
+
+- 表記ゆれは一般的な数式記法の正規化（LaTeX ギリシャ文字コマンド → Unicode、
+  装飾コマンド除去）と cartridge の aliases で同一 symbol_id に集約する
+- 同一記号が複数の式で定義される場合は redefinition として
+  review_reasons=["symbol_redefinition"] を付与する
+- scope（equation_local / section / document）は定義・使用の分布から導出する
+- unit / domain_constraints は原文に無ければ None / 空のまま保持する
+  （情報を落とさない。LLM enrichment を将来追加する場合は llm_proposed 止まり）
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from .cartridge_loader import CartridgeContext, CartridgeLoader
+from .schema import (
+    SYMBOL_REGISTRY_VERSION,
+    SymbolRecord,
+    SymbolRegistryResult,
+    ValidationIssue,
+)
+
+logger = logging.getLogger(__name__)
+
+# General math notation only — no field- or paper-specific vocabulary here
+# (domain knowledge belongs in the cartridge).
+_LATEX_GREEK = {
+    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε",
+    "varepsilon": "ε", "zeta": "ζ", "eta": "η", "theta": "θ", "vartheta": "θ",
+    "iota": "ι", "kappa": "κ", "lambda": "λ", "mu": "μ", "nu": "ν", "xi": "ξ",
+    "pi": "π", "rho": "ρ", "sigma": "σ", "tau": "τ", "upsilon": "υ",
+    "phi": "φ", "varphi": "φ", "chi": "χ", "psi": "ψ", "omega": "ω",
+    "Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ", "Xi": "Ξ",
+    "Pi": "Π", "Sigma": "Σ", "Upsilon": "Υ", "Phi": "Φ", "Psi": "Ψ",
+    "Omega": "Ω",
+}
+
+_WRAPPER_COMMANDS = ("mathrm", "mathbf", "mathit", "mathcal", "text", "boldsymbol")
+
+
+def normalize_symbol(raw: str) -> str:
+    """Normalise general math notation so variants share a canonical key.
+
+    ``\\beta`` → ``β``, ``\\mathrm{b}_1`` → ``b_1``, ``$x$`` → ``x``.
+    Case is preserved (b and B are different symbols in math).
+    """
+    text = str(raw or "").strip().strip("$").strip()
+    if not text:
+        return ""
+    for command in _WRAPPER_COMMANDS:
+        text = re.sub(r"\\" + command + r"\{([^{}]*)\}", r"\1", text)
+    for name, glyph in _LATEX_GREEK.items():
+        text = re.sub(r"\\" + name + r"(?![A-Za-z])", glyph, text)
+    text = text.replace("{", "").replace("}", "")
+    text = re.sub(r"\s+", "", text)
+    return text
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", str(text or "")).strip("_")
+    return slug or "sym"
+
+
+class _SymbolAccumulator:
+    def __init__(self, canonical: str) -> None:
+        self.canonical = canonical
+        self.variants: list[str] = []
+        self.defining_equation_ids: list[str] = []
+        self.used_in_equation_ids: list[str] = []
+        self.section_ids: set[str] = set()
+        self.evidence_texts: list[str] = []
+        self.evidence_ids: list[str] = []
+        self.upstream_redefined = False
+
+    def add_variant(self, raw: str) -> None:
+        raw = str(raw or "").strip()
+        if raw and raw not in self.variants:
+            self.variants.append(raw)
+
+    def add_defining(self, eq_id: str) -> None:
+        if eq_id and eq_id not in self.defining_equation_ids:
+            self.defining_equation_ids.append(eq_id)
+
+    def add_used(self, eq_id: str) -> None:
+        if eq_id and eq_id not in self.used_in_equation_ids:
+            self.used_in_equation_ids.append(eq_id)
+
+
+class SymbolRegistryBuilder:
+    """Deterministic registry assembly. Works with or without a cartridge."""
+
+    def __init__(self, cartridge_base_dir: str | None = None) -> None:
+        self._cartridge_loader = CartridgeLoader(cartridge_base_dir)
+
+    def run(
+        self,
+        equations,
+        cartridge_id: str | None = None,
+        annotate_equations: bool = True,
+    ) -> SymbolRegistryResult:
+        cartridge = self._load_cartridge(cartridge_id)
+        document_id = str(getattr(equations, "document_id", "") or "")
+        records = list(getattr(equations, "equations", []) or [])
+
+        alias_map = self._alias_map(cartridge)
+        accumulators: dict[str, _SymbolAccumulator] = {}
+
+        for record in records:
+            eq_id = str(getattr(record, "equation_id", "") or "")
+            sem = getattr(record, "semantics", None)
+            if sem is None:
+                continue
+            src = getattr(record, "source_extraction", None)
+            location = getattr(src, "source_location", None) or {}
+            section_id = str(location.get("section_id") or "")
+            sem_evidence_ids = [
+                str(v) for v in (getattr(sem, "source_evidence_ids", []) or []) if v
+            ]
+
+            for ds in getattr(sem, "defined_symbols", []) or []:
+                raw = str(getattr(ds, "symbol", "") or "")
+                if not raw:
+                    continue
+                acc = self._accumulator(accumulators, raw, alias_map)
+                acc.add_variant(raw)
+                if section_id:
+                    acc.section_ids.add(section_id)
+                status = str(getattr(ds, "definition_status", "") or "")
+                if status in ("defined", "redefined"):
+                    acc.add_defining(eq_id)
+                    evidence = getattr(ds, "evidence_text", None)
+                    if evidence and evidence not in acc.evidence_texts:
+                        acc.evidence_texts.append(str(evidence))
+                    for ev_id in sem_evidence_ids:
+                        if ev_id not in acc.evidence_ids:
+                            acc.evidence_ids.append(ev_id)
+                    if status == "redefined":
+                        acc.upstream_redefined = True
+                else:
+                    acc.add_used(eq_id)
+
+            for raw in getattr(sem, "used_symbols", []) or []:
+                raw = str(raw or "")
+                if not raw:
+                    continue
+                acc = self._accumulator(accumulators, raw, alias_map)
+                acc.add_variant(raw)
+                acc.add_used(eq_id)
+                if section_id:
+                    acc.section_ids.add(section_id)
+
+        symbol_records, symbol_id_by_key = self._build_records(
+            document_id, accumulators, cartridge
+        )
+
+        if annotate_equations:
+            self._annotate_equations(records, alias_map, symbol_id_by_key)
+
+        return SymbolRegistryResult(
+            document_id=document_id,
+            registry_version=SYMBOL_REGISTRY_VERSION,
+            cartridge_id=cartridge.cartridge_id if cartridge else cartridge_id,
+            records=symbol_records,
+            validation_issues=[],
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
+        if not cartridge_id:
+            return None
+        try:
+            return self._cartridge_loader.load(cartridge_id)
+        except FileNotFoundError:
+            logger.warning(
+                "Cartridge '%s' not found; proceeding without cartridge", cartridge_id
+            )
+            return None
+
+    @staticmethod
+    def _alias_map(cartridge: CartridgeContext | None) -> dict[str, str]:
+        """normalized alias → cartridge canonical name."""
+        mapping: dict[str, str] = {}
+        if not cartridge or not cartridge.aliases:
+            return mapping
+        for canonical, aliases in cartridge.aliases.items():
+            canonical_key = normalize_symbol(canonical)
+            if canonical_key:
+                mapping[canonical_key] = str(canonical)
+            for alias in aliases or []:
+                alias_key = normalize_symbol(alias)
+                if alias_key:
+                    mapping[alias_key] = str(canonical)
+        return mapping
+
+    @classmethod
+    def _canonical_key(cls, raw: str, alias_map: dict[str, str]) -> str:
+        normalized = normalize_symbol(raw)
+        canonical = alias_map.get(normalized)
+        if canonical:
+            return normalize_symbol(canonical)
+        return normalized
+
+    @classmethod
+    def _accumulator(
+        cls,
+        accumulators: dict[str, _SymbolAccumulator],
+        raw: str,
+        alias_map: dict[str, str],
+    ) -> _SymbolAccumulator:
+        normalized = normalize_symbol(raw)
+        cartridge_canonical = alias_map.get(normalized)
+        key = normalize_symbol(cartridge_canonical) if cartridge_canonical else normalized
+        acc = accumulators.get(key)
+        if acc is None:
+            acc = _SymbolAccumulator(cartridge_canonical or normalized)
+            accumulators[key] = acc
+        return acc
+
+    def _build_records(
+        self,
+        document_id: str,
+        accumulators: dict[str, _SymbolAccumulator],
+        cartridge: CartridgeContext | None,
+    ) -> tuple[list[SymbolRecord], dict[str, str]]:
+        records: list[SymbolRecord] = []
+        symbol_id_by_key: dict[str, str] = {}
+        used_ids: set[str] = set()
+        doc_slug = _slug(document_id)
+
+        for key in sorted(accumulators):
+            acc = accumulators[key]
+            symbol_id = f"sym_{doc_slug}_{_slug(acc.canonical)}"
+            suffix = 2
+            while symbol_id in used_ids:
+                symbol_id = f"sym_{doc_slug}_{_slug(acc.canonical)}_{suffix}"
+                suffix += 1
+            used_ids.add(symbol_id)
+            symbol_id_by_key[key] = symbol_id
+
+            review_reasons: list[str] = []
+            if len(acc.defining_equation_ids) > 1 or acc.upstream_redefined:
+                definition_status = "redefined"
+                review_reasons.append("symbol_redefinition")
+            elif acc.defining_equation_ids:
+                definition_status = "defined"
+            elif acc.used_in_equation_ids:
+                definition_status = "used"
+                review_reasons.append("definition_missing")
+            else:
+                definition_status = "unknown"
+
+            if acc.defining_equation_ids and acc.evidence_texts:
+                confidence = 0.9
+                reason = "defined with source evidence text"
+            elif acc.defining_equation_ids:
+                confidence = 0.7
+                reason = "defined without quoted evidence text"
+            else:
+                confidence = 0.4
+                reason = "used but never defined in the document"
+
+            records.append(SymbolRecord(
+                symbol_id=symbol_id,
+                document_id=document_id,
+                canonical_symbol=acc.canonical,
+                notation_variants=list(acc.variants),
+                kind=self._classify_kind(acc, cartridge),
+                unit=None,
+                domain_constraints=[],
+                scope=self._scope(acc),
+                defining_equation_ids=list(acc.defining_equation_ids),
+                used_in_equation_ids=list(acc.used_in_equation_ids),
+                source_evidence_ids=list(acc.evidence_ids),
+                definition_status=definition_status,
+                definition_evidence_texts=list(acc.evidence_texts),
+                review_reasons=review_reasons,
+                maturity_source="deterministic",
+                confidence=confidence,
+                reason=reason,
+            ))
+        return records, symbol_id_by_key
+
+    @staticmethod
+    def _scope(acc: _SymbolAccumulator) -> str:
+        equation_ids = set(acc.defining_equation_ids) | set(acc.used_in_equation_ids)
+        if len(equation_ids) <= 1:
+            return "equation_local"
+        if len(acc.section_ids) > 1:
+            return "document"
+        return "section"
+
+    @staticmethod
+    def _classify_kind(
+        acc: _SymbolAccumulator,
+        cartridge: CartridgeContext | None,
+    ) -> str:
+        if not cartridge or not cartridge.notation_patterns:
+            return "unknown"
+        for entry in cartridge.notation_patterns:
+            if not isinstance(entry, dict):
+                continue
+            pattern = str(entry.get("pattern") or "")
+            if not pattern:
+                continue
+            try:
+                matched = any(
+                    re.fullmatch(pattern, variant)
+                    for variant in [acc.canonical] + acc.variants
+                )
+            except re.error:
+                continue
+            if not matched:
+                continue
+            concept_type = str(entry.get("concept_type") or "").lower()
+            for kind in ("parameter", "observable", "operator", "constant", "variable"):
+                if kind in concept_type:
+                    return kind
+            return "unknown"
+        return "unknown"
+
+    @classmethod
+    def _annotate_equations(
+        cls,
+        records: list,
+        alias_map: dict[str, str],
+        symbol_id_by_key: dict[str, str],
+    ) -> None:
+        """Set DefinedSymbol.symbol_id in place so equations reference the registry."""
+        for record in records:
+            sem = getattr(record, "semantics", None)
+            if sem is None:
+                continue
+            for ds in getattr(sem, "defined_symbols", []) or []:
+                raw = str(getattr(ds, "symbol", "") or "")
+                if not raw or not hasattr(ds, "symbol_id"):
+                    continue
+                key = cls._canonical_key(raw, alias_map)
+                symbol_id = symbol_id_by_key.get(key)
+                if symbol_id:
+                    ds.symbol_id = symbol_id

--- a/src/episteme_graph/agents/symbol_registry/cartridge_loader.py
+++ b/src/episteme_graph/agents/symbol_registry/cartridge_loader.py
@@ -1,0 +1,59 @@
+"""Load cartridge context for SymbolRegistryBuilder (issue #355)."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+
+from episteme_graph.agents.cartridge_paths import resolve_cartridge_base_dir
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_CARTRIDGE_BASE = os.path.abspath(
+    os.path.join(_HERE, "..", "..", "..", "..", "backend", "cartridges")
+)
+
+
+@dataclass
+class CartridgeContext:
+    cartridge_id: str
+    ontology: dict
+    validation_rules: dict
+    aliases: dict | None = None
+    notation_patterns: list | None = None
+    normalization_rules: list | None = None
+    extraction_hints: list | None = None
+
+
+class CartridgeLoader:
+    def __init__(self, cartridge_base_dir: str | None = None) -> None:
+        self._base_dir = cartridge_base_dir or resolve_cartridge_base_dir(_DEFAULT_CARTRIDGE_BASE)
+
+    def load(self, cartridge_id: str) -> CartridgeContext:
+        cartridge_dir = os.path.join(self._base_dir, cartridge_id)
+        if not os.path.isdir(cartridge_dir):
+            raise FileNotFoundError(
+                f"Cartridge '{cartridge_id}' not found at {cartridge_dir}"
+            )
+        ontology = self._load_json(cartridge_dir, "ontology.json")
+        validation_rules = self._load_json(cartridge_dir, "validation_rules.json")
+        aliases = (
+            {a["canonical"]: a["aliases"] for a in ontology.get("aliases", [])}
+            if ontology
+            else None
+        )
+        return CartridgeContext(
+            cartridge_id=cartridge_id,
+            ontology=ontology,
+            validation_rules=validation_rules,
+            aliases=aliases,
+            notation_patterns=ontology.get("notation_patterns") if ontology else None,
+            normalization_rules=ontology.get("normalization_rules") if ontology else None,
+            extraction_hints=ontology.get("extraction_hints") if ontology else None,
+        )
+
+    def _load_json(self, directory: str, filename: str) -> dict:
+        path = os.path.join(directory, filename)
+        if not os.path.exists(path):
+            return {}
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)

--- a/src/episteme_graph/agents/symbol_registry/examples/symbol_registry_example.json
+++ b/src/episteme_graph/agents/symbol_registry/examples/symbol_registry_example.json
@@ -1,0 +1,46 @@
+{
+  "document_id": "doc_example",
+  "registry_version": "v1",
+  "cartridge_id": "particle_physics",
+  "records": [
+    {
+      "symbol_id": "sym_doc_example_β",
+      "document_id": "doc_example",
+      "canonical_symbol": "β",
+      "notation_variants": ["β", "\\beta"],
+      "kind": "parameter",
+      "unit": null,
+      "domain_constraints": [],
+      "scope": "document",
+      "defining_equation_ids": ["eq_2_1"],
+      "used_in_equation_ids": ["eq_2_3", "eq_3_1"],
+      "source_evidence_ids": ["ev_0001"],
+      "definition_status": "defined",
+      "definition_evidence_texts": ["where β is the linear bias parameter"],
+      "review_reasons": [],
+      "maturity_source": "deterministic",
+      "confidence": 0.9,
+      "reason": "defined with source evidence text"
+    },
+    {
+      "symbol_id": "sym_doc_example_σ_8",
+      "document_id": "doc_example",
+      "canonical_symbol": "σ_8",
+      "notation_variants": ["σ_8", "\\sigma_8"],
+      "kind": "unknown",
+      "unit": null,
+      "domain_constraints": [],
+      "scope": "section",
+      "defining_equation_ids": [],
+      "used_in_equation_ids": ["eq_2_3", "eq_2_4"],
+      "source_evidence_ids": [],
+      "definition_status": "used",
+      "definition_evidence_texts": [],
+      "review_reasons": ["definition_missing"],
+      "maturity_source": "deterministic",
+      "confidence": 0.4,
+      "reason": "used but never defined in the document"
+    }
+  ],
+  "validation_issues": []
+}

--- a/src/episteme_graph/agents/symbol_registry/schema.py
+++ b/src/episteme_graph/agents/symbol_registry/schema.py
@@ -1,0 +1,103 @@
+"""SymbolRegistryBuilder data models (issue #355).
+
+A SymbolRecord makes a math symbol reusable outside its source paper: the
+notation variants it appears under, where it is defined and used, its scope,
+and (when known) its kind / unit / domain constraints. Unknown values are kept
+as ``unknown`` / ``None`` / empty — never dropped.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+SYMBOL_REGISTRY_VERSION = "v1"
+
+SYMBOL_KINDS = [
+    "parameter",
+    "variable",
+    "observable",
+    "operator",
+    "constant",
+    "unknown",
+]
+
+SYMBOL_SCOPES = [
+    "equation_local",
+    "section",
+    "document",
+]
+
+DEFINITION_STATUSES = [
+    "defined",
+    "used",
+    "redefined",
+    "unknown",
+]
+
+REVIEW_REASONS = [
+    "symbol_redefinition",
+    "definition_missing",
+]
+
+# Provisional enrichment markers (LLM never finalises maturity).
+MATURITY_SOURCES = ["deterministic", "llm_proposed", "teacher_approved"]
+
+
+@dataclass
+class SymbolRecord:
+    symbol_id: str
+    document_id: str
+    canonical_symbol: str
+    notation_variants: list[str] = field(default_factory=list)
+    kind: str = "unknown"
+    # Unit / constraints stay None / empty when the source does not state them
+    # (issue #355: keep unknown, never invent). LLM enrichment, when added,
+    # must mark maturity_source="llm_proposed".
+    unit: str | None = None
+    domain_constraints: list[str] = field(default_factory=list)
+    scope: str = "equation_local"
+    defining_equation_ids: list[str] = field(default_factory=list)
+    used_in_equation_ids: list[str] = field(default_factory=list)
+    source_evidence_ids: list[str] = field(default_factory=list)
+    definition_status: str = "unknown"
+    # Raw definition quotes carried from DefinedSymbol.evidence_text.
+    definition_evidence_texts: list[str] = field(default_factory=list)
+    review_reasons: list[str] = field(default_factory=list)
+    maturity_source: str = "deterministic"
+    confidence: float = 0.0
+    reason: str = ""
+
+
+@dataclass
+class ValidationIssue:
+    rule_id: str
+    severity: str
+    message: str
+    field: str | None = None
+
+
+@dataclass
+class SymbolRegistryResult:
+    document_id: str
+    registry_version: str
+    cartridge_id: str | None
+    records: list[SymbolRecord]
+    validation_issues: list[ValidationIssue] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SymbolRegistryResult":
+        records = [SymbolRecord(**r) for r in d.get("records", [])]
+        issues = [ValidationIssue(**i) for i in d.get("validation_issues", [])]
+        return cls(
+            document_id=d["document_id"],
+            registry_version=d.get("registry_version", SYMBOL_REGISTRY_VERSION),
+            cartridge_id=d.get("cartridge_id"),
+            records=records,
+            validation_issues=issues,
+        )

--- a/src/episteme_graph/agents/symbol_registry/validator.py
+++ b/src/episteme_graph/agents/symbol_registry/validator.py
@@ -1,0 +1,81 @@
+"""SymbolRegistryResult validation (issue #355)."""
+from __future__ import annotations
+
+from .schema import (
+    DEFINITION_STATUSES,
+    MATURITY_SOURCES,
+    SYMBOL_KINDS,
+    SYMBOL_SCOPES,
+    SymbolRegistryResult,
+    ValidationIssue,
+)
+
+
+class SymbolRegistryValidator:
+    def validate(self, result: SymbolRegistryResult) -> list[ValidationIssue]:
+        issues: list[ValidationIssue] = []
+        seen_ids: set[str] = set()
+        for record in result.records or []:
+            field = record.symbol_id or record.canonical_symbol
+            if not record.symbol_id:
+                issues.append(ValidationIssue(
+                    "symbol_id_missing", "error",
+                    f"symbol record {record.canonical_symbol!r} has no symbol_id",
+                    field,
+                ))
+            elif record.symbol_id in seen_ids:
+                issues.append(ValidationIssue(
+                    "symbol_id_duplicate", "error",
+                    f"duplicate symbol_id {record.symbol_id!r}",
+                    field,
+                ))
+            else:
+                seen_ids.add(record.symbol_id)
+
+            if not record.canonical_symbol:
+                issues.append(ValidationIssue(
+                    "canonical_symbol_empty", "error",
+                    f"symbol {record.symbol_id!r} has empty canonical_symbol",
+                    field,
+                ))
+            if record.kind not in SYMBOL_KINDS:
+                issues.append(ValidationIssue(
+                    "invalid_symbol_kind", "error",
+                    f"symbol {field!r} has invalid kind {record.kind!r}",
+                    field,
+                ))
+            if record.scope not in SYMBOL_SCOPES:
+                issues.append(ValidationIssue(
+                    "invalid_symbol_scope", "error",
+                    f"symbol {field!r} has invalid scope {record.scope!r}",
+                    field,
+                ))
+            if record.definition_status not in DEFINITION_STATUSES:
+                issues.append(ValidationIssue(
+                    "invalid_definition_status", "error",
+                    f"symbol {field!r} has invalid definition_status "
+                    f"{record.definition_status!r}",
+                    field,
+                ))
+            if record.maturity_source not in MATURITY_SOURCES:
+                issues.append(ValidationIssue(
+                    "invalid_maturity_source", "error",
+                    f"symbol {field!r} has invalid maturity_source "
+                    f"{record.maturity_source!r}",
+                    field,
+                ))
+            if record.definition_status == "redefined" and \
+                    "symbol_redefinition" not in (record.review_reasons or []):
+                issues.append(ValidationIssue(
+                    "redefinition_without_review_reason", "warning",
+                    f"redefined symbol {field!r} lacks symbol_redefinition "
+                    "review reason",
+                    field,
+                ))
+            if not (0.0 <= float(record.confidence) <= 1.0):
+                issues.append(ValidationIssue(
+                    "confidence_out_of_bounds", "error",
+                    f"symbol {field!r} confidence {record.confidence} out of [0,1]",
+                    field,
+                ))
+        return issues

--- a/src/episteme_graph/agents/thesis_reconstruction/agent.py
+++ b/src/episteme_graph/agents/thesis_reconstruction/agent.py
@@ -6,6 +6,7 @@ import logging
 from episteme_graph.agents.claim_qualification.schema import ClaimQualificationResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.paper_skeleton.schema import PaperSkeletonResult
+from episteme_graph.agents.claim_selection import selection_issue_payloads
 from episteme_graph.agents.id_canonicalization import (
     canonicalize_claim_refs,
     claim_aliases_from_accepted_claims,
@@ -16,7 +17,7 @@ from .input_builder import ThesisReconstructionInputBuilder
 from .llm_client import ThesisReconstructionLLMClient
 from .prompt import ThesisReconstructionPromptFactory
 from .repair import ThesisReconstructionRepairer, _parse_raw
-from .schema import CartridgeContext, ThesisReconstructionResult
+from .schema import CartridgeContext, ThesisReconstructionResult, ValidationIssue
 from .validator import ThesisReconstructionValidator
 
 logger = logging.getLogger(__name__)
@@ -58,9 +59,11 @@ class ThesisReconstructionAgent:
             raw_output = self._llm_client.generate(messages)
         except Exception as exc:
             logger.error("Thesis reconstruction failed: %s", exc)
-            return ThesisReconstructionResult.make_fallback(
+            result = ThesisReconstructionResult.make_fallback(
                 skeleton.document_id, cartridge_id, str(exc)
             )
+            self._record_claim_exclusions(result, llm_input)
+            return result
 
         raw_output = canonicalize_claim_refs(
             raw_output,
@@ -81,7 +84,22 @@ class ThesisReconstructionAgent:
             )
         else:
             result.validation_issues = issues
+        self._record_claim_exclusions(result, llm_input)
         return result
+
+    @staticmethod
+    def _record_claim_exclusions(result, llm_input) -> None:
+        """Persist limit-dropped claims and surface them as warnings (#356)."""
+        excluded = list(getattr(llm_input, "excluded_from_pipeline_input", []) or [])
+        if not excluded:
+            return
+        result.excluded_from_pipeline_input = excluded
+        result.validation_issues = list(result.validation_issues or []) + [
+            ValidationIssue(**payload)
+            for payload in selection_issue_payloads(
+                excluded, stage="thesis_reconstruction"
+            )
+        ]
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
         if not cartridge_id:

--- a/src/episteme_graph/agents/thesis_reconstruction/input_builder.py
+++ b/src/episteme_graph/agents/thesis_reconstruction/input_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from episteme_graph.agents.claim_qualification.schema import ClaimQualificationResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.paper_skeleton.schema import PaperSkeletonResult
+from episteme_graph.agents.claim_selection import select_claim_rows
 from episteme_graph.agents.id_canonicalization import (
     canonical_claim_id_for_span,
     legacy_claim_id_for_span,
@@ -27,11 +28,12 @@ class ThesisReconstructionInputBuilder:
         claim_objects=None,
     ) -> ThesisLLMInput:
         cfg = config or {}
-        accepted_claims = self._accepted_claims(
+        claim_selection = self._accepted_claims(
             qualified_claims,
             int(cfg.get("max_claims", _MAX_CLAIMS)),
             claim_objects=claim_objects,
         )
+        accepted_claims = claim_selection.selected
         major_equations = self._major_equations(
             equations, int(cfg.get("max_equations", _MAX_EQUATIONS))
         )
@@ -52,6 +54,7 @@ class ThesisReconstructionInputBuilder:
             major_equations=major_equations,
             excluded_regions=excluded_regions,
             normalized_terms=self._build_normalized_terms(cartridge) if cartridge else None,
+            excluded_from_pipeline_input=claim_selection.excluded,
         )
 
     @staticmethod
@@ -81,9 +84,9 @@ class ThesisReconstructionInputBuilder:
         result: ClaimQualificationResult,
         limit: int,
         claim_objects=None,
-    ) -> list[dict]:
+    ):
         claims = []
-        for record in result.qualified_spans[:limit]:
+        for record in result.qualified_spans:
             claims.append({
                 "claim_id": canonical_claim_id_for_span(record, claim_objects),
                 "legacy_claim_id": legacy_claim_id_for_span(record),
@@ -98,7 +101,7 @@ class ThesisReconstructionInputBuilder:
                 "reason": record.reason,
                 "confidence": record.confidence,
             })
-        return claims
+        return select_claim_rows(claims, limit, stage="thesis_reconstruction")
 
     @staticmethod
     def _major_equations(

--- a/src/episteme_graph/agents/thesis_reconstruction/input_builder.py
+++ b/src/episteme_graph/agents/thesis_reconstruction/input_builder.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from episteme_graph.agents.claim_qualification.schema import ClaimQualificationResult
 from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
 from episteme_graph.agents.paper_skeleton.schema import PaperSkeletonResult
-from episteme_graph.agents.claim_selection import select_claim_rows
+from episteme_graph.agents.claim_selection import (
+    headline_text_for_selection,
+    select_claim_rows,
+)
 from episteme_graph.agents.id_canonicalization import (
     canonical_claim_id_for_span,
     legacy_claim_id_for_span,
@@ -32,6 +35,7 @@ class ThesisReconstructionInputBuilder:
             qualified_claims,
             int(cfg.get("max_claims", _MAX_CLAIMS)),
             claim_objects=claim_objects,
+            skeleton=skeleton,
         )
         accepted_claims = claim_selection.selected
         major_equations = self._major_equations(
@@ -84,15 +88,24 @@ class ThesisReconstructionInputBuilder:
         result: ClaimQualificationResult,
         limit: int,
         claim_objects=None,
+        skeleton=None,
     ):
+        claim_index = {
+            str(getattr(c, "claim_id", "") or ""): c
+            for c in getattr(claim_objects, "claims", []) or []
+        }
         claims = []
         for record in result.qualified_spans:
+            claim_id = canonical_claim_id_for_span(record, claim_objects)
+            claim_obj = claim_index.get(claim_id)
             claims.append({
-                "claim_id": canonical_claim_id_for_span(record, claim_objects),
+                "claim_id": claim_id,
                 "legacy_claim_id": legacy_claim_id_for_span(record),
                 "span_id": record.span_id,
                 "block_id": record.block_id,
                 "section_id": record.section_id,
+                # Human-readable section title (issue #359).
+                "section_title": getattr(claim_obj, "section_title", None),
                 "text": record.text,
                 "role_labels": record.role_labels,
                 "claim_tier": record.qualification.get("claim_tier"),
@@ -101,7 +114,12 @@ class ThesisReconstructionInputBuilder:
                 "reason": record.reason,
                 "confidence": record.confidence,
             })
-        return select_claim_rows(claims, limit, stage="thesis_reconstruction")
+        return select_claim_rows(
+            claims,
+            limit,
+            stage="thesis_reconstruction",
+            headline_text=headline_text_for_selection(skeleton=skeleton),
+        )
 
     @staticmethod
     def _major_equations(

--- a/src/episteme_graph/agents/thesis_reconstruction/schema.py
+++ b/src/episteme_graph/agents/thesis_reconstruction/schema.py
@@ -61,6 +61,8 @@ class ThesisLLMInput:
     major_equations: list[dict]
     excluded_regions: list[dict]
     normalized_terms: list[dict] | None = None
+    # Claims dropped by the shared input limit (issue #356).
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -104,6 +106,10 @@ class ThesisReconstructionResult:
     review_notes: list[str]
     confidence: float
     validation_issues: list[ValidationIssue] = field(default_factory=list)
+    # Claims dropped from the LLM input by the shared selection policy
+    # (issue #356): {claim_id, span_id, claim_tier, excluded_at_stage, reason,
+    # referenced_by_thesis}. Recorded so the drop is explicit, never silent.
+    excluded_from_pipeline_input: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -126,6 +132,7 @@ class ThesisReconstructionResult:
             review_notes=d.get("review_notes", []),
             confidence=float(d.get("confidence", 0.0)),
             validation_issues=issues,
+            excluded_from_pipeline_input=d.get("excluded_from_pipeline_input", []),
         )
 
     @classmethod

--- a/src/tests/agents/claim_object_builder/test_vocabulary_unification.py
+++ b/src/tests/agents/claim_object_builder/test_vocabulary_unification.py
@@ -1,0 +1,201 @@
+"""Tests for vocabulary unification + section_title (issue #359)."""
+from __future__ import annotations
+
+from episteme_graph.agents.claim_object_builder import ClaimObjectBuilder
+from episteme_graph.agents.claim_object_builder.schema import (
+    CANONICAL_ATOMICITY_VALUES,
+    ClaimObjectBuildResult,
+    derive_support_status,
+    normalize_atomicity,
+)
+from episteme_graph.agents.claim_qualification.schema import QualifiedSpanRecord
+from episteme_graph.agents.component_assembly.input_builder import (
+    _attach_claim_object_metadata as attach_component_metadata,
+)
+from episteme_graph.agents.document_structure.schema import (
+    DocumentMetadata,
+    DocumentStructureResult,
+    Section,
+    TypedBlock,
+)
+from episteme_graph.agents.dsl_linking.input_builder import (
+    _attach_claim_object_metadata as attach_dsl_metadata,
+)
+from episteme_graph.agents.evidence_registry import EvidenceRegistryBuilder
+
+
+# ---------------------------------------------------------------------------
+# atomicity normalization
+# ---------------------------------------------------------------------------
+
+def test_normalize_atomicity_maps_legacy_aliases():
+    assert normalize_atomicity("compound") == "composite"
+    assert normalize_atomicity("non_atomic") == "split_required"
+    assert normalize_atomicity("split_pending") == "split_required"
+
+
+def test_normalize_atomicity_keeps_canonical_values():
+    for value in CANONICAL_ATOMICITY_VALUES:
+        assert normalize_atomicity(value) == value
+
+
+def test_normalize_atomicity_defaults_unknown_to_atomic():
+    assert normalize_atomicity("") == "atomic"
+    assert normalize_atomicity(None) == "atomic"
+    assert normalize_atomicity("banana") == "atomic"
+
+
+def test_from_dict_converts_legacy_atomicity():
+    payload = {
+        "document_id": "doc",
+        "cartridge_id": None,
+        "claims": [
+            {"claim_id": "c1", "document_id": "doc", "claim_type": "result",
+             "text": "t", "source_evidence_ids": [], "source_span_ids": [],
+             "concepts": [], "atomicity": "split_pending", "is_atomic": False},
+            {"claim_id": "c2", "document_id": "doc", "claim_type": "result",
+             "text": "t", "source_evidence_ids": [], "source_span_ids": [],
+             "concepts": [], "atomicity": "compound", "is_atomic": False},
+        ],
+        "validation_issues": [],
+    }
+    result = ClaimObjectBuildResult.from_dict(payload)
+    assert result.claims[0].atomicity == "split_required"
+    assert result.claims[1].atomicity == "composite"
+    # 出力 JSON には legacy 語彙が現れない
+    for claim in result.to_dict()["claims"]:
+        assert claim["atomicity"] in CANONICAL_ATOMICITY_VALUES
+
+
+# ---------------------------------------------------------------------------
+# evidence_adequacy → support_status mapping
+# ---------------------------------------------------------------------------
+
+def test_derive_support_status_mapping():
+    assert derive_support_status(True, "sufficient") == "source_backed"
+    assert derive_support_status(True, "weak") == "partially_source_backed"
+    assert derive_support_status(True, "broken") == "review_required"
+    assert derive_support_status(True, None) == "source_backed"
+    assert derive_support_status(False, "sufficient") == "inferred"
+
+
+# ---------------------------------------------------------------------------
+# builder integration: section_title + support_status
+# ---------------------------------------------------------------------------
+
+def _span(span_id, block_id, text, *, adequacy="sufficient"):
+    return QualifiedSpanRecord(
+        span_id=span_id,
+        block_id=block_id,
+        section_id="doc_test:sec_3_1",
+        text=text,
+        role_labels=["approximation"],
+        qualification={
+            "status": "accepted",
+            "claim_type_candidate": "approximation",
+            "claim_tier": "paper_core",
+            "granularity": "good",
+            "evidence_adequacy": adequacy,
+        },
+        edit_suggestions={"normalized_text": text},
+        reason="auto-derived",
+        confidence=0.82,
+    )
+
+
+def _structure(block_id, text):
+    return DocumentStructureResult(
+        document_id="doc_test",
+        source_file="/tmp/x.pdf",
+        cartridge_id=None,
+        metadata=DocumentMetadata(pages=10),
+        sections=[Section("doc_test:sec_3_1", "Methods", 1, 4, 5)],
+        blocks=[TypedBlock(
+            block_id=block_id, page=4, order=65, text=text,
+            block_type="body_paragraph", section_id="doc_test:sec_3_1",
+        )],
+    )
+
+
+def _build(spans, structure):
+    ev_builder = EvidenceRegistryBuilder(structure)
+    for block in structure.blocks:
+        ev_builder.add_for_block(block.block_id)
+    registry = ev_builder.build("doc_test")
+    builder = ClaimObjectBuilder(
+        evidence_registry=registry, document_structure=structure,
+    )
+    return builder.build("doc_test", spans)
+
+
+def test_claim_carries_section_title():
+    structure = _structure("blk_1", "Take the zero-recoil limit in the analysis.")
+    result = _build([_span("s1", "blk_1", "Take the zero-recoil limit.")], structure)
+    assert result.claims[0].section_id == "doc_test:sec_3_1"
+    assert result.claims[0].section_title == "Methods"
+    # JSON round trip keeps the title
+    reloaded = ClaimObjectBuildResult.from_dict(result.to_dict())
+    assert reloaded.claims[0].section_title == "Methods"
+
+
+def test_builder_without_structure_leaves_title_none():
+    structure = _structure("blk_1", "text")
+    ev_builder = EvidenceRegistryBuilder(structure)
+    ev_builder.add_for_block("blk_1")
+    registry = ev_builder.build("doc_test")
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    result = builder.build("doc_test", [_span("s1", "blk_1", "Take the limit.")])
+    assert result.claims[0].section_title is None
+
+
+def test_broken_evidence_adequacy_caps_support_status():
+    structure = _structure("blk_1", "text for the claim")
+    result = _build(
+        [_span("s1", "blk_1", "Take the limit.", adequacy="broken")], structure,
+    )
+    assert result.claims[0].support_status == "review_required"
+
+
+def test_weak_evidence_adequacy_is_partially_source_backed():
+    structure = _structure("blk_1", "text for the claim")
+    result = _build(
+        [_span("s1", "blk_1", "Take the limit.", adequacy="weak")], structure,
+    )
+    assert result.claims[0].support_status == "partially_source_backed"
+
+
+def test_sufficient_evidence_stays_source_backed():
+    structure = _structure("blk_1", "text for the claim")
+    result = _build([_span("s1", "blk_1", "Take the limit.")], structure)
+    assert result.claims[0].support_status == "source_backed"
+
+
+# ---------------------------------------------------------------------------
+# section_title propagation into downstream input rows
+# ---------------------------------------------------------------------------
+
+class _Claim:
+    claim_id = "c1"
+    text = "claim text"
+    claim_type = "result"
+    atomicity = "atomic"
+    is_atomic = True
+    split_suggestions: list = []
+    source_evidence_ids = ["ev_1"]
+    qualification_reason = None
+    confidence = 0.8
+    section_title = "Methods"
+    concepts: list = []
+    concept_assignment_status = "source_backed"
+
+
+def test_section_title_propagates_to_dsl_rows():
+    row: dict = {"text": "", "claim_type_candidate": "unknown"}
+    attach_dsl_metadata(row, _Claim())
+    assert row["section_title"] == "Methods"
+
+
+def test_section_title_propagates_to_component_rows():
+    row: dict = {"text": "", "claim_type_candidate": "unknown"}
+    attach_component_metadata(row, _Claim())
+    assert row["section_title"] == "Methods"

--- a/src/tests/agents/claim_object_builder/test_vocabulary_unification.py
+++ b/src/tests/agents/claim_object_builder/test_vocabulary_unification.py
@@ -199,3 +199,24 @@ def test_section_title_propagates_to_component_rows():
     row: dict = {"text": "", "claim_type_candidate": "unknown"}
     attach_component_metadata(row, _Claim())
     assert row["section_title"] == "Methods"
+
+
+def test_section_title_propagates_to_thesis_rows():
+    """thesis_reconstruction の入力行にも section_title が付く（#359 レビュー対応）。"""
+    from episteme_graph.agents.thesis_reconstruction.input_builder import (
+        ThesisReconstructionInputBuilder,
+    )
+
+    class _ClaimObj:
+        claim_id = "claim:blk_1:s1"
+        section_title = "Methods"
+
+    class _ClaimObjects:
+        claims = [_ClaimObj()]
+
+    selection = ThesisReconstructionInputBuilder._accepted_claims(
+        type("_Q", (), {"qualified_spans": [_span("s1", "blk_1", "Take the limit.")]})(),
+        10,
+        claim_objects=_ClaimObjects(),
+    )
+    assert selection.selected[0]["section_title"] == "Methods"

--- a/src/tests/agents/claim_qualification/test_context_lint.py
+++ b/src/tests/agents/claim_qualification/test_context_lint.py
@@ -1,0 +1,329 @@
+"""Tests for the atomic-claim context-dependency lint + retry (issue #357)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from episteme_graph.agents.claim_qualification.agent import ClaimQualificationAgent
+from episteme_graph.agents.claim_qualification.context_lint import (
+    apply_context_lint,
+    extract_context_refs,
+    find_unresolved_reference,
+    unresolved_fragments,
+)
+from episteme_graph.agents.claim_qualification.repair import _parse_record
+from episteme_graph.agents.claim_qualification.schema import (
+    ClaimQualificationResult,
+    QualificationLLMInput,
+    QualifiedSpanRecord,
+)
+from episteme_graph.agents.claim_qualification.validator import (
+    ClaimQualificationValidator,
+)
+from episteme_graph.agents.document_structure.schema import (
+    DocumentMetadata,
+    DocumentStructureResult,
+    Section,
+    TypedBlock,
+)
+from episteme_graph.agents.paper_skeleton.schema import (
+    LogicalBlock,
+    PaperSkeletonResult,
+    SKELETON_VERSION,
+)
+from episteme_graph.agents.rhetorical_role.schema import (
+    BlockRoleAnnotation,
+    RhetoricalRoleResult,
+    SpanAnnotation,
+)
+
+
+# ---------------------------------------------------------------------------
+# find_unresolved_reference
+# ---------------------------------------------------------------------------
+
+def test_detects_demonstrative_plus_discourse_noun():
+    assert find_unresolved_reference("This result shows the rate vanishes.")
+    assert find_unresolved_reference("These findings imply a lower bound.")
+
+
+def test_detects_bare_demonstrative_subject():
+    assert find_unresolved_reference("This shows the bias is small.")
+    assert find_unresolved_reference("Those were computed at leading order.")
+
+
+def test_detects_bare_pronoun_subject():
+    assert find_unresolved_reference("It implies the sum rule holds.")
+    assert find_unresolved_reference("They are suppressed by the mass ratio.")
+
+
+def test_detects_former_latter_and_as_shown_above():
+    assert find_unresolved_reference("The latter dominates the error budget.")
+    assert find_unresolved_reference("As shown above, the integral converges.")
+
+
+def test_detects_japanese_leading_anaphora():
+    assert find_unresolved_reference("この結果はバイアスが小さいことを示す。")
+    assert find_unresolved_reference("上記の関係式は線形近似で成り立つ。")
+
+
+def test_self_contained_claims_are_not_flagged():
+    assert find_unresolved_reference(
+        "The bias parameter measures clustering strength."
+    ) is None
+    assert find_unresolved_reference(
+        "The sum rule relates the three decay ratios."
+    ) is None
+
+
+def test_paper_self_reference_is_allowed():
+    assert find_unresolved_reference("This paper shows the rate vanishes.") is None
+    assert find_unresolved_reference("This work derives a new bound.") is None
+    assert find_unresolved_reference("The present study confirms the relation.") is None
+
+
+def test_mid_sentence_demonstrative_is_not_flagged():
+    assert find_unresolved_reference(
+        "The fit shows that this bias parameter is small."
+    ) is None
+
+
+def test_demonstrative_with_concrete_noun_is_not_flagged():
+    # "This bias parameter…" names a concrete subject — not a discourse noun.
+    assert find_unresolved_reference(
+        "This bias parameter controls the clustering amplitude."
+    ) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_context_refs
+# ---------------------------------------------------------------------------
+
+def test_equation_refs_are_normalized_to_eq_ids():
+    refs = extract_context_refs("Combining Eq. (2.7) with Eq. (3.1) gives the bound.")
+    assert "eq_2_7" in refs
+    assert "eq_3_1" in refs
+
+
+def test_section_figure_table_refs_are_structured():
+    refs = extract_context_refs(
+        "The method of Section 3 is validated in Fig. 2 and Table 1."
+    )
+    assert "Section 3" in refs
+    assert "Fig 2" in refs
+    assert "Table 1" in refs
+
+
+def test_document_refs_do_not_demote_the_claim():
+    claims = [{
+        "text": "The bound from Eq. (2.7) excludes the scalar scenario.",
+        "normalized_text": "The bound from Eq. (2.7) excludes the scalar scenario.",
+        "atomicity": "atomic",
+        "status": "accepted",
+        "qualification_reason": "",
+    }]
+    fragments = apply_context_lint(claims)
+    assert fragments == []
+    assert claims[0]["status"] == "accepted"
+    assert "eq_2_7" in claims[0]["context_refs"]
+
+
+# ---------------------------------------------------------------------------
+# apply_context_lint
+# ---------------------------------------------------------------------------
+
+def test_accepted_atomic_claim_with_anaphora_is_demoted():
+    claims = [{
+        "text": "This result shows the rate vanishes.",
+        "normalized_text": "This result shows the rate vanishes.",
+        "atomicity": "atomic",
+        "status": "accepted",
+        "qualification_reason": "",
+    }]
+    fragments = apply_context_lint(claims)
+    assert fragments
+    assert claims[0]["status"] == "review_required"
+    assert "unresolved_reference" in claims[0]["qualification_reason"]
+
+
+def test_non_atomic_claims_are_not_demoted_again():
+    claims = [{
+        "text": "This result shows X and also Y.",
+        "normalized_text": "This result shows X and also Y.",
+        "atomicity": "non_atomic",
+        "status": "review_required",
+        "qualification_reason": "multiple propositions",
+    }]
+    fragments = apply_context_lint(claims)
+    assert fragments == []
+    assert claims[0]["qualification_reason"] == "multiple propositions"
+
+
+def test_parse_record_applies_lint():
+    llm_input = QualificationLLMInput(
+        document_id="doc", cartridge_id=None, span_id="s1", block_id="b1",
+        section_id="sec_1", section_title=None, backbone_block_type=None,
+        headline_claim=None, span_text="span", role_labels=["relation"],
+        is_claim_candidate=True, is_reject_candidate=False,
+        prev_span_text=None, next_span_text=None, source_block_text=None,
+    )
+    raw = {
+        "span_id": "s1", "block_id": "b1", "section_id": "sec_1",
+        "text": "span", "role_labels": ["relation"],
+        "qualification": {
+            "status": "accepted", "claim_tier": "paper_core",
+            "claim_type_candidate": "relation", "granularity": "too_broad",
+            "evidence_adequacy": "sufficient", "reviewability": "good",
+        },
+        "edit_suggestions": {"should_split": True},
+        "atomic_claims": [
+            {"text": "It implies the sum rule holds.", "atomicity": "atomic",
+             "status": "accepted", "source_span_id": "s1",
+             "evidence_quote": "implies the sum rule"},
+            {"text": "The decay width is suppressed.", "atomicity": "atomic",
+             "status": "accepted", "source_span_id": "s1",
+             "evidence_quote": "width is suppressed"},
+        ],
+        "reason": "r", "confidence": 0.9,
+    }
+    record = _parse_record(raw, llm_input)
+    statuses = [c["status"] for c in record.atomic_claims]
+    assert statuses == ["review_required", "accepted"]
+    assert unresolved_fragments(record.atomic_claims)
+
+
+# ---------------------------------------------------------------------------
+# validator safety net
+# ---------------------------------------------------------------------------
+
+def test_validator_warns_on_unresolved_reference_in_reloaded_artifact():
+    record = QualifiedSpanRecord(
+        span_id="s1", block_id="b1", section_id="sec_1",
+        text="span", role_labels=["relation"],
+        qualification={
+            "status": "accepted", "claim_tier": "paper_core",
+            "claim_type_candidate": "relation", "granularity": "good",
+            "evidence_adequacy": "sufficient", "reviewability": "good",
+        },
+        edit_suggestions={},
+        reason="r", confidence=0.9,
+        atomic_claims=[{
+            "text": "This result shows the rate vanishes.",
+            "atomicity": "atomic", "status": "accepted",
+            "source_span_id": "s1", "evidence_quote": "rate vanishes",
+        }],
+    )
+    result = ClaimQualificationResult(
+        "doc", None, [record], [], [], {"accepted": 1},
+    )
+    issues = ClaimQualificationValidator().validate(result)
+    assert any(i.rule_id == "atomic_claim_unresolved_reference" for i in issues)
+    assert all(
+        i.severity == "warning"
+        for i in issues if i.rule_id == "atomic_claim_unresolved_reference"
+    )
+
+
+# ---------------------------------------------------------------------------
+# agent retry (single shot)
+# ---------------------------------------------------------------------------
+
+def _structure():
+    block = TypedBlock("b1", 1, 0, "The sum rule implies the rate vanishes.", "body_paragraph")
+    block.section_id = "sec_1"
+    return DocumentStructureResult(
+        document_id="doc_test",
+        source_file="/tmp/test.pdf",
+        cartridge_id=None,
+        metadata=DocumentMetadata(title="Test", pages=1),
+        sections=[Section("sec_1", "Results", 1, 1, 1)],
+        blocks=[block],
+    )
+
+
+def _skeleton():
+    return PaperSkeletonResult(
+        document_id="doc_test",
+        skeleton_version=SKELETON_VERSION,
+        cartridge_id=None,
+        paper_goal={"text": "goal", "evidence_block_ids": ["b1"], "reason": "", "confidence": 0.8},
+        central_question={"text": "q", "evidence_block_ids": ["b1"], "reason": "", "confidence": 0.8},
+        headline_claim={"text": "h", "evidence_block_ids": ["b1"], "reason": "", "confidence": 0.8},
+        supporting_subclaims=[],
+        logical_blocks=[LogicalBlock("l1", "result", "Results", ["sec_1"], ["b1"], "s", "r", 0.8)],
+        excluded_regions=[],
+        review_notes=[],
+        confidence=0.8,
+    )
+
+
+def _roles():
+    span = SpanAnnotation(
+        span_id="s1", text="The sum rule implies the rate vanishes.",
+        char_start=0, char_end=39, role_labels=["relation"],
+        is_claim_candidate=True, is_reject_candidate=False,
+        confidence=0.9, reason="r",
+    )
+    return RhetoricalRoleResult(
+        document_id="doc_test", cartridge_id=None,
+        role_annotations=[BlockRoleAnnotation("b1", "sec_1", "result", [span])],
+        summary_stats={},
+    )
+
+
+def _llm_response(atomic_text):
+    return {
+        "span_id": "s1", "block_id": "b1", "section_id": "sec_1",
+        "text": "The sum rule implies the rate vanishes.",
+        "role_labels": ["relation"],
+        "qualification": {
+            "status": "accepted", "claim_tier": "paper_core",
+            "claim_type_candidate": "relation", "granularity": "too_broad",
+            "evidence_adequacy": "sufficient", "reviewability": "good",
+        },
+        "edit_suggestions": {"should_split": True},
+        "atomic_claims": [{
+            "text": atomic_text, "atomicity": "atomic", "status": "accepted",
+            "source_span_id": "s1", "evidence_quote": "the rate vanishes",
+        }],
+        "reason": "mocked", "confidence": 0.9,
+    }
+
+
+def test_agent_retries_once_and_accepts_resolved_rewrite():
+    agent = ClaimQualificationAgent()
+    responses = [
+        _llm_response("This result shows the rate vanishes."),  # unresolved
+        _llm_response("The decay rate vanishes in the heavy-quark limit."),  # fixed
+    ]
+    with patch.object(agent._llm_client, "generate", side_effect=responses) as mocked:
+        result = agent.run(_structure(), _skeleton(), _roles())
+    assert mocked.call_count == 2  # initial + one retry, no loop
+    claim = result.qualified_spans[0].atomic_claims[0]
+    assert claim["status"] == "accepted"
+    assert claim["text"].startswith("The decay rate")
+
+
+def test_agent_keeps_demotion_when_retry_still_unresolved():
+    agent = ClaimQualificationAgent()
+    responses = [
+        _llm_response("This result shows the rate vanishes."),
+        _llm_response("It implies the rate vanishes."),  # still unresolved
+    ]
+    with patch.object(agent._llm_client, "generate", side_effect=responses) as mocked:
+        result = agent.run(_structure(), _skeleton(), _roles())
+    assert mocked.call_count == 2  # exactly one retry, then stop
+    claim = result.qualified_spans[0].atomic_claims[0]
+    assert claim["status"] == "review_required"
+    assert "unresolved_reference" in claim["qualification_reason"]
+
+
+def test_agent_keeps_demotion_when_retry_raises():
+    agent = ClaimQualificationAgent()
+    responses = [
+        _llm_response("This result shows the rate vanishes."),
+        RuntimeError("LLM down"),
+    ]
+    with patch.object(agent._llm_client, "generate", side_effect=responses):
+        result = agent.run(_structure(), _skeleton(), _roles())
+    claim = result.qualified_spans[0].atomic_claims[0]
+    assert claim["status"] == "review_required"

--- a/src/tests/agents/claim_qualification/test_context_lint.py
+++ b/src/tests/agents/claim_qualification/test_context_lint.py
@@ -327,3 +327,18 @@ def test_agent_keeps_demotion_when_retry_raises():
         result = agent.run(_structure(), _skeleton(), _roles())
     claim = result.qualified_spans[0].atomic_claims[0]
     assert claim["status"] == "review_required"
+
+
+def test_agent_rejects_retry_that_drops_atomic_claims():
+    """repair が atomic claim を消した場合は採用しない（#357 レビュー対応）。"""
+    agent = ClaimQualificationAgent()
+    bad = _llm_response("This result shows the rate vanishes.")
+    dropped = _llm_response("placeholder")
+    dropped["atomic_claims"] = []  # retry silently drops the claims
+    with patch.object(agent._llm_client, "generate", side_effect=[bad, dropped]):
+        result = agent.run(_structure(), _skeleton(), _roles())
+    claim = result.qualified_spans[0].atomic_claims[0]
+    # 元の降格済み record を保持（情報を落とさない）
+    assert claim["status"] == "review_required"
+    assert "unresolved_reference" in claim["qualification_reason"]
+    assert len(result.qualified_spans[0].atomic_claims) == 1

--- a/src/tests/agents/component_assembly/test_thesis_support_refs.py
+++ b/src/tests/agents/component_assembly/test_thesis_support_refs.py
@@ -1,0 +1,131 @@
+"""Tests for deterministic supports_thesis_node_ids enrichment (issue #354)."""
+from episteme_graph.agents.component_assembly.enrichment import enrich_component_assembly
+from episteme_graph.agents.component_assembly.schema import (
+    COMPONENTS_VERSION,
+    ComponentAssemblyLLMInput,
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+
+
+def _component(component_id, *, linked_claim_ids=None, linked_equation_ids=None):
+    return ComponentRecord(
+        component_id,
+        "RelationComponent",
+        f"{component_id} label",
+        f"{component_id} summary",
+        [], [], [], [], [],
+        {"claim_ids": [], "equation_ids": list(linked_equation_ids or []),
+         "thesis_refs": [], "dsl_refs": {"node_ids": [], "edge_ids": []}},
+        "reason",
+        0.8,
+        [],
+        linked_claim_ids=list(linked_claim_ids or []),
+        linked_equation_ids=list(linked_equation_ids or []),
+    )
+
+
+def _llm_input(thesis_nodes):
+    return ComponentAssemblyLLMInput(
+        document_id="doc",
+        cartridge_id=None,
+        accepted_claims=[],
+        equations=[],
+        thesis_nodes=thesis_nodes,
+        dsl_nodes=[],
+        dsl_edges=[],
+        allowed_component_types=["RelationComponent"],
+        allowed_dependency_types=["requires"],
+    )
+
+
+_THESIS_NODES = [
+    {
+        "thesis_ref": "central_thesis",
+        "text": "central",
+        "claim_ids": ["claim_main"],
+        "equation_ids": ["eq_final"],
+        "kind": "central_thesis",
+    },
+    {
+        "thesis_ref": "support:assumptions:0",
+        "text": "assumption",
+        "claim_ids": ["claim_assume"],
+        "equation_ids": [],
+        "kind": "support",
+    },
+]
+
+
+def _result(components):
+    return ComponentAssemblyResult(
+        "doc", COMPONENTS_VERSION, None, components, [], [], 0.8
+    )
+
+
+def test_claim_overlap_links_component_to_thesis_node():
+    comp = _component("comp_a", linked_claim_ids=["claim_main"])
+    enrich_component_assembly(_result([comp]), _llm_input(_THESIS_NODES))
+    assert comp.supports_thesis_node_ids == ["central_thesis"]
+
+
+def test_equation_overlap_links_component_to_thesis_node():
+    comp = _component("comp_b", linked_equation_ids=["eq_final"])
+    enrich_component_assembly(_result([comp]), _llm_input(_THESIS_NODES))
+    assert comp.supports_thesis_node_ids == ["central_thesis"]
+
+
+def test_component_can_back_multiple_thesis_nodes():
+    comp = _component(
+        "comp_c",
+        linked_claim_ids=["claim_main", "claim_assume"],
+    )
+    enrich_component_assembly(_result([comp]), _llm_input(_THESIS_NODES))
+    assert comp.supports_thesis_node_ids == [
+        "central_thesis",
+        "support:assumptions:0",
+    ]
+
+
+def test_no_overlap_leaves_thesis_refs_empty():
+    comp = _component("comp_d", linked_claim_ids=["claim_other"])
+    enrich_component_assembly(_result([comp]), _llm_input(_THESIS_NODES))
+    assert comp.supports_thesis_node_ids == []
+
+
+def test_no_thesis_nodes_leaves_field_untouched():
+    comp = _component("comp_e", linked_claim_ids=["claim_main"])
+    enrich_component_assembly(_result([comp]), _llm_input([]))
+    assert comp.supports_thesis_node_ids == []
+
+
+def test_thesis_support_refs_are_deterministic():
+    def build():
+        comp = _component(
+            "comp_f",
+            linked_claim_ids=["claim_assume", "claim_main"],
+            linked_equation_ids=["eq_final"],
+        )
+        enrich_component_assembly(_result([comp]), _llm_input(_THESIS_NODES))
+        return comp.supports_thesis_node_ids
+
+    first = build()
+    second = build()
+    assert first == second
+
+
+def test_enrichment_is_idempotent_no_duplicates():
+    comp = _component("comp_g", linked_claim_ids=["claim_main"])
+    result = _result([comp])
+    llm_input = _llm_input(_THESIS_NODES)
+    enrich_component_assembly(result, llm_input)
+    enrich_component_assembly(result, llm_input)
+    assert comp.supports_thesis_node_ids == ["central_thesis"]
+
+
+def test_supports_thesis_node_ids_round_trips_via_dict():
+    comp = _component("comp_h", linked_claim_ids=["claim_main"])
+    result = _result([comp])
+    enrich_component_assembly(result, _llm_input(_THESIS_NODES))
+    reloaded = ComponentAssemblyResult.from_dict(result.to_dict())
+    assert reloaded.components[0].supports_thesis_node_ids == ["central_thesis"]

--- a/src/tests/agents/component_graph/test_generic_fallback_grading.py
+++ b/src/tests/agents/component_graph/test_generic_fallback_grading.py
@@ -1,0 +1,180 @@
+"""Tests for the graded generic-operation fallback (issue #361)."""
+from episteme_graph.agents.component_assembly.schema import ComponentAssemblyResult
+from episteme_graph.agents.component_graph.normalizer import ComponentGraphNormalizer
+from episteme_graph.agents.component_graph.validator import ComponentGraphValidator
+from episteme_graph.agents.component_graph.schema import (
+    ComponentGraphNode,
+    ComponentGraphResult,
+    GRAPH_SCHEMA_VERSION,
+)
+from episteme_graph.agents.derivation_chain.agent import DerivationChainAgent
+from episteme_graph.agents.derivation_chain.schema import (
+    DerivationChainRecord,
+    DerivationChainResult,
+    DerivationStep,
+)
+
+
+def _step(operation, inputs, outputs, **kwargs):
+    return DerivationStep(
+        step_id=f"step_{operation}_{len(inputs)}_{len(outputs)}",
+        input_equation_ids=inputs,
+        operation=operation,
+        output_equation_ids=outputs,
+        review_status="teacher_review_required",
+        **kwargs,
+    )
+
+
+def _derivations(steps):
+    return DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[DerivationChainRecord(
+            derivation_id="deriv",
+            document_id="doc",
+            source_section_ids=[],
+            steps=steps,
+        )],
+    )
+
+
+def _components():
+    return ComponentAssemblyResult(
+        document_id="doc", components_version="v1", cartridge_id=None,
+        components=[], assembly_hints=[], review_notes=[], confidence=0.8,
+    )
+
+
+def _normalize(steps):
+    return ComponentGraphNormalizer().normalize(
+        ComponentGraphResult(
+            document_id="doc", graph_schema_version=GRAPH_SCHEMA_VERSION,
+            cartridge_id=None, nodes=[], edges=[], review_notes=[],
+            confidence=0.8,
+        ),
+        components=_components(),
+        derivations=_derivations(steps),
+    )
+
+
+def _layer(result, layer):
+    return [n for n in result.nodes if n.graph_layer == layer]
+
+
+def test_all_generic_chain_with_io_stays_in_detail_layer():
+    """両端 source_backed の generic step は debug に落ちない."""
+    result = _normalize([
+        _step("transform", ["eq_a"], ["eq_b"]),
+        _step("relate", ["eq_b"], ["eq_c"]),
+    ])
+    detail = _layer(result, "equation_detail")
+    assert len(detail) == 2
+    assert _layer(result, "debug") == []
+    for node in detail:
+        assert node.source_backing_status == "partially_source_backed"
+        assert "generic_operation" in node.review_reasons
+
+
+def test_generic_without_equation_backing_falls_to_debug():
+    result = _normalize([
+        _step("transform", [], ["eq_b"]),
+        _step("relate", ["eq_b"], []),
+    ])
+    assert _layer(result, "equation_detail") == []
+    debug = _layer(result, "debug")
+    assert len(debug) == 2
+    for node in debug:
+        assert node.source_backing_status == "inferred"
+
+
+def test_kept_generic_never_becomes_main_node():
+    """generic は main node にしない（#308 の hard error を維持）."""
+    result = _normalize([
+        _step("define_operator", ["eq_a"], ["eq_b"]),
+        _step("transform", ["eq_b"], ["eq_c"]),
+    ])
+    main_ops = {n.operation for n in _layer(result, "main")}
+    assert "transform" not in main_ops
+    issues = ComponentGraphValidator().validate(result)
+    assert not any(i.rule_id == "main_graph_generic_operation" for i in issues)
+
+
+def test_validator_reports_empty_main_graph_with_quality_breakdown():
+    """main graph 全滅時は generic 率・backing 欠落率を warning で report."""
+    nodes = [
+        ComponentGraphNode(
+            component_id=f"eq_op_{i}", label=f"step {i}",
+            component_type="EquationOperationNode",
+            graph_layer="debug", operation="transform",
+            source_backing_status="inferred",
+            review_reasons=["fallback_or_inferred_node"],
+        )
+        for i in range(3)
+    ]
+    result = ComponentGraphResult(
+        document_id="doc", graph_schema_version=GRAPH_SCHEMA_VERSION,
+        cartridge_id=None, nodes=nodes, edges=[], review_notes=[],
+        confidence=0.8,
+    )
+    issues = ComponentGraphValidator().validate(result)
+    reports = [i for i in issues if i.rule_id == "main_graph_empty_derivation_quality"]
+    assert len(reports) == 1
+    assert reports[0].severity == "warning"
+    assert "3/3" in reports[0].message
+
+
+def test_validator_silent_when_main_graph_present():
+    result = _normalize([
+        _step("define_operator", ["eq_a"], ["eq_b"]),
+        _step("transform", ["eq_b"], ["eq_c"]),
+    ])
+    issues = ComponentGraphValidator().validate(result)
+    assert not any(
+        i.rule_id == "main_graph_empty_derivation_quality" for i in issues
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic generic-operation reclassification (derivation_chain side)
+# ---------------------------------------------------------------------------
+
+class _Sem:
+    def __init__(self, secondary_types=(), defined=()):
+        self.secondary_types = list(secondary_types)
+        self.defined_symbols = list(defined)
+
+
+class _Defined:
+    def __init__(self, status="defined"):
+        self.definition_status = status
+
+
+class _Record:
+    def __init__(self, secondary_types=(), defined=()):
+        self.semantics = _Sem(secondary_types, defined)
+
+
+def test_refine_generic_operation_uses_secondary_roles():
+    refine = DerivationChainAgent._refine_generic_operation
+    assert refine("relate", _Record(secondary_types=["result"])) == "derive_result"
+    assert refine("transform", _Record(secondary_types=["approximation"])) == "approximate"
+    assert refine("relate", _Record(secondary_types=["constraint"])) == "apply_constraint"
+
+
+def test_refine_generic_operation_uses_defined_symbols():
+    refine = DerivationChainAgent._refine_generic_operation
+    assert refine("relate", _Record(defined=[_Defined()])) == "apply_definition"
+
+
+def test_refine_keeps_generic_when_no_signal():
+    refine = DerivationChainAgent._refine_generic_operation
+    assert refine("relate", _Record()) == "relate"
+    assert refine("relate", None) == "relate"
+
+
+def test_refine_does_not_touch_concrete_operations():
+    refine = DerivationChainAgent._refine_generic_operation
+    assert refine(
+        "eliminate_parameter", _Record(secondary_types=["result"])
+    ) == "eliminate_parameter"

--- a/src/tests/agents/component_graph/test_issue_311_acceptance.py
+++ b/src/tests/agents/component_graph/test_issue_311_acceptance.py
@@ -62,7 +62,10 @@ def _payload():
         ),
         _step("derive_consistency_relation", ["eq_d"], ["eq_e"]),
         _step("apply_criterion", ["eq_e"], ["eq_f"]),
-        _step("transform", ["eq_f"], ["eq_g"]),  # generic → debug layer
+        # Generic with equation IO → kept in equation_detail (issue #361).
+        _step("transform", ["eq_f"], ["eq_g"]),
+        # Generic without output equations → debug layer.
+        _step("relate", ["eq_g"], []),
     ]
     derivations = DerivationChainResult(
         document_id="doc",
@@ -203,7 +206,7 @@ def test_review_required_nodes_and_edges_always_have_reasons():
 def test_inferred_nodes_are_not_confirmed_source_backed():
     _result, payload = _payload()
     debug = _layer(payload, "debug")
-    assert debug  # the generic "transform" step lands here
+    assert debug  # the generic "relate" step (no equation outputs) lands here
     for node in debug:
         assert node["source_backing_status"] != "source_backed"
         assert node["source_backing_status"] in ("inferred", "review_required")

--- a/src/tests/agents/component_graph/test_normalizer.py
+++ b/src/tests/agents/component_graph/test_normalizer.py
@@ -39,7 +39,11 @@ def _derivations():
         ),
         _step("derive_consistency_relation", ["eq_d"], ["eq_e"]),
         _step("apply_criterion", ["eq_e"], ["eq_f"]),
+        # Generic but equation-backed on both ends → kept in equation_detail
+        # as partially_source_backed (issue #361).
         _step("transform", ["eq_f"], ["eq_g"]),
+        # Generic without output equations → debug layer.
+        _step("relate", ["eq_g"], []),
     ]
     return DerivationChainResult(
         document_id="doc",
@@ -133,10 +137,10 @@ def test_main_graph_is_smaller_than_detail_graph():
     detail_nodes = _layer(result, "equation_detail")
     debug_nodes = _layer(result, "debug")
 
-    # 6 derivation steps → 5 non-generic steps become main nodes (one per
+    # 7 derivation steps → 5 non-generic steps become main nodes (one per
     # operation family), and every step is preserved in the detail/debug layer.
     assert len(main_nodes) == 5
-    assert len(detail_nodes) + len(debug_nodes) == 6
+    assert len(detail_nodes) + len(debug_nodes) == 7
     assert len(main_nodes) < len(detail_nodes) + len(debug_nodes)
     assert all(n.component_type == "TheoryOperationNode" for n in main_nodes)
     assert all(n.component_type == "EquationOperationNode" for n in detail_nodes)
@@ -318,12 +322,36 @@ def test_generic_operations_excluded_from_main_graph():
     result = _normalized()
     main_ops = {n.operation for n in _layer(result, "main")}
     assert "transform" not in main_ops
+    assert "relate" not in main_ops
 
-    # The generic step is kept in the debug layer, flagged as inferred.
+    # Issue #361: a generic step with input AND output equations stays in the
+    # equation_detail layer as partially_source_backed (never stronger).
+    detail = _layer(result, "equation_detail")
+    kept = next(n for n in detail if n.operation == "transform")
+    assert kept.source_backing_status == "partially_source_backed"
+    assert "generic_operation" in kept.review_reasons
+    assert kept.review_status == "teacher_review_required"
+
+    # A generic step without equation backing still lands in debug as inferred.
     debug = _layer(result, "debug")
-    generic = next(n for n in debug if n.operation == "transform")
+    generic = next(n for n in debug if n.operation == "relate")
     assert generic.source_backing_status == "inferred"
     assert "fallback_or_inferred_node" in generic.review_reasons
+
+
+def test_kept_generic_detail_node_has_parent_main_node():
+    # Issue #361: the kept-generic step is attached to the nearest preceding
+    # non-generic step's main node so the layer linkage invariant holds, but
+    # it must not strengthen that main node's backing.
+    result = _normalized()
+    detail = _layer(result, "equation_detail")
+    kept = next(n for n in detail if n.operation == "transform")
+    main_by_id = {n.component_id: n for n in _layer(result, "main")}
+    assert kept.parent_component_id in main_by_id
+    parent = main_by_id[kept.parent_component_id]
+    assert kept.component_id in parent.member_component_ids
+    # eq_g (only produced by the generic step) never backs the main node.
+    assert "eq_g" not in parent.linked_equation_ids
 
 
 # --- source backing / review status (acceptance #6, #7, #8, #9) -------------
@@ -412,8 +440,12 @@ def test_main_edges_carry_operation_edge_types():
 
 def test_generic_step_edge_in_detail_is_review_required():
     result = _normalized()
-    debug_ids = {n.component_id for n in _layer(result, "debug")}
-    into_generic = [e for e in result.edges if e.target in debug_ids]
+    generic_ids = {
+        n.component_id
+        for n in result.nodes
+        if n.operation in ("transform", "relate")
+    }
+    into_generic = [e for e in result.edges if e.target in generic_ids]
     assert into_generic
     assert all(e.review_status == "review_required" for e in into_generic)
     assert all(e.review_reasons for e in into_generic)

--- a/src/tests/agents/evidence_registry/test_sentence_granularity.py
+++ b/src/tests/agents/evidence_registry/test_sentence_granularity.py
@@ -88,11 +88,19 @@ def test_sentence_records_inherit_export_policy():
             assert record.public_export_policy == "snippet_allowed"
 
 
-def test_single_sentence_block_adds_no_sentence_records():
+def test_single_sentence_block_still_gets_a_sentence_record():
+    """単一文 block でも sentence_quote を生成する（#363 レビュー対応）。"""
     structure = _structure(text="Only one sentence here.")
     builder = EvidenceRegistryBuilder(structure)
     parent_id = builder.add_for_block("blk_1")
-    assert builder.add_sentences_for_block("blk_1", parent_evidence_id=parent_id) == []
+    sentence_ids = builder.add_sentences_for_block(
+        "blk_1", parent_evidence_id=parent_id
+    )
+    assert len(sentence_ids) == 1
+    registry = builder.build("doc_test")
+    record = registry.index_by_id()[sentence_ids[0]]
+    assert record.evidence_role == "sentence_quote"
+    assert record.parent_evidence_id == parent_id
 
 
 def test_sentence_records_round_trip_via_dict():
@@ -194,3 +202,36 @@ def test_empty_quote_keeps_block_evidence_silently():
     assert not any(
         i.rule_id == "evidence_quote_unmatched" for i in result.validation_issues
     )
+
+
+def test_span_alignment_mismatch_is_warned():
+    """RhetoricalRole span が evidence span の外にはみ出すと warning (#363)。"""
+    from episteme_graph.agents.evidence_registry.builder import check_span_alignment
+    from episteme_graph.agents.rhetorical_role.schema import (
+        BlockRoleAnnotation,
+        RhetoricalRoleResult,
+        SpanAnnotation,
+    )
+
+    registry, _ = _registry_with_sentences()
+    bad_span = SpanAnnotation(
+        span_id="s_bad", text="x", char_start=0, char_end=99999,
+        role_labels=["result"], is_claim_candidate=True,
+        is_reject_candidate=False, confidence=0.9, reason="r",
+    )
+    ok_span = SpanAnnotation(
+        span_id="s_ok", text="x", char_start=0, char_end=10,
+        role_labels=["result"], is_claim_candidate=True,
+        is_reject_candidate=False, confidence=0.9, reason="r",
+    )
+    roles = RhetoricalRoleResult(
+        document_id="doc_test", cartridge_id=None,
+        role_annotations=[BlockRoleAnnotation("blk_1", "sec_1", "result",
+                                              [bad_span, ok_span])],
+        summary_stats={},
+    )
+    issues = check_span_alignment(roles, registry)
+    assert len(issues) == 1
+    assert issues[0].rule_id == "evidence_span_alignment_mismatch"
+    assert "s_bad" in issues[0].message
+    assert issues[0] in registry.validation_issues

--- a/src/tests/agents/evidence_registry/test_sentence_granularity.py
+++ b/src/tests/agents/evidence_registry/test_sentence_granularity.py
@@ -1,0 +1,196 @@
+"""Tests for sentence-level evidence granularity (issue #363)."""
+from __future__ import annotations
+
+from episteme_graph.agents.claim_object_builder import ClaimObjectBuilder
+from episteme_graph.agents.claim_qualification.schema import QualifiedSpanRecord
+from episteme_graph.agents.document_structure.schema import (
+    DocumentMetadata,
+    DocumentStructureResult,
+    TypedBlock,
+)
+from episteme_graph.agents.evidence_registry import EvidenceRegistryBuilder
+from episteme_graph.agents.evidence_registry.builder import (
+    split_sentences_with_offsets,
+)
+
+_BLOCK_TEXT = (
+    "The decay rate vanishes in the heavy-quark limit. "
+    "The sum rule relates the three measured ratios. "
+    "This was verified numerically."
+)
+
+
+def _structure(block_id="blk_1", text=_BLOCK_TEXT):
+    return DocumentStructureResult(
+        document_id="doc_test",
+        source_file="/tmp/x.pdf",
+        cartridge_id=None,
+        metadata=DocumentMetadata(pages=1),
+        sections=[],
+        blocks=[TypedBlock(
+            block_id=block_id, page=1, order=1, text=text,
+            block_type="body_paragraph", section_id="sec_1",
+        )],
+    )
+
+
+# ---------------------------------------------------------------------------
+# sentence splitting
+# ---------------------------------------------------------------------------
+
+def test_split_sentences_returns_offsets():
+    spans = split_sentences_with_offsets(_BLOCK_TEXT)
+    sentences = [_BLOCK_TEXT[a:b] for a, b in spans]
+    assert sentences == [
+        "The decay rate vanishes in the heavy-quark limit.",
+        "The sum rule relates the three measured ratios.",
+        "This was verified numerically.",
+    ]
+
+
+def test_split_sentences_guards_abbreviations_and_decimals():
+    text = "Combining Eq. (2.7) with v2.0 of the code gives 3.14 exactly. Done."
+    spans = split_sentences_with_offsets(text)
+    assert [text[a:b] for a, b in spans] == [
+        "Combining Eq. (2.7) with v2.0 of the code gives 3.14 exactly.",
+        "Done.",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# registry records
+# ---------------------------------------------------------------------------
+
+def _registry_with_sentences():
+    structure = _structure()
+    builder = EvidenceRegistryBuilder(structure)
+    parent_id = builder.add_for_block("blk_1", public_export_policy="snippet_allowed")
+    builder.add_sentences_for_block("blk_1", parent_evidence_id=parent_id)
+    return builder.build("doc_test"), parent_id
+
+
+def test_sentence_records_link_to_parent_block_record():
+    registry, parent_id = _registry_with_sentences()
+    sentence_records = [
+        r for r in registry.records if r.evidence_role == "sentence_quote"
+    ]
+    assert len(sentence_records) == 3
+    for record in sentence_records:
+        assert record.parent_evidence_id == parent_id
+        assert record.source.block_id == "blk_1"
+        assert _BLOCK_TEXT[record.source.span_start:record.source.span_end] == record.evidence_text
+
+
+def test_sentence_records_inherit_export_policy():
+    registry, _ = _registry_with_sentences()
+    for record in registry.records:
+        if record.evidence_role == "sentence_quote":
+            assert record.public_export_policy == "snippet_allowed"
+
+
+def test_single_sentence_block_adds_no_sentence_records():
+    structure = _structure(text="Only one sentence here.")
+    builder = EvidenceRegistryBuilder(structure)
+    parent_id = builder.add_for_block("blk_1")
+    assert builder.add_sentences_for_block("blk_1", parent_evidence_id=parent_id) == []
+
+
+def test_sentence_records_round_trip_via_dict():
+    from episteme_graph.agents.evidence_registry.schema import EvidenceRegistryResult
+    registry, parent_id = _registry_with_sentences()
+    reloaded = EvidenceRegistryResult.from_dict(registry.to_dict())
+    sentence_records = [
+        r for r in reloaded.records if r.evidence_role == "sentence_quote"
+    ]
+    assert sentence_records and all(
+        r.parent_evidence_id == parent_id for r in sentence_records
+    )
+
+
+# ---------------------------------------------------------------------------
+# atomic claim → sentence evidence refinement
+# ---------------------------------------------------------------------------
+
+def _span_with_atomic_claims(atomic_claims):
+    return QualifiedSpanRecord(
+        span_id="s1",
+        block_id="blk_1",
+        section_id="sec_1",
+        text=_BLOCK_TEXT,
+        role_labels=["result"],
+        qualification={
+            "status": "accepted",
+            "claim_type_candidate": "result",
+            "claim_tier": "paper_core",
+            "granularity": "too_broad",
+            "evidence_adequacy": "sufficient",
+        },
+        edit_suggestions={"should_split": True},
+        reason="r",
+        confidence=0.9,
+        atomic_claims=atomic_claims,
+    )
+
+
+def _build_claims(atomic_claims):
+    registry, _ = _registry_with_sentences()
+    builder = ClaimObjectBuilder(evidence_registry=registry)
+    return registry, builder.build("doc_test", [_span_with_atomic_claims(atomic_claims)])
+
+
+def test_matching_evidence_quote_narrows_to_sentence():
+    registry, result = _build_claims([
+        {"text": "The decay rate vanishes in the heavy-quark limit.",
+         "atomicity": "atomic", "status": "accepted", "source_span_id": "s1",
+         "evidence_quote": "The decay rate vanishes in the heavy-quark limit."},
+        {"text": "The sum rule relates the three measured ratios.",
+         "atomicity": "atomic", "status": "accepted", "source_span_id": "s1",
+         "evidence_quote": "The sum rule relates the three measured ratios"},
+    ])
+    sentence_ids = {
+        r.evidence_id: r.evidence_text
+        for r in registry.records if r.evidence_role == "sentence_quote"
+    }
+    children = [c for c in result.claims if c.parent_claim_id]
+    assert len(children) == 2
+    for child in children:
+        assert len(child.source_evidence_ids) == 1
+        evidence_id = child.source_evidence_ids[0]
+        assert evidence_id in sentence_ids
+        # 引用文と claim が同じ文を指す
+        assert child.text.rstrip(".") in sentence_ids[evidence_id].rstrip(".") or \
+            sentence_ids[evidence_id].rstrip(".") in child.text
+
+
+def test_unmatched_quote_keeps_block_evidence_with_warning():
+    registry, result = _build_claims([
+        {"text": "An unrelated rewritten statement.",
+         "atomicity": "atomic", "status": "accepted", "source_span_id": "s1",
+         "evidence_quote": "totally different wording that matches nothing"},
+        {"text": "The sum rule relates the three measured ratios.",
+         "atomicity": "atomic", "status": "accepted", "source_span_id": "s1",
+         "evidence_quote": ""},
+    ])
+    block_ids = {
+        r.evidence_id for r in registry.records
+        if r.evidence_role == "source_quote"
+    }
+    children = [c for c in result.claims if c.parent_claim_id]
+    unmatched = children[0]
+    assert set(unmatched.source_evidence_ids) == block_ids  # kept, not dropped
+    assert any(
+        i.rule_id == "evidence_quote_unmatched" for i in result.validation_issues
+    )
+
+
+def test_empty_quote_keeps_block_evidence_silently():
+    registry, result = _build_claims([
+        {"text": "The sum rule relates the ratios.", "atomicity": "atomic",
+         "status": "accepted", "source_span_id": "s1", "evidence_quote": ""},
+        {"text": "This was verified numerically by the authors.",
+         "atomicity": "atomic", "status": "accepted", "source_span_id": "s1",
+         "evidence_quote": ""},
+    ])
+    assert not any(
+        i.rule_id == "evidence_quote_unmatched" for i in result.validation_issues
+    )

--- a/src/tests/agents/narrative_annotator/test_agent.py
+++ b/src/tests/agents/narrative_annotator/test_agent.py
@@ -1,0 +1,218 @@
+"""Tests for NarrativeAnnotator (issue #360)."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from episteme_graph.agents.component_graph.schema import (
+    ComponentGraphEdge,
+    ComponentGraphNode,
+    ComponentGraphResult,
+    GRAPH_SCHEMA_VERSION,
+)
+from episteme_graph.agents.narrative_annotator.agent import NarrativeAnnotator
+from episteme_graph.agents.narrative_annotator.input_builder import (
+    NarrativeInputBuilder,
+)
+from episteme_graph.agents.narrative_annotator.repair import _parse_raw
+from episteme_graph.agents.narrative_annotator.schema import (
+    NarrativeAnnotationResult,
+)
+from episteme_graph.agents.narrative_annotator.validator import (
+    NarrativeValidator,
+    verify_graph_unchanged,
+)
+
+
+def _graph():
+    main_a = ComponentGraphNode(
+        component_id="main_a", label="Theory basis",
+        component_type="TheoryOperationNode", graph_layer="main",
+        description="Defines the operators.",
+        linked_derivation_ids=["derivation_1"],
+        display_order=0,
+    )
+    main_b = ComponentGraphNode(
+        component_id="main_b", label="Consistency relation",
+        component_type="TheoryOperationNode", graph_layer="main",
+        description="Derives the final relation.",
+        display_order=1,
+    )
+    detail = ComponentGraphNode(
+        component_id="detail_1", label="derive eq_2",
+        component_type="EquationOperationNode", graph_layer="equation_detail",
+        parent_component_id="main_a",
+    )
+    edge = ComponentGraphEdge(
+        edge_id="edge_ab", source="main_a", target="main_b",
+        edge_type="derives", support_status="source_inferred",
+        evidence_claims=[], reasoning="basis feeds the relation",
+    )
+    detail_edge = ComponentGraphEdge(
+        edge_id="edge_detail", source="detail_1", target="main_b",
+        edge_type="derives", support_status="source_inferred",
+        evidence_claims=[], reasoning="detail",
+    )
+    return ComponentGraphResult(
+        document_id="doc", graph_schema_version=GRAPH_SCHEMA_VERSION,
+        cartridge_id=None, nodes=[main_a, main_b, detail],
+        edges=[edge, detail_edge], review_notes=[], confidence=0.8,
+    )
+
+
+class _Thesis:
+    central_thesis = {"text": "A single relation links the ratios."}
+
+
+class _Chain:
+    derivation_id = "derivation_1"
+    teaching_takeaway = "The operators define every later stage."
+
+
+class _Derivations:
+    chains = [_Chain()]
+
+
+def _llm_output(node_ids=("main_a", "main_b"), edge_ids=("edge_ab",)):
+    return {
+        "graph_summary": "The paper links the ratios through one relation.",
+        "node_narratives": [
+            {"component_id": nid, "narrative_role": f"Role of {nid}.",
+             "reason": "desc", "confidence": 0.8}
+            for nid in node_ids
+        ],
+        "edge_narratives": [
+            {"edge_id": eid, "transition_text": f"Transition {eid}.",
+             "reason": "edge", "confidence": 0.7}
+            for eid in edge_ids
+        ],
+        "review_notes": [],
+        "confidence": 0.8,
+    }
+
+
+# ---------------------------------------------------------------------------
+# input builder
+# ---------------------------------------------------------------------------
+
+def test_input_builder_packages_main_layer_only():
+    llm_input = NarrativeInputBuilder().build(
+        _graph(), thesis=_Thesis(), derivations=_Derivations(),
+    )
+    node_ids = [n["component_id"] for n in llm_input.main_nodes]
+    assert node_ids == ["main_a", "main_b"]  # detail node excluded
+    edge_ids = [e["edge_id"] for e in llm_input.main_edges]
+    assert edge_ids == ["edge_ab"]  # detail edge excluded
+    assert llm_input.central_thesis_text.startswith("A single relation")
+
+
+def test_input_builder_rolls_up_teaching_takeaways():
+    llm_input = NarrativeInputBuilder().build(
+        _graph(), derivations=_Derivations(),
+    )
+    node_a = next(n for n in llm_input.main_nodes if n["component_id"] == "main_a")
+    assert node_a["teaching_takeaways"] == [
+        "The operators define every later stage."
+    ]
+
+
+# ---------------------------------------------------------------------------
+# agent
+# ---------------------------------------------------------------------------
+
+def test_agent_annotates_without_modifying_graph():
+    graph = _graph()
+    snapshot = graph.to_dict()
+    agent = NarrativeAnnotator()
+    with patch.object(agent._llm_client, "generate", return_value=_llm_output()):
+        result = agent.run(graph, thesis=_Thesis(), derivations=_Derivations())
+    assert verify_graph_unchanged(snapshot, graph.to_dict())
+    assert result.graph_summary
+    assert result.maturity_source == "llm_proposed"
+    assert not [i for i in result.validation_issues if i.severity == "error"]
+    assert {n.component_id for n in result.node_narratives} == {"main_a", "main_b"}
+
+
+def test_agent_llm_failure_returns_fallback():
+    agent = NarrativeAnnotator()
+    with patch.object(agent._llm_client, "generate", side_effect=RuntimeError("down")):
+        result = agent.run(_graph())
+    assert result.graph_summary == ""
+    assert any(
+        i.rule_id == "narrative_annotation_failed" for i in result.validation_issues
+    )
+
+
+def test_agent_repairs_unknown_component_id():
+    agent = NarrativeAnnotator()
+    bad = _llm_output(node_ids=("ghost",))
+    good = _llm_output()
+    with patch.object(agent._llm_client, "generate", side_effect=[bad, good]):
+        result = agent.run(_graph(), thesis=_Thesis())
+    assert {n.component_id for n in result.node_narratives} == {"main_a", "main_b"}
+    assert not [i for i in result.validation_issues if i.severity == "error"]
+
+
+def test_agent_without_main_nodes_degrades():
+    graph = _graph()
+    for node in graph.nodes:
+        node.graph_layer = "equation_detail"
+    agent = NarrativeAnnotator()
+    result = agent.run(graph)
+    assert any(
+        i.rule_id == "narrative_annotation_failed" for i in result.validation_issues
+    )
+
+
+# ---------------------------------------------------------------------------
+# validator
+# ---------------------------------------------------------------------------
+
+def _validate(raw, graph=None):
+    builder = NarrativeInputBuilder()
+    llm_input = builder.build(graph or _graph())
+    result = _parse_raw(raw, llm_input)
+    return NarrativeValidator().validate(result, llm_input), result
+
+
+def test_validator_flags_unknown_ids_and_lengths():
+    raw = _llm_output(node_ids=("ghost",), edge_ids=("ghost_edge",))
+    raw["graph_summary"] = "x" * 2000
+    raw["node_narratives"][0]["narrative_role"] = "y" * 500
+    issues, _ = _validate(raw)
+    rule_ids = {i.rule_id for i in issues}
+    assert "unknown_component_id" in rule_ids
+    assert "unknown_edge_id" in rule_ids
+    assert "graph_summary_too_long" in rule_ids
+    assert "narrative_role_too_long" in rule_ids
+
+
+def test_validator_warns_on_missing_coverage():
+    raw = _llm_output(node_ids=("main_a",), edge_ids=())
+    issues, _ = _validate(raw)
+    warnings = {i.rule_id for i in issues if i.severity == "warning"}
+    assert "node_without_narrative" in warnings
+    assert "edge_without_narrative" in warnings
+    assert not [i for i in issues if i.severity == "error"]
+
+
+def test_validator_enforces_provisional_maturity():
+    raw = _llm_output()
+    issues, result = _validate(raw)
+    assert result.maturity_source == "llm_proposed"
+    result.maturity_source = "auto_confirmed"
+    issues = NarrativeValidator().validate(result)
+    assert any(i.rule_id == "invalid_maturity_source" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# schema round trip
+# ---------------------------------------------------------------------------
+
+def test_result_round_trips_via_dict():
+    builder = NarrativeInputBuilder()
+    llm_input = builder.build(_graph())
+    result = _parse_raw(_llm_output(), llm_input)
+    reloaded = NarrativeAnnotationResult.from_dict(result.to_dict())
+    assert reloaded.graph_summary == result.graph_summary
+    assert len(reloaded.node_narratives) == len(result.node_narratives)
+    assert reloaded.maturity_source == "llm_proposed"

--- a/src/tests/agents/symbol_registry/test_builder.py
+++ b/src/tests/agents/symbol_registry/test_builder.py
@@ -1,0 +1,216 @@
+"""Tests for SymbolRegistryBuilder (issue #355)."""
+import json
+
+from episteme_graph.agents.equation_semantics.schema import (
+    DefinedSymbol,
+    EquationConfidencePolicy,
+    EquationReconstruction,
+    EquationRecord,
+    EquationSemantics,
+    EquationSemanticsResult,
+    EquationSourceExtraction,
+)
+from episteme_graph.agents.symbol_registry.builder import (
+    SymbolRegistryBuilder,
+    normalize_symbol,
+)
+from episteme_graph.agents.symbol_registry.schema import SymbolRegistryResult
+from episteme_graph.agents.symbol_registry.validator import SymbolRegistryValidator
+
+
+def _equation(
+    equation_id,
+    *,
+    section_id="sec_1",
+    defined=None,
+    used=None,
+    evidence_ids=None,
+):
+    src = EquationSourceExtraction(
+        raw_text="x = y",
+        latex=None,
+        plain_text="x = y",
+        source_location={"page": 1, "section_id": section_id,
+                         "block_id": f"b_{equation_id}", "bbox": None},
+        extraction_source="pdf_text_layer",
+        extraction_status="complete",
+    )
+    rec = EquationReconstruction.make_none()
+    sem = EquationSemantics(
+        equation_type="relation",
+        secondary_types=[],
+        semantic_status="source_backed",
+        confidence=0.9,
+        reason="r",
+        defined_symbols=list(defined or []),
+        used_symbols=list(used or []),
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=list(evidence_ids or []),
+        linked_claim_ids=[],
+        summary="",
+        review_flags=[],
+    )
+    policy = EquationConfidencePolicy.derive(src, rec, sem)
+    return EquationRecord(
+        equation_id=equation_id,
+        document_id="doc",
+        label=equation_id,
+        candidate_trace_ids=[],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=policy,
+    )
+
+
+def _result(equations):
+    return EquationSemanticsResult("doc", None, [], list(equations))
+
+
+BUILDER = SymbolRegistryBuilder()
+
+
+def test_normalize_symbol_merges_latex_and_unicode():
+    assert normalize_symbol("\\beta") == "β"
+    assert normalize_symbol("β") == "β"
+    assert normalize_symbol("\\mathrm{b}_1") == "b_1"
+    assert normalize_symbol("$x$") == "x"
+    assert normalize_symbol("B") == "B"  # case preserved
+
+
+def test_variants_aggregate_into_one_record():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("\\beta", "defined", "β is the bias")],
+                    evidence_ids=["ev_1"])
+    eq2 = _equation("eq_2", used=["β"])
+    result = BUILDER.run(_result([eq1, eq2]))
+    assert len(result.records) == 1
+    record = result.records[0]
+    assert record.canonical_symbol == "β"
+    assert set(record.notation_variants) == {"\\beta", "β"}
+    assert record.defining_equation_ids == ["eq_1"]
+    assert record.used_in_equation_ids == ["eq_2"]
+    assert record.source_evidence_ids == ["ev_1"]
+    assert record.definition_status == "defined"
+    assert record.definition_evidence_texts == ["β is the bias"]
+
+
+def test_redefinition_is_detected_with_review_reason():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("b_1", "defined", "first def")])
+    eq2 = _equation("eq_2", defined=[DefinedSymbol("b_1", "defined", "second def")])
+    result = BUILDER.run(_result([eq1, eq2]))
+    record = result.records[0]
+    assert record.definition_status == "redefined"
+    assert "symbol_redefinition" in record.review_reasons
+
+
+def test_used_only_symbol_keeps_definition_missing_reason():
+    eq1 = _equation("eq_1", used=["σ_8"])
+    result = BUILDER.run(_result([eq1]))
+    record = result.records[0]
+    assert record.definition_status == "used"
+    assert "definition_missing" in record.review_reasons
+    assert record.unit is None
+    assert record.domain_constraints == []
+
+
+def test_scope_derivation():
+    eq1 = _equation("eq_1", section_id="sec_1",
+                    defined=[DefinedSymbol("a", "defined", None)])
+    eq2 = _equation("eq_2", section_id="sec_1", used=["a", "b"])
+    eq3 = _equation("eq_3", section_id="sec_2", used=["a"])
+    eq4 = _equation("eq_4", section_id="sec_1", used=["c"])
+    result = BUILDER.run(_result([eq1, eq2, eq3, eq4]))
+    by_symbol = {r.canonical_symbol: r for r in result.records}
+    assert by_symbol["a"].scope == "document"      # 3 equations, 2 sections
+    assert by_symbol["b"].scope == "equation_local"
+    assert by_symbol["c"].scope == "equation_local"
+
+
+def test_annotates_defined_symbols_with_symbol_id():
+    ds = DefinedSymbol("\\beta", "defined", "β is the bias")
+    eq1 = _equation("eq_1", defined=[ds])
+    result = BUILDER.run(_result([eq1]))
+    assert ds.symbol_id == result.records[0].symbol_id
+
+
+def test_works_without_cartridge_and_kind_is_unknown():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("R_D", "defined", None)])
+    result = BUILDER.run(_result([eq1]), cartridge_id=None)
+    assert result.records[0].kind == "unknown"
+
+
+def test_missing_cartridge_id_degrades_gracefully():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("x", "defined", None)])
+    result = BUILDER.run(_result([eq1]), cartridge_id="no_such_cartridge")
+    assert len(result.records) == 1
+
+
+def test_cartridge_notation_pattern_classifies_kind(tmp_path):
+    cartridge_dir = tmp_path / "test_cartridge"
+    cartridge_dir.mkdir()
+    (cartridge_dir / "ontology.json").write_text(json.dumps({
+        "aliases": [{"canonical": "R Lambda c", "aliases": ["RΛc", "R_Λc"]}],
+        "notation_patterns": [
+            {"id": "wilson", "pattern": "C_[A-Za-z0-9]+", "concept_type": "Parameter"},
+        ],
+    }), encoding="utf-8")
+    builder = SymbolRegistryBuilder(cartridge_base_dir=str(tmp_path))
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("C_9", "defined", None)],
+                    used=["RΛc"])
+    eq2 = _equation("eq_2", used=["R_Λc"])
+    result = builder.run(_result([eq1, eq2]), cartridge_id="test_cartridge")
+    by_symbol = {r.canonical_symbol: r for r in result.records}
+    assert by_symbol["C_9"].kind == "parameter"
+    # cartridge aliases merge variants under the canonical name
+    assert "R Lambda c" in by_symbol
+    assert set(by_symbol["R Lambda c"].notation_variants) == {"RΛc", "R_Λc"}
+
+
+def test_result_is_json_serializable_and_round_trips():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("β", "defined", "def")],
+                    used=["x"])
+    result = BUILDER.run(_result([eq1]))
+    payload = result.to_json()
+    reloaded = SymbolRegistryResult.from_dict(json.loads(payload))
+    assert reloaded.document_id == "doc"
+    assert len(reloaded.records) == len(result.records)
+    assert reloaded.records[0].symbol_id == result.records[0].symbol_id
+
+
+def test_builder_is_deterministic():
+    def build():
+        eq1 = _equation("eq_1", defined=[DefinedSymbol("\\beta", "defined", "d")],
+                        used=["x", "y"])
+        eq2 = _equation("eq_2", used=["β", "x"])
+        return BUILDER.run(_result([eq1, eq2])).to_dict()
+
+    assert build() == build()
+
+
+def test_validator_passes_builder_output():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("b_1", "defined", "d")],
+                    used=["σ_8"])
+    eq2 = _equation("eq_2", defined=[DefinedSymbol("b_1", "defined", "d2")])
+    result = BUILDER.run(_result([eq1, eq2]))
+    issues = SymbolRegistryValidator().validate(result)
+    assert [i for i in issues if i.severity == "error"] == []
+
+
+def test_validator_detects_invalid_vocab():
+    eq1 = _equation("eq_1", defined=[DefinedSymbol("a", "defined", None)])
+    result = BUILDER.run(_result([eq1]))
+    result.records[0].kind = "banana"
+    result.records[0].scope = "galaxy"
+    issues = SymbolRegistryValidator().validate(result)
+    rule_ids = [i.rule_id for i in issues]
+    assert "invalid_symbol_kind" in rule_ids
+    assert "invalid_symbol_scope" in rule_ids
+
+
+def test_empty_equations_result_is_empty_registry():
+    result = BUILDER.run(_result([]))
+    assert result.records == []
+    assert result.document_id == "doc"

--- a/src/tests/agents/test_claim_input_sampling.py
+++ b/src/tests/agents/test_claim_input_sampling.py
@@ -1,0 +1,230 @@
+"""Cross-stage tests for the unified claim input sampling policy (issue #356).
+
+thesis_reconstruction / dsl_linking / component_assembly must share the same
+importance-based selection and record every dropped claim explicitly.
+"""
+from episteme_graph.agents.claim_qualification.schema import (
+    ClaimQualificationResult,
+    QualifiedSpanRecord,
+)
+from episteme_graph.agents.claim_selection import (
+    RULE_CLAIM_INPUT_LIMIT_EXCEEDED,
+    RULE_THESIS_REFERENCED_CLAIM_EXCLUDED,
+)
+from episteme_graph.agents.component_assembly.input_builder import (
+    ComponentAssemblyInputBuilder,
+)
+from episteme_graph.agents.dsl_linking.agent import DSLLinkingAgent
+from episteme_graph.agents.dsl_linking.input_builder import DSLLinkingInputBuilder
+from episteme_graph.agents.dsl_linking.schema import DSLLinkingResult
+from episteme_graph.agents.paper_skeleton.schema import (
+    LogicalBlock,
+    PaperSkeletonResult,
+    SKELETON_VERSION,
+)
+from episteme_graph.agents.thesis_reconstruction.agent import (
+    ThesisReconstructionAgent,
+)
+from episteme_graph.agents.thesis_reconstruction.input_builder import (
+    ThesisReconstructionInputBuilder,
+)
+from episteme_graph.agents.thesis_reconstruction.schema import (
+    SUPPORT_SECTIONS,
+    ThesisReconstructionResult,
+    THESIS_VERSION,
+)
+
+
+def _span(span_id, *, tier="background", confidence=0.5):
+    return QualifiedSpanRecord(
+        span_id=span_id,
+        block_id=f"b_{span_id}",
+        section_id="sec_1",
+        text=f"claim text {span_id}",
+        role_labels=["relation"],
+        qualification={
+            "status": "accepted",
+            "claim_tier": tier,
+            "claim_type_candidate": "relation",
+            "granularity": "good",
+            "evidence_adequacy": "sufficient",
+            "reviewability": "good",
+        },
+        edit_suggestions={},
+        reason="r",
+        confidence=confidence,
+    )
+
+
+def _qualified(spans):
+    return ClaimQualificationResult(
+        "doc", None, list(spans), [], [], {"accepted": len(spans)}
+    )
+
+
+def _skeleton():
+    return PaperSkeletonResult(
+        document_id="doc",
+        skeleton_version=SKELETON_VERSION,
+        cartridge_id=None,
+        paper_goal={"text": "goal", "evidence_block_ids": [], "reason": "", "confidence": 0.8},
+        central_question={"text": "q", "evidence_block_ids": [], "reason": "", "confidence": 0.8},
+        headline_claim={"text": "h", "evidence_block_ids": [], "reason": "", "confidence": 0.8},
+        supporting_subclaims=[],
+        logical_blocks=[
+            LogicalBlock("l1", "derivation", "Derivation", ["sec_1"], [], "s", "r", 0.9)
+        ],
+        excluded_regions=[],
+        review_notes=[],
+        confidence=0.8,
+    )
+
+
+def _thesis(claim_ids):
+    return ThesisReconstructionResult(
+        document_id="doc",
+        thesis_version=THESIS_VERSION,
+        cartridge_id=None,
+        central_thesis={
+            "text": "central",
+            "claim_ids": list(claim_ids),
+            "equation_ids": [],
+            "evidence_block_ids": [],
+            "reason": "r",
+            "confidence": 0.9,
+        },
+        alternative_theses=[],
+        support_structure={section: [] for section in SUPPORT_SECTIONS},
+        excluded_from_core=[],
+        thesis_graph_hints=[],
+        review_notes=[],
+        confidence=0.9,
+    )
+
+
+_SPANS = [
+    _span("s1", tier="background", confidence=0.9),
+    _span("s2", tier="background", confidence=0.8),
+    _span("s3", tier="paper_core", confidence=0.4),
+    _span("s4", tier="meta", confidence=0.9),
+]
+
+
+def test_thesis_builder_keeps_paper_core_over_limit():
+    llm_input = ThesisReconstructionInputBuilder().build(
+        _skeleton(), _qualified(_SPANS), config={"max_claims": 2},
+    )
+    selected_spans = [c["span_id"] for c in llm_input.accepted_claims]
+    assert "s3" in selected_spans  # paper_core survives
+    assert len(selected_spans) == 2
+    excluded_spans = {e["span_id"] for e in llm_input.excluded_from_pipeline_input}
+    assert len(excluded_spans) == 2
+    assert all(
+        e["excluded_at_stage"] == "thesis_reconstruction"
+        for e in llm_input.excluded_from_pipeline_input
+    )
+
+
+def test_dsl_builder_keeps_paper_core_over_limit():
+    llm_input = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 2},
+    )
+    selected_spans = [c["span_id"] for c in llm_input.accepted_claims]
+    assert "s3" in selected_spans
+    assert len(llm_input.excluded_from_pipeline_input) == 2
+
+
+def test_component_builder_keeps_paper_core_over_limit():
+    llm_input = ComponentAssemblyInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 2},
+    )
+    selected_spans = [c["span_id"] for c in llm_input.accepted_claims]
+    assert "s3" in selected_spans
+    assert len(llm_input.excluded_from_pipeline_input) == 2
+    assert all(
+        e["excluded_at_stage"] == "component_assembly"
+        for e in llm_input.excluded_from_pipeline_input
+    )
+
+
+def test_stages_share_the_same_selection_membership():
+    """同じ入力・同じ上限なら 3 stage で同じ claim 集合が選ばれる."""
+    thesis_in = ThesisReconstructionInputBuilder().build(
+        _skeleton(), _qualified(_SPANS), config={"max_claims": 2},
+    )
+    dsl_in = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 2},
+    )
+    comp_in = ComponentAssemblyInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 2},
+    )
+    thesis_ids = {c["claim_id"] for c in thesis_in.accepted_claims}
+    dsl_ids = {c["claim_id"] for c in dsl_in.accepted_claims}
+    comp_ids = {c["claim_id"] for c in comp_in.accepted_claims}
+    assert thesis_ids == dsl_ids == comp_ids
+
+
+def test_thesis_referenced_exclusion_is_flagged_in_dsl_stage():
+    # claim_id for span s4 (meta, will be dropped) referenced by thesis.
+    dropped_claim_id = "claim:b_s4:s4"
+    llm_input = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS),
+        thesis=_thesis([dropped_claim_id]),
+        config={"max_claims": 2},
+    )
+    flagged = [
+        e for e in llm_input.excluded_from_pipeline_input
+        if e["claim_id"] == dropped_claim_id
+    ]
+    assert flagged and flagged[0]["referenced_by_thesis"] is True
+
+
+def test_no_exclusions_under_limit():
+    llm_input = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 10},
+    )
+    assert llm_input.excluded_from_pipeline_input == []
+
+
+def test_agent_records_exclusions_as_warnings():
+    """除外があると result に excluded_from_pipeline_input + warning が付く."""
+    llm_input = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS),
+        thesis=_thesis(["claim:b_s4:s4"]),
+        config={"max_claims": 2},
+    )
+    result = DSLLinkingResult(
+        document_id="doc", dsl_version="v1", nodes=[], edges=[],
+        graph_hints=[], review_notes=[], confidence=0.8,
+    )
+    DSLLinkingAgent._record_claim_exclusions(result, llm_input)
+    assert len(result.excluded_from_pipeline_input) == 2
+    rule_ids = [i.rule_id for i in result.validation_issues]
+    assert RULE_CLAIM_INPUT_LIMIT_EXCEEDED in rule_ids
+    assert RULE_THESIS_REFERENCED_CLAIM_EXCLUDED in rule_ids
+    assert all(i.severity == "warning" for i in result.validation_issues)
+
+
+def test_thesis_agent_records_exclusions_as_warnings():
+    llm_input = ThesisReconstructionInputBuilder().build(
+        _skeleton(), _qualified(_SPANS), config={"max_claims": 2},
+    )
+    result = _thesis([])
+    ThesisReconstructionAgent._record_claim_exclusions(result, llm_input)
+    assert len(result.excluded_from_pipeline_input) == 2
+    assert RULE_CLAIM_INPUT_LIMIT_EXCEEDED in [
+        i.rule_id for i in result.validation_issues
+    ]
+
+
+def test_exclusions_round_trip_via_dict():
+    llm_input = DSLLinkingInputBuilder().build(
+        _qualified(_SPANS), config={"max_claims": 2},
+    )
+    result = DSLLinkingResult(
+        document_id="doc", dsl_version="v1", nodes=[], edges=[],
+        graph_hints=[], review_notes=[], confidence=0.8,
+        excluded_from_pipeline_input=llm_input.excluded_from_pipeline_input,
+    )
+    reloaded = DSLLinkingResult.from_dict(result.to_dict())
+    assert reloaded.excluded_from_pipeline_input == llm_input.excluded_from_pipeline_input

--- a/src/tests/agents/test_claim_selection.py
+++ b/src/tests/agents/test_claim_selection.py
@@ -134,3 +134,32 @@ def test_thesis_claim_id_set_collects_all_sections():
 
 def test_thesis_claim_id_set_handles_none():
     assert thesis_claim_id_set(None) == set()
+
+
+def test_headline_relevance_breaks_ties_within_tier():
+    """同 tier 内では headline claim との関連が confidence より優先される (#356)。"""
+    rows = [
+        _row("unrelated", tier="background", confidence=0.9),
+        _row("related", tier="background", confidence=0.2),
+    ]
+    rows[0]["text"] = "An unrelated statement about the apparatus calibration."
+    rows[1]["text"] = "The sum rule relates the three decay ratios."
+    selection = select_claim_rows(
+        rows, 1, stage="thesis_reconstruction",
+        headline_text="A sum rule relates the decay ratios.",
+    )
+    assert selection.selected[0]["claim_id"] == "related"
+
+
+def test_headline_text_helper_prefers_skeleton_then_thesis():
+    from episteme_graph.agents.claim_selection import headline_text_for_selection
+
+    class _Skeleton:
+        headline_claim = {"text": "headline from skeleton"}
+
+    class _ThesisObj:
+        central_thesis = {"text": "central from thesis"}
+
+    assert headline_text_for_selection(skeleton=_Skeleton()) == "headline from skeleton"
+    assert headline_text_for_selection(thesis=_ThesisObj()) == "central from thesis"
+    assert headline_text_for_selection() == ""

--- a/src/tests/agents/test_claim_selection.py
+++ b/src/tests/agents/test_claim_selection.py
@@ -1,0 +1,136 @@
+"""Tests for the shared claim input selection policy (issue #356)."""
+from episteme_graph.agents.claim_selection import (
+    RULE_CLAIM_INPUT_LIMIT_EXCEEDED,
+    RULE_THESIS_REFERENCED_CLAIM_EXCLUDED,
+    select_claim_rows,
+    selection_issue_payloads,
+    thesis_claim_id_set,
+)
+
+
+def _row(claim_id, *, tier="background", confidence=0.5, span_id=""):
+    return {
+        "claim_id": claim_id,
+        "span_id": span_id or f"span_{claim_id}",
+        "claim_tier": tier,
+        "confidence": confidence,
+        "text": f"text for {claim_id}",
+    }
+
+
+def test_under_limit_keeps_everything():
+    rows = [_row("c1"), _row("c2")]
+    selection = select_claim_rows(rows, 5, stage="thesis_reconstruction")
+    assert selection.selected == rows
+    assert selection.excluded == []
+
+
+def test_paper_core_claims_survive_the_limit():
+    """paper_core が末尾にあっても上限超過時に必ず選抜される."""
+    rows = [_row(f"bg_{i}", tier="background", confidence=0.9) for i in range(5)]
+    rows.append(_row("core_1", tier="paper_core", confidence=0.1))
+    selection = select_claim_rows(rows, 3, stage="thesis_reconstruction")
+    selected_ids = [r["claim_id"] for r in selection.selected]
+    assert "core_1" in selected_ids
+    assert len(selected_ids) == 3
+
+
+def test_higher_confidence_wins_within_same_tier():
+    rows = [
+        _row("low", tier="background", confidence=0.2),
+        _row("high", tier="background", confidence=0.9),
+        _row("mid", tier="background", confidence=0.5),
+    ]
+    selection = select_claim_rows(rows, 2, stage="dsl_linking")
+    selected_ids = [r["claim_id"] for r in selection.selected]
+    assert "high" in selected_ids and "mid" in selected_ids
+    assert "low" not in selected_ids
+
+
+def test_selected_rows_keep_original_document_order():
+    rows = [
+        _row("a", tier="background", confidence=0.3),
+        _row("b", tier="paper_core", confidence=0.9),
+        _row("c", tier="background", confidence=0.8),
+    ]
+    selection = select_claim_rows(rows, 2, stage="dsl_linking")
+    assert [r["claim_id"] for r in selection.selected] == ["b", "c"]
+
+
+def test_excluded_entries_record_stage_and_reason():
+    rows = [_row("keep", tier="paper_core"), _row("drop", tier="meta")]
+    selection = select_claim_rows(rows, 1, stage="component_assembly")
+    assert len(selection.excluded) == 1
+    entry = selection.excluded[0]
+    assert entry["claim_id"] == "drop"
+    assert entry["excluded_at_stage"] == "component_assembly"
+    assert entry["reason"] == "max_claims_exceeded"
+    assert entry["referenced_by_thesis"] is False
+
+
+def test_thesis_referenced_exclusion_is_flagged():
+    rows = [_row("keep", tier="paper_core"), _row("thesis_ref", tier="meta")]
+    selection = select_claim_rows(
+        rows, 1, stage="dsl_linking", thesis_claim_ids={"thesis_ref"}
+    )
+    assert selection.excluded[0]["referenced_by_thesis"] is True
+
+
+def test_selection_is_deterministic():
+    rows = [
+        _row(f"c{i}", tier=t, confidence=c)
+        for i, (t, c) in enumerate([
+            ("background", 0.5), ("paper_core", 0.4), ("meta", 0.9),
+            ("paper_supporting", 0.7), ("background", 0.5),
+        ])
+    ]
+    first = select_claim_rows(rows, 3, stage="thesis_reconstruction")
+    second = select_claim_rows(list(rows), 3, stage="thesis_reconstruction")
+    assert [r["claim_id"] for r in first.selected] == [
+        r["claim_id"] for r in second.selected
+    ]
+    assert first.excluded == second.excluded
+
+
+def test_unknown_tier_ranks_with_background():
+    rows = [
+        _row("unknown_tier", tier="", confidence=0.5),
+        _row("prior", tier="prior_work", confidence=0.9),
+    ]
+    selection = select_claim_rows(rows, 1, stage="dsl_linking")
+    assert selection.selected[0]["claim_id"] == "unknown_tier"
+
+
+def test_issue_payloads_for_exclusions():
+    rows = [_row("keep", tier="paper_core"), _row("drop", tier="meta")]
+    selection = select_claim_rows(
+        rows, 1, stage="dsl_linking", thesis_claim_ids={"drop"}
+    )
+    payloads = selection_issue_payloads(selection.excluded, stage="dsl_linking")
+    rule_ids = [p["rule_id"] for p in payloads]
+    assert RULE_CLAIM_INPUT_LIMIT_EXCEEDED in rule_ids
+    assert RULE_THESIS_REFERENCED_CLAIM_EXCLUDED in rule_ids
+    assert all(p["severity"] == "warning" for p in payloads)
+    assert any("drop" in p["message"] for p in payloads)
+
+
+def test_issue_payloads_empty_when_nothing_excluded():
+    assert selection_issue_payloads([], stage="dsl_linking") == []
+
+
+class _Thesis:
+    def __init__(self):
+        self.central_thesis = {"claim_ids": ["claim_central"]}
+        self.support_structure = {
+            "assumptions": [{"claim_ids": ["claim_assume"]}],
+            "derivation_core": "not-a-list",
+        }
+
+
+def test_thesis_claim_id_set_collects_all_sections():
+    ids = thesis_claim_id_set(_Thesis())
+    assert ids == {"claim_central", "claim_assume"}
+
+
+def test_thesis_claim_id_set_handles_none():
+    assert thesis_claim_id_set(None) == set()

--- a/src/tests/agents/test_content_normalization.py
+++ b/src/tests/agents/test_content_normalization.py
@@ -79,7 +79,9 @@ def test_hash_is_deterministic_and_versioned():
         normalize_text_for_hash("x")
     )
     assert content_hash("") == ""
-    assert isinstance(CONTENT_HASH_VERSION, int) and CONTENT_HASH_VERSION >= 1
+    # v2: prose-token casefolding replaced the v1 full lowercasing — old hashes
+    # are incompatible, so the version must have been bumped (#362 レビュー対応).
+    assert isinstance(CONTENT_HASH_VERSION, int) and CONTENT_HASH_VERSION >= 2
 
 
 def test_normalize_equation_empty_input():

--- a/src/tests/agents/test_content_normalization.py
+++ b/src/tests/agents/test_content_normalization.py
@@ -44,6 +44,19 @@ def test_case_folding_for_claim_text():
     )
 
 
+def test_math_symbols_in_claims_keep_case():
+    """記号・数式部分は小文字化しない (issue #362)。"""
+    assert claim_content_hash("The ratio R_D is measured.") != claim_content_hash(
+        "The ratio r_d is measured."
+    )
+    assert claim_content_hash("The coupling B vanishes.") != claim_content_hash(
+        "The coupling b vanishes."
+    )
+    assert claim_content_hash("DHOST theories survive.") != claim_content_hash(
+        "dhost theories survive."
+    )
+
+
 def test_different_claims_have_different_hashes():
     assert claim_content_hash("The rate vanishes.") != claim_content_hash(
         "The rate diverges."

--- a/src/tests/agents/test_content_normalization.py
+++ b/src/tests/agents/test_content_normalization.py
@@ -1,0 +1,233 @@
+"""Tests for deterministic content hashing (issue #362)."""
+from __future__ import annotations
+
+from episteme_graph.agents.claim_object_builder import ClaimObjectBuilder
+from episteme_graph.agents.claim_object_builder.schema import (
+    ClaimObjectBuildResult,
+)
+from episteme_graph.agents.claim_qualification.schema import QualifiedSpanRecord
+from episteme_graph.agents.content_normalization import (
+    CONTENT_HASH_VERSION,
+    claim_content_hash,
+    content_hash,
+    equation_content_hash,
+    normalize_equation_for_hash,
+    normalize_text_for_hash,
+)
+from episteme_graph.agents.document_structure.schema import (
+    DocumentMetadata,
+    DocumentStructureResult,
+    TypedBlock,
+)
+from episteme_graph.agents.equation_semantics.schema import (
+    EquationSemanticsResult,
+)
+from episteme_graph.agents.equation_semantics.validator import (
+    EquationSemanticsValidator,
+)
+from episteme_graph.agents.evidence_registry import EvidenceRegistryBuilder
+
+
+# ---------------------------------------------------------------------------
+# normalization rules
+# ---------------------------------------------------------------------------
+
+def test_whitespace_and_punctuation_variants_share_a_hash():
+    a = claim_content_hash("The decay rate  vanishes\n in the heavy-quark limit.")
+    b = claim_content_hash("The decay rate vanishes in the heavy-quark limit")
+    assert a == b != ""
+
+
+def test_case_folding_for_claim_text():
+    assert claim_content_hash("The Sum Rule holds.") == claim_content_hash(
+        "the sum rule holds"
+    )
+
+
+def test_different_claims_have_different_hashes():
+    assert claim_content_hash("The rate vanishes.") != claim_content_hash(
+        "The rate diverges."
+    )
+
+
+def test_equation_normalization_ignores_whitespace_and_math_mode():
+    a = equation_content_hash("$R_D = a + b$")
+    b = equation_content_hash("R_D=a+b")
+    c = equation_content_hash(None, "R_D = a + b")
+    assert a == b == c != ""
+
+
+def test_equation_normalization_preserves_case():
+    assert equation_content_hash("b = 1") != equation_content_hash("B = 1")
+
+
+def test_hash_is_deterministic_and_versioned():
+    assert content_hash(normalize_text_for_hash("x")) == content_hash(
+        normalize_text_for_hash("x")
+    )
+    assert content_hash("") == ""
+    assert isinstance(CONTENT_HASH_VERSION, int) and CONTENT_HASH_VERSION >= 1
+
+
+def test_normalize_equation_empty_input():
+    assert normalize_equation_for_hash(None, None) == ""
+    assert equation_content_hash(None, None) == ""
+
+
+# ---------------------------------------------------------------------------
+# claim builder integration
+# ---------------------------------------------------------------------------
+
+def _span(span_id, block_id, text):
+    return QualifiedSpanRecord(
+        span_id=span_id,
+        block_id=block_id,
+        section_id="sec_1",
+        text=text,
+        role_labels=["approximation"],
+        qualification={
+            "status": "accepted",
+            "claim_type_candidate": "approximation",
+            "claim_tier": "paper_core",
+            "granularity": "good",
+            "evidence_adequacy": "sufficient",
+        },
+        edit_suggestions={"normalized_text": text},
+        reason="r",
+        confidence=0.8,
+    )
+
+
+def _structure(block_id):
+    return DocumentStructureResult(
+        document_id="doc_test",
+        source_file="/tmp/x.pdf",
+        cartridge_id=None,
+        metadata=DocumentMetadata(pages=1),
+        sections=[],
+        blocks=[TypedBlock(
+            block_id=block_id, page=1, order=1, text="source text",
+            block_type="body_paragraph", section_id="sec_1",
+        )],
+    )
+
+
+def _build(spans):
+    structure = _structure("blk_1")
+    ev_builder = EvidenceRegistryBuilder(structure)
+    ev_builder.add_for_block("blk_1")
+    registry = ev_builder.build("doc_test")
+    return ClaimObjectBuilder(evidence_registry=registry).build("doc_test", spans)
+
+
+def test_built_claims_carry_content_hash_and_version():
+    result = _build([_span("s1", "blk_1", "Take the zero-recoil limit.")])
+    claim = result.claims[0]
+    assert claim.content_hash
+    assert claim.content_hash_version == CONTENT_HASH_VERSION
+    assert claim.content_hash == claim_content_hash(claim.normalized_text)
+
+
+def test_duplicate_claim_hashes_are_reported_not_merged():
+    result = _build([
+        _span("s1", "blk_1", "Take the zero-recoil limit."),
+        _span("s2", "blk_1", "Take  the zero-recoil limit"),  # whitespace variant
+    ])
+    assert len(result.claims) == 2  # never auto-merged
+    duplicates = [
+        i for i in result.validation_issues
+        if i.rule_id == "duplicate_claim_content_hash"
+    ]
+    assert len(duplicates) == 1
+    assert duplicates[0].severity == "warning"
+
+
+def test_legacy_claim_payload_without_hash_loads():
+    payload = {
+        "document_id": "doc",
+        "cartridge_id": None,
+        "claims": [
+            {"claim_id": "c1", "document_id": "doc", "claim_type": "result",
+             "text": "t", "source_evidence_ids": [], "source_span_ids": [],
+             "concepts": []},
+        ],
+        "validation_issues": [],
+    }
+    result = ClaimObjectBuildResult.from_dict(payload)
+    assert result.claims[0].content_hash == ""
+    assert result.claims[0].content_hash_version == 0
+
+
+# ---------------------------------------------------------------------------
+# equation integration
+# ---------------------------------------------------------------------------
+
+def test_equation_records_round_trip_hash_fields():
+    payload = {
+        "document_id": "doc",
+        "cartridge_id": None,
+        "equation_candidates": [],
+        "equations": [{
+            "equation_id": "eq_1",
+            "document_id": "doc",
+            "label": "1",
+            "candidate_trace_ids": [],
+            "source_extraction": {
+                "raw_text": "a = b", "latex": "a = b", "plain_text": "a = b",
+                "source_location": {"page": 1, "section_id": "s", "block_id": "b"},
+                "extraction_source": "pdf_text_layer",
+                "extraction_status": "complete",
+            },
+            "reconstruction": {
+                "latex": None, "plain_text": None, "status": "none",
+                "method": [], "supporting_refs": [], "confidence": 0.0,
+                "review_required": False,
+            },
+            "semantics": {"equation_type": "relation"},
+            "confidence_policy": {"can_support_claim": True},
+            "content_hash": "abc123",
+            "content_hash_version": 1,
+        }],
+        "validation_issues": [],
+    }
+    result = EquationSemanticsResult.from_dict(payload)
+    assert result.equations[0].content_hash == "abc123"
+    assert result.equations[0].content_hash_version == 1
+
+
+def test_equation_validator_reports_duplicate_hashes():
+    payload_eq = {
+        "equation_id": "eq_1",
+        "document_id": "doc",
+        "label": "1",
+        "candidate_trace_ids": ["cand_1"],
+        "source_extraction": {
+            "raw_text": "a = b", "latex": "a = b", "plain_text": "a = b",
+            "source_location": {"page": 1, "section_id": "s", "block_id": "b"},
+            "extraction_source": "pdf_text_layer",
+            "extraction_status": "complete",
+        },
+        "reconstruction": {
+            "latex": None, "plain_text": None, "status": "none",
+            "method": [], "supporting_refs": [], "confidence": 0.0,
+            "review_required": False,
+        },
+        "semantics": {"equation_type": "relation", "semantic_status": "source_backed",
+                      "confidence": 0.9},
+        "confidence_policy": {"can_support_claim": True},
+        "content_hash": "samehash",
+        "content_hash_version": 1,
+    }
+    second = dict(payload_eq)
+    second["equation_id"] = "eq_2"
+    result = EquationSemanticsResult.from_dict({
+        "document_id": "doc", "cartridge_id": None,
+        "equation_candidates": [], "equations": [payload_eq, second],
+        "validation_issues": [],
+    })
+    issues = EquationSemanticsValidator().validate(result)
+    duplicates = [
+        i for i in issues if i.rule_id == "duplicate_equation_content_hash"
+    ]
+    assert len(duplicates) == 1
+    assert duplicates[0].severity == "warning"

--- a/src/tests/agents/test_graph_health_checks.py
+++ b/src/tests/agents/test_graph_health_checks.py
@@ -1,0 +1,355 @@
+"""Tests for deterministic graph health checks (issue #358)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+from episteme_graph.agents.component_assembly.schema import (
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+from episteme_graph.agents.component_assembly.validator import (
+    ComponentAssemblyValidator,
+)
+from episteme_graph.agents.component_graph.schema import (
+    ComponentGraphEdge,
+    ComponentGraphNode,
+    ComponentGraphResult,
+    GRAPH_SCHEMA_VERSION,
+)
+from episteme_graph.agents.component_graph.validator import ComponentGraphValidator
+
+_GATE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "../../../backend/core/document_pipeline/export_validation_gate.py",
+)
+_spec = importlib.util.spec_from_file_location("export_validation_gate_gh", _GATE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["export_validation_gate_gh"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+ExportValidationGate = _mod.ExportValidationGate
+
+
+# ---------------------------------------------------------------------------
+# component_assembly: dependency cycle detection
+# ---------------------------------------------------------------------------
+
+def _component(component_id, dependencies=None):
+    return ComponentRecord(
+        component_id=component_id,
+        component_type="TheoryComponent",
+        label=f"{component_id} label",
+        summary=f"{component_id} summary",
+        inputs=[], outputs=[], preconditions=[], cautions=[],
+        dependencies=list(dependencies or []),
+        evidence_refs={"claim_ids": ["claim_1"], "evidence_ids": ["ev_1"]},
+        reason="r",
+        confidence=0.8,
+        review_notes=[],
+        linked_claim_ids=["claim_1"],
+    )
+
+
+def _dep(dep_type, refs):
+    return {"dependency_type": dep_type, "component_refs": list(refs), "reason": "r"}
+
+
+def _assembly(components):
+    return ComponentAssemblyResult(
+        document_id="doc", components_version="v1", cartridge_id=None,
+        components=components, assembly_hints=[], review_notes=[],
+        confidence=0.8,
+    )
+
+
+def test_requires_cycle_is_hard_error_with_path():
+    components = [
+        _component("comp_a", [_dep("requires", ["comp_b"])]),
+        _component("comp_b", [_dep("depends_on", ["comp_a"])]),
+    ]
+    issues = ComponentAssemblyValidator().validate(_assembly(components))
+    cycles = [i for i in issues if i.rule_id == "component_dependency_cycle"]
+    assert len(cycles) == 1
+    assert cycles[0].severity == "error"
+    assert "comp_a" in cycles[0].message and "comp_b" in cycles[0].message
+
+
+def test_self_requires_cycle_is_detected():
+    components = [_component("comp_a", [_dep("requires", ["comp_a"])])]
+    issues = ComponentAssemblyValidator().validate(_assembly(components))
+    assert any(i.rule_id == "component_dependency_cycle" for i in issues)
+
+
+def test_acyclic_dependencies_produce_no_cycle_error():
+    components = [
+        _component("comp_a", [_dep("requires", ["comp_b"])]),
+        _component("comp_b", [_dep("requires", ["comp_c"])]),
+        _component("comp_c"),
+    ]
+    issues = ComponentAssemblyValidator().validate(_assembly(components))
+    assert not any(i.rule_id == "component_dependency_cycle" for i in issues)
+
+
+def test_non_dependency_edge_types_do_not_count_for_cycles():
+    # supports / qualifies edges may legitimately form loops of discussion.
+    components = [
+        _component("comp_a", [_dep("supports", ["comp_b"])]),
+        _component("comp_b", [_dep("qualifies", ["comp_a"])]),
+    ]
+    issues = ComponentAssemblyValidator().validate(_assembly(components))
+    assert not any(i.rule_id == "component_dependency_cycle" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# component_graph: layer linkage + dependency edge cycles
+# ---------------------------------------------------------------------------
+
+def _graph_node(component_id, *, layer="main", component_type="TheoryOperationNode",
+                parent="", members=(), operation="define_operator"):
+    return ComponentGraphNode(
+        component_id=component_id,
+        label="Theory basis" if layer == "main" else "derive eq",
+        component_type=component_type,
+        graph_layer=layer,
+        parent_component_id=parent,
+        member_component_ids=list(members),
+        operation=operation,
+        source_backing_status="partially_source_backed",
+        review_reasons=["missing_atomic_claim"],
+        linked_equation_ids=["eq_1"],
+        input_equation_ids=["eq_1"],
+    )
+
+
+def _graph(nodes, edges=()):
+    return ComponentGraphResult(
+        document_id="doc", graph_schema_version=GRAPH_SCHEMA_VERSION,
+        cartridge_id=None, nodes=nodes, edges=list(edges),
+        review_notes=[], confidence=0.8,
+    )
+
+
+def _dep_edge(edge_id, source, target, edge_type="requires"):
+    return ComponentGraphEdge(
+        edge_id=edge_id, source=source, target=target, edge_type=edge_type,
+        support_status="dependency_declared", evidence_claims=["claim_1"],
+        reasoning="r", evidence_equation_ids=["eq_1"],
+        source_backing_status="source_backed", review_status="source_backed",
+    )
+
+
+def test_orphan_detail_node_is_warned():
+    nodes = [
+        _graph_node("main_1", members=["detail_1"]),
+        _graph_node("detail_1", layer="equation_detail",
+                    component_type="EquationOperationNode", parent="main_1"),
+        _graph_node("detail_orphan", layer="equation_detail",
+                    component_type="EquationOperationNode", parent=""),
+    ]
+    issues = ComponentGraphValidator().validate(_graph(nodes))
+    orphans = [i for i in issues if i.rule_id == "orphan_detail_node"]
+    assert len(orphans) == 1
+    assert "detail_orphan" in orphans[0].message
+    assert orphans[0].severity == "warning"
+
+
+def test_empty_main_node_is_warned():
+    nodes = [_graph_node("main_lonely", members=())]
+    issues = ComponentGraphValidator().validate(_graph(nodes))
+    assert any(i.rule_id == "empty_main_node" for i in issues)
+
+
+def test_linked_layers_produce_no_linkage_warnings():
+    nodes = [
+        _graph_node("main_1", members=["detail_1"]),
+        _graph_node("detail_1", layer="equation_detail",
+                    component_type="EquationOperationNode", parent="main_1"),
+    ]
+    issues = ComponentGraphValidator().validate(_graph(nodes))
+    assert not any(
+        i.rule_id in ("orphan_detail_node", "empty_main_node") for i in issues
+    )
+
+
+def test_dependency_edge_cycle_is_hard_error():
+    nodes = [
+        _graph_node("main_1", members=["x"]),
+        _graph_node("main_2", members=["y"]),
+    ]
+    edges = [
+        _dep_edge("e1", "main_1", "main_2"),
+        _dep_edge("e2", "main_2", "main_1", edge_type="depends_on"),
+    ]
+    issues = ComponentGraphValidator().validate(_graph(nodes, edges))
+    cycles = [i for i in issues if i.rule_id == "component_graph_dependency_cycle"]
+    assert len(cycles) == 1
+    assert cycles[0].severity == "error"
+
+
+def test_derivation_flow_edges_do_not_count_for_cycles():
+    nodes = [
+        _graph_node("main_1", members=["x"]),
+        _graph_node("main_2", members=["y"]),
+    ]
+    edges = [
+        _dep_edge("e1", "main_1", "main_2", edge_type="derives"),
+        _dep_edge("e2", "main_2", "main_1", edge_type="diagnoses"),
+    ]
+    issues = ComponentGraphValidator().validate(_graph(nodes, edges))
+    assert not any(
+        i.rule_id == "component_graph_dependency_cycle" for i in issues
+    )
+
+
+# ---------------------------------------------------------------------------
+# export gate: claim↔equation symmetry + equation role conflicts
+# ---------------------------------------------------------------------------
+
+class _ClaimObject:
+    def __init__(self, claim_id, equation_ids=()):
+        self.claim_id = claim_id
+        self.support_status = "source_backed"
+        self.source_evidence_ids = ["ev_001"]
+        self.atomicity = "atomic"
+        self.claim_type = "definition"
+        self.equation_ids = list(equation_ids)
+
+
+class _ClaimObjectResult:
+    def __init__(self, claims):
+        self.claims = claims
+
+
+class _EvidenceRecord:
+    def __init__(self, evidence_id):
+        self.evidence_id = evidence_id
+
+
+class _EvidenceResult:
+    def __init__(self, records):
+        self.records = records
+
+
+def _make_artifacts(equations):
+    return {
+        "document_structure": {"blocks": [], "sections": []},
+        "source_chunking": [{"text": "chunk"}],
+        "claim_qualification": {"qualified_spans": []},
+        "component_assembly": {"components": [], "validation_issues": []},
+        "equation_semantics": {"equations": equations},
+    }
+
+
+def _run_gate(artifacts, *, claim_objects=None, component_result=None):
+    return ExportValidationGate().run(
+        artifacts=artifacts,
+        component_result=component_result,
+        course_mapping=None,
+        claim_objects=claim_objects,
+        evidence=_EvidenceResult([_EvidenceRecord("ev_001")]),
+        dsl=None,
+    )
+
+
+def test_one_way_claim_to_equation_link_is_warned():
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_1", "linked_claim_ids": []},
+    ])
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_1", ["eq_1"])]),
+    )
+    asym = [w for w in result.warnings if w.code == "CLAIM_EQUATION_LINK_ASYMMETRY"]
+    assert len(asym) == 1
+    assert "claim_1" in asym[0].message
+    # report only — never a hard error
+    assert not any(e.code == "CLAIM_EQUATION_LINK_ASYMMETRY" for e in result.errors)
+
+
+def test_one_way_equation_to_claim_link_is_warned():
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_1", "linked_claim_ids": ["claim_1"]},
+    ])
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_1", [])]),
+    )
+    asym = [w for w in result.warnings if w.code == "CLAIM_EQUATION_LINK_ASYMMETRY"]
+    assert len(asym) == 1
+    assert asym[0].artifact == "equation_semantics"
+
+
+def test_symmetric_links_produce_no_warning():
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_1", "linked_claim_ids": ["claim_1"]},
+    ])
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_1", ["eq_1"])]),
+    )
+    assert not any(
+        w.code == "CLAIM_EQUATION_LINK_ASYMMETRY" for w in result.warnings
+    )
+
+
+class _RoleComponent:
+    def __init__(self, component_id, *, output_equation_ids=(),
+                 definition_equation_ids=()):
+        self.component_id = component_id
+        self.component_type = "TheoryComponent"
+        self.label = component_id
+        self.summary = ""
+        self.evidence_refs = {"claim_ids": ["claim_1"], "evidence_ids": ["ev_001"]}
+        self.linked_claim_ids = ["claim_1"]
+        self.linked_equation_ids = []
+        self.output_equation_ids = list(output_equation_ids)
+        self.definition_equation_ids = list(definition_equation_ids)
+        self.review_status = "teacher_review_required"
+        self.internal_flow = []
+        self.maturity_source = "llm_proposed"
+        self.fallback_reason = ""
+        self.inputs = []
+        self.outputs = []
+        self.preconditions = []
+        self.cautions = []
+
+
+class _ComponentResult:
+    def __init__(self, components):
+        self.components = components
+
+
+def test_definition_equation_used_as_output_is_role_conflict():
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_def", "semantics": {"equation_type": "definition"}},
+    ])
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_1")]),
+        component_result=_ComponentResult([
+            _RoleComponent("comp_1", output_equation_ids=["eq_def"]),
+        ]),
+    )
+    conflicts = [w for w in result.warnings if w.code == "EQUATION_ROLE_CONFLICT"]
+    assert len(conflicts) == 1
+    assert "eq_def" in conflicts[0].message
+
+
+def test_consistent_equation_roles_produce_no_conflict():
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_def", "semantics": {"equation_type": "definition"}},
+        {"equation_id": "eq_res", "semantics": {"equation_type": "result"}},
+    ])
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_1")]),
+        component_result=_ComponentResult([
+            _RoleComponent(
+                "comp_1",
+                definition_equation_ids=["eq_def"],
+                output_equation_ids=["eq_res"],
+            ),
+        ]),
+    )
+    assert not any(w.code == "EQUATION_ROLE_CONFLICT" for w in result.warnings)

--- a/src/tests/agents/test_graph_health_checks.py
+++ b/src/tests/agents/test_graph_health_checks.py
@@ -280,6 +280,61 @@ def test_one_way_equation_to_claim_link_is_warned():
     assert asym[0].artifact == "equation_semantics"
 
 
+def test_demoted_inferred_links_stay_visible_in_gate_report():
+    """annotation で降格済みのリンクも gate report に残る（#358 レビュー対応）。"""
+    artifacts = _make_artifacts([
+        {"equation_id": "eq_1", "linked_claim_ids": [],
+         "inferred_claim_ids": ["claim_1"]},
+    ])
+    claim = _ClaimObject("claim_1", [])
+    claim.inferred_equation_ids = ["eq_1"]
+    result = _run_gate(artifacts, claim_objects=_ClaimObjectResult([claim]))
+    asym = [w for w in result.warnings if w.code == "CLAIM_EQUATION_LINK_ASYMMETRY"]
+    assert len(asym) == 2
+    assert {w.artifact for w in asym} == {"claim_object_builder", "equation_semantics"}
+    assert all("demoted to inferred" in w.message for w in asym)
+
+
+def test_component_graph_validator_error_is_hard_error():
+    """component_graph stage の error は persist を止める（#358 レビュー対応）。"""
+    artifacts = _make_artifacts([])
+    artifacts["component_graph"] = {
+        "nodes": [], "edges": [],
+        "validation_issues": [{
+            "rule_id": "component_graph_dependency_cycle",
+            "severity": "error",
+            "message": "dependency edge cycle detected: a -> b -> a",
+            "field": "edges[e2]",
+        }],
+    }
+    result = _run_gate(
+        artifacts, claim_objects=_ClaimObjectResult([_ClaimObject("claim_1")]),
+    )
+    assert any(
+        e.code == "component_graph_dependency_cycle" for e in result.errors
+    )
+    assert result.exportable is False
+
+
+def test_component_graph_stage_fallback_stays_non_fatal():
+    """orchestrator の非fatal設計どおり component_graph_failed は warning 止まり。"""
+    artifacts = _make_artifacts([])
+    artifacts["component_graph"] = {
+        "nodes": [], "edges": [],
+        "validation_issues": [{
+            "rule_id": "component_graph_failed",
+            "severity": "error",
+            "message": "LLM down",
+            "field": "edges",
+        }],
+    }
+    result = _run_gate(
+        artifacts, claim_objects=_ClaimObjectResult([_ClaimObject("claim_1")]),
+    )
+    assert not any(e.code == "component_graph_failed" for e in result.errors)
+    assert any(w.code == "component_graph_failed" for w in result.warnings)
+
+
 def test_symmetric_links_produce_no_warning():
     artifacts = _make_artifacts([
         {"equation_id": "eq_1", "linked_claim_ids": ["claim_1"]},
@@ -400,13 +455,16 @@ def test_asymmetry_annotation_demotes_links_on_both_artifacts():
         _Claims([claim_one_way, claim_symmetric]), equations
     )
     assert count == 2
-    # claim 側: review_note に明示。リンクは保持
+    # claim 側: リンクは inferred_equation_ids に移動（実体としての降格）
     assert "one-way" in claim_one_way.review_note
-    assert claim_one_way.equation_ids == ["eq_1"]
+    assert claim_one_way.equation_ids == []
+    assert claim_one_way.inferred_equation_ids == ["eq_1"]
     assert claim_symmetric.review_note == ""
-    # equation 側: review flag に明示。リンクは保持
+    assert claim_symmetric.equation_ids == ["eq_2"]
+    # equation 側: リンクは inferred_claim_ids に移動 + review flag
     assert "claim_link_asymmetry" in eq_one_way.semantics.review_flags
-    assert eq_one_way.semantics.linked_claim_ids == ["claim_b"]
+    assert eq_one_way.semantics.linked_claim_ids == []
+    assert eq_one_way.semantics.inferred_claim_ids == ["claim_b"]
 
 
 def test_enrichment_flags_equation_role_conflict_on_component():

--- a/src/tests/agents/test_graph_health_checks.py
+++ b/src/tests/agents/test_graph_health_checks.py
@@ -353,3 +353,108 @@ def test_consistent_equation_roles_produce_no_conflict():
         ]),
     )
     assert not any(w.code == "EQUATION_ROLE_CONFLICT" for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# issue #358 review fixes: 降格・review reason の artifact への付与
+# ---------------------------------------------------------------------------
+
+def test_asymmetry_annotation_demotes_links_on_both_artifacts():
+    from episteme_graph.agents.id_canonicalization import (
+        annotate_claim_equation_link_asymmetries,
+    )
+
+    class _Sem:
+        def __init__(self, linked):
+            self.linked_claim_ids = list(linked)
+            self.review_flags = []
+
+    class _Equation:
+        def __init__(self, equation_id, linked):
+            self.equation_id = equation_id
+            self.semantics = _Sem(linked)
+
+    class _Equations:
+        def __init__(self, equations):
+            self.equations = equations
+
+    class _Claim:
+        def __init__(self, claim_id, equation_ids):
+            self.claim_id = claim_id
+            self.equation_ids = list(equation_ids)
+            self.review_note = ""
+
+    class _Claims:
+        def __init__(self, claims):
+            self.claims = claims
+
+    claim_one_way = _Claim("claim_a", ["eq_1"])      # eq_1 does not link back
+    claim_symmetric = _Claim("claim_b", ["eq_2"])
+    eq_one_way = _Equation("eq_3", ["claim_b"])      # claim_b does not link eq_3
+    equations = _Equations([
+        _Equation("eq_1", []),
+        _Equation("eq_2", ["claim_b"]),
+        eq_one_way,
+    ])
+    count = annotate_claim_equation_link_asymmetries(
+        _Claims([claim_one_way, claim_symmetric]), equations
+    )
+    assert count == 2
+    # claim 側: review_note に明示。リンクは保持
+    assert "one-way" in claim_one_way.review_note
+    assert claim_one_way.equation_ids == ["eq_1"]
+    assert claim_symmetric.review_note == ""
+    # equation 側: review flag に明示。リンクは保持
+    assert "claim_link_asymmetry" in eq_one_way.semantics.review_flags
+    assert eq_one_way.semantics.linked_claim_ids == ["claim_b"]
+
+
+def test_enrichment_flags_equation_role_conflict_on_component():
+    from episteme_graph.agents.component_assembly.enrichment import (
+        enrich_component_assembly,
+    )
+    from episteme_graph.agents.component_assembly.schema import (
+        COMPONENTS_VERSION,
+        ComponentAssemblyLLMInput,
+        ComponentAssemblyResult,
+        ComponentRecord,
+    )
+
+    component = ComponentRecord(
+        "comp_1", "TheoryComponent", "label", "summary",
+        [], [], [], [], [],
+        {"claim_ids": [], "equation_ids": ["eq_def"],
+         "dsl_refs": {"node_ids": [], "edge_ids": []}},
+        "r", 0.8, [],
+        output_equation_ids=["eq_def"],
+        review_status="auto_accepted",
+    )
+    llm_input = ComponentAssemblyLLMInput(
+        document_id="doc", cartridge_id=None, accepted_claims=[],
+        equations=[{"equation_id": "eq_def", "role": "definition"}],
+        thesis_nodes=[], dsl_nodes=[], dsl_edges=[],
+        allowed_component_types=["TheoryComponent"],
+        allowed_dependency_types=["requires"],
+    )
+    enrich_component_assembly(
+        ComponentAssemblyResult("doc", COMPONENTS_VERSION, None, [component], [], [], 0.8),
+        llm_input,
+    )
+    assert any("equation_role_conflict" in note for note in component.review_notes)
+    assert component.review_status == "teacher_review_required"
+    assert "eq_def" in component.output_equation_ids  # link kept
+
+
+def test_normalizer_annotates_orphan_and_empty_main_nodes():
+    from episteme_graph.agents.component_graph.normalizer import (
+        _annotate_layer_linkage_gaps,
+    )
+
+    main = _graph_node("main_1", members=())
+    orphan = _graph_node(
+        "detail_orphan", layer="equation_detail",
+        component_type="EquationOperationNode", parent="",
+    )
+    _annotate_layer_linkage_gaps([main, orphan])
+    assert "empty_main_node" in main.review_reasons
+    assert "orphan_detail_node" in orphan.review_reasons

--- a/src/tests/agents/test_thesis_coverage.py
+++ b/src/tests/agents/test_thesis_coverage.py
@@ -1,0 +1,312 @@
+"""Tests for the ExportValidationGate thesis coverage report (issue #354)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+# Import the gate module directly to avoid pulling in sqlalchemy via __init__.py
+_GATE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "../../../backend/core/document_pipeline/export_validation_gate.py",
+)
+_spec = importlib.util.spec_from_file_location("export_validation_gate_tc", _GATE_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["export_validation_gate_tc"] = _mod
+_spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+
+ExportValidationGate = _mod.ExportValidationGate
+
+
+# ---------------------------------------------------------------------------
+# Minimal stubs
+# ---------------------------------------------------------------------------
+
+class _ClaimObject:
+    def __init__(self, claim_id: str):
+        self.claim_id = claim_id
+        self.support_status = "source_backed"
+        self.source_evidence_ids = ["ev_001"]
+        self.atomicity = "atomic"
+        self.claim_type = "definition"
+
+
+class _ClaimObjectResult:
+    def __init__(self, claims):
+        self.claims = claims
+
+
+class _EvidenceRecord:
+    def __init__(self, evidence_id: str):
+        self.evidence_id = evidence_id
+
+
+class _EvidenceResult:
+    def __init__(self, records):
+        self.records = records
+
+
+class _ComponentRecord:
+    def __init__(self, component_id, *, linked_claim_ids=None, linked_equation_ids=None):
+        self.component_id = component_id
+        self.component_type = "ClaimBundleComponent"
+        self.label = component_id
+        self.summary = ""
+        self.evidence_refs = {"claim_ids": list(linked_claim_ids or []),
+                              "evidence_ids": ["ev_001"]}
+        self.linked_claim_ids = list(linked_claim_ids or [])
+        self.linked_equation_ids = list(linked_equation_ids or [])
+        self.review_status = "teacher_review_required"
+        self.internal_flow = []
+        self.maturity_source = "llm_proposed"
+        self.fallback_reason = ""
+        self.inputs = []
+        self.outputs = []
+        self.preconditions = []
+        self.cautions = []
+
+
+class _ComponentResult:
+    def __init__(self, components):
+        self.components = components
+
+
+def _thesis_artifact(*, claim_ids=("claim_main",), equation_ids=("eq_final",),
+                     assumptions=None):
+    support = {section: [] for section in (
+        "direct_supports", "assumptions", "derivation_core", "correction_sources",
+        "uncertainty_sources", "diagnostic_consequences", "future_requirements",
+    )}
+    if assumptions:
+        support["assumptions"] = list(assumptions)
+    return {
+        "document_id": "doc",
+        "central_thesis": {
+            "text": "central thesis",
+            "claim_ids": list(claim_ids),
+            "equation_ids": list(equation_ids),
+            "evidence_block_ids": [],
+            "reason": "r",
+            "confidence": 0.9,
+        },
+        "support_structure": support,
+        "validation_issues": [],
+    }
+
+
+def _graph_artifact(*, main_claim_ids=("claim_main",), main_equation_ids=(),
+                    member_equation_ids=("eq_final",)):
+    """Main node backed by claims plus an equation_detail member node."""
+    return {
+        "nodes": [
+            {
+                "component_id": "main_1",
+                "label": "Theory basis",
+                "component_type": "TheoryOperationNode",
+                "graph_layer": "main",
+                "source_backing_status": "source_backed",
+                "linked_claim_ids": list(main_claim_ids),
+                "linked_equation_ids": list(main_equation_ids),
+                "member_component_ids": ["detail_1"],
+            },
+            {
+                "component_id": "detail_1",
+                "label": "derive eq",
+                "component_type": "EquationOperationNode",
+                "graph_layer": "equation_detail",
+                "source_backing_status": "source_backed",
+                "parent_component_id": "main_1",
+                "linked_claim_ids": [],
+                "linked_equation_ids": list(member_equation_ids),
+            },
+        ],
+        "edges": [],
+    }
+
+
+def _make_artifacts(**kwargs):
+    base = {
+        "document_structure": {"blocks": [], "sections": []},
+        "source_chunking": [{"text": "chunk"}],
+        "claim_qualification": {"qualified_spans": []},
+        "component_assembly": {"components": [], "validation_issues": []},
+        "equation_semantics": {"equations": [{"equation_id": "eq_final"}]},
+    }
+    base.update(kwargs)
+    return base
+
+
+def _run_gate(artifacts, *, component_result=None, claim_objects=None):
+    gate = ExportValidationGate()
+    return gate.run(
+        artifacts=artifacts,
+        component_result=component_result,
+        course_mapping=None,
+        claim_objects=claim_objects,
+        evidence=_EvidenceResult([_EvidenceRecord("ev_001")]),
+        dsl=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_fully_backed_thesis_has_full_coverage():
+    """全参照が main graph に到達する fixture で coverage = 1.0."""
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(),
+        component_graph=_graph_artifact(),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    coverage = result.thesis_coverage
+    assert coverage["thesis_present"] is True
+    assert coverage["coverage_by_section"]["central_thesis"] == 1.0
+    assert coverage["unreachable_refs"] == []
+    assert coverage["total_refs"] == 2
+    assert coverage["reachable_refs"] == 2
+    assert not any(
+        r.code == "THESIS_SUPPORT_UNREACHABLE" for r in result.review_items
+    )
+
+
+def test_dropped_claim_is_reported_unreachable():
+    """thesis 参照 claim が claims.json から脱落 → missing_claim で report."""
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(claim_ids=("claim_dropped",)),
+        component_graph=_graph_artifact(),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    unreachable = result.thesis_coverage["unreachable_refs"]
+    assert any(
+        u["ref_id"] == "claim_dropped"
+        and u["reason"] == "missing_claim"
+        and u["review_reasons"] == ["thesis_support_unreachable"]
+        for u in unreachable
+    )
+    assert any(
+        r.code == "THESIS_SUPPORT_UNREACHABLE" for r in result.review_items
+    )
+    assert result.thesis_coverage["coverage_by_section"]["central_thesis"] == 0.5
+
+
+def test_existing_claim_not_linked_to_main_graph_is_unreachable():
+    """claims.json には存在するが main graph に link されない claim."""
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(
+            claim_ids=("claim_orphan",), equation_ids=(),
+        ),
+        component_graph=_graph_artifact(main_claim_ids=("claim_main",)),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult(
+            [_ClaimObject("claim_main"), _ClaimObject("claim_orphan")]
+        ),
+    )
+    unreachable = result.thesis_coverage["unreachable_refs"]
+    assert any(
+        u["ref_id"] == "claim_orphan" and u["reason"] == "not_linked_to_main_graph"
+        for u in unreachable
+    )
+
+
+def test_support_section_coverage_is_reported_per_section():
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(
+            assumptions=[{
+                "text": "assumption",
+                "claim_ids": ["claim_assume"],
+                "equation_ids": [],
+                "support_type": "assumption_support",
+                "reason": "r",
+                "confidence": 0.8,
+            }],
+        ),
+        component_graph=_graph_artifact(
+            main_claim_ids=("claim_main", "claim_assume"),
+        ),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult(
+            [_ClaimObject("claim_main"), _ClaimObject("claim_assume")]
+        ),
+    )
+    coverage = result.thesis_coverage["coverage_by_section"]
+    assert coverage["central_thesis"] == 1.0
+    assert coverage["assumptions"] == 1.0
+
+
+def test_thesis_absent_degrades_to_empty_report():
+    """thesis 不在 → thesis_present=False、review item なし."""
+    result = _run_gate(_make_artifacts())
+    assert result.thesis_coverage["thesis_present"] is False
+    assert result.thesis_coverage["coverage_by_section"] == {}
+    assert not any(
+        r.code == "THESIS_SUPPORT_UNREACHABLE" for r in result.review_items
+    )
+
+
+def test_unreachable_thesis_refs_never_produce_hard_errors():
+    """カバレッジ欠落は review item のみで hard error を出さない."""
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(claim_ids=("claim_dropped",)),
+        component_graph=_graph_artifact(),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    assert not any(
+        e.code == "THESIS_SUPPORT_UNREACHABLE" for e in result.errors
+    )
+    assert result.exportable is True
+    assert result.status == "needs_review"
+
+
+def test_components_stand_in_when_component_graph_absent():
+    """component_graph artifact が無い場合は components に fallback する."""
+    artifacts = _make_artifacts(thesis_reconstruction=_thesis_artifact())
+    component_result = _ComponentResult([
+        _ComponentRecord(
+            "comp_1",
+            linked_claim_ids=["claim_main"],
+            linked_equation_ids=["eq_final"],
+        ),
+    ])
+    result = _run_gate(
+        artifacts,
+        component_result=component_result,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    assert result.thesis_coverage["coverage_by_section"]["central_thesis"] == 1.0
+    assert result.thesis_coverage["unreachable_refs"] == []
+
+
+def test_equation_detail_member_backing_counts_for_main_node():
+    """main node 自身ではなく member detail node が式を持つ場合も到達扱い."""
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(claim_ids=()),
+        component_graph=_graph_artifact(
+            main_equation_ids=(), member_equation_ids=("eq_final",),
+        ),
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    assert result.thesis_coverage["coverage_by_section"]["central_thesis"] == 1.0
+
+
+def test_thesis_coverage_in_result_dict():
+    result = _run_gate(_make_artifacts(thesis_reconstruction=_thesis_artifact()))
+    d = result.to_dict()
+    assert "thesis_coverage" in d
+    assert d["thesis_coverage"]["thesis_present"] is True

--- a/src/tests/agents/test_thesis_coverage.py
+++ b/src/tests/agents/test_thesis_coverage.py
@@ -217,6 +217,54 @@ def test_existing_claim_not_linked_to_main_graph_is_unreachable():
     )
 
 
+def test_weak_main_node_backing_is_not_counted_as_support():
+    """inferred / review_required main node 経由の到達は support にしない (#354)。"""
+    graph = _graph_artifact()
+    graph["nodes"][0]["source_backing_status"] = "inferred"
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(),
+        component_graph=graph,
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    coverage = result.thesis_coverage
+    assert coverage["coverage_by_section"]["central_thesis"] == 0.0
+    assert all(
+        u["reason"] == "main_node_backing_insufficient"
+        for u in coverage["unreachable_refs"]
+    )
+    assert any(
+        r.code == "THESIS_SUPPORT_UNREACHABLE" for r in result.review_items
+    )
+
+
+def test_strong_node_coverage_wins_over_weak_node():
+    """同じ ref を strong / weak 両方の node が持つ場合は strong 扱い。"""
+    graph = _graph_artifact()
+    weak_node = {
+        "component_id": "main_weak",
+        "label": "Observation model",
+        "component_type": "TheoryOperationNode",
+        "graph_layer": "main",
+        "source_backing_status": "inferred",
+        "linked_claim_ids": ["claim_main"],
+        "linked_equation_ids": ["eq_final"],
+        "member_component_ids": [],
+    }
+    graph["nodes"].append(weak_node)
+    artifacts = _make_artifacts(
+        thesis_reconstruction=_thesis_artifact(),
+        component_graph=graph,
+    )
+    result = _run_gate(
+        artifacts,
+        claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+    )
+    assert result.thesis_coverage["coverage_by_section"]["central_thesis"] == 1.0
+
+
 def test_support_section_coverage_is_reported_per_section():
     artifacts = _make_artifacts(
         thesis_reconstruction=_thesis_artifact(

--- a/src/tests/agents/test_thesis_coverage.py
+++ b/src/tests/agents/test_thesis_coverage.py
@@ -240,6 +240,28 @@ def test_weak_main_node_backing_is_not_counted_as_support():
     )
 
 
+def test_partially_backed_or_unknown_main_node_is_not_strong_support():
+    """source_backed 以外（partially / 空文字）の main node 経由の到達は
+    support に数えない（#354 レビュー対応）。"""
+    for backing in ("partially_source_backed", ""):
+        graph = _graph_artifact()
+        graph["nodes"][0]["source_backing_status"] = backing
+        artifacts = _make_artifacts(
+            thesis_reconstruction=_thesis_artifact(),
+            component_graph=graph,
+        )
+        result = _run_gate(
+            artifacts,
+            claim_objects=_ClaimObjectResult([_ClaimObject("claim_main")]),
+        )
+        coverage = result.thesis_coverage
+        assert coverage["coverage_by_section"]["central_thesis"] == 0.0, backing
+        assert all(
+            u["reason"] == "main_node_backing_insufficient"
+            for u in coverage["unreachable_refs"]
+        ), backing
+
+
 def test_strong_node_coverage_wins_over_weak_node():
     """同じ ref を strong / weak 両方の node が持つ場合は strong 扱い。"""
     graph = _graph_artifact()


### PR DESCRIPTION
## Summary

This PR implements five interconnected features to improve deterministic processing, cross-paper reuse, and reader-facing narrative in the document pipeline:

1. **Deterministic graph health checks (#358)**: Validates claim↔equation link symmetry and equation role conflicts across stages
2. **Symbol registry builder (#355)**: Non-LLM deterministic construction of document-wide math symbol registry with notation normalization
3. **Atomic claim context-dependency lint (#357)**: Enforces resolution of anaphoric references in atomic claims with explicit context extraction
4. **Unified claim input sampling (#356)**: Centralizes importance-based claim selection across thesis_reconstruction, dsl_linking, and component_assembly stages
5. **Narrative annotator (#360)**: LLM-first annotation layer adding reader-facing narrative (graph_summary, node narratives, edge transitions) without modifying the graph

## Key Changes

### New Agents & Builders
- **SymbolRegistryBuilder** (`src/episteme_graph/agents/symbol_registry/`): Deterministic symbol registry from EquationSemanticsResult with LaTeX normalization, redefinition detection, and scope derivation
- **NarrativeAnnotator** (`src/episteme_graph/agents/narrative_annotator/`): Adds narrative_role, transition_text, and graph_summary to ComponentGraphResult with hard invariant that graph structure never changes
- **ClaimSelectionPolicy** (`src/episteme_graph/agents/claim_selection.py`): Shared importance-based (tier → confidence → document order) claim filtering with explicit exclusion tracking

### Validation & Linting
- **ContextLint** (`src/episteme_graph/agents/claim_qualification/context_lint.py`): Detects unresolved anaphoric references in atomic claims and extracts intra-document context refs (sections, figures, equations)
- **Graph health checks** in ComponentGraphValidator: Layer linkage (orphan detail nodes, member-less main nodes), dependency edge cycles
- **Dependency cycle detection** in ComponentAssemblyValidator

### Content Normalization
- **ContentNormalization** (`src/episteme_graph/agents/content_normalization.py`): Deterministic claim/equation hashing for cross-paper reuse via whitespace/punctuation/case normalization

### Schema & Vocabulary Unification
- **Atomicity normalization** (#359): Single source of truth for atomicity values (atomic, composite, split_required) with legacy alias mapping
- **Support status derivation**: Canonical support_status from evidence presence + adequacy
- **Section title tracking** in ClaimObjectBuilder for claim context
- **Sentence-level evidence** (#363): Deterministic sentence splitting with offset tracking in EvidenceRegistryBuilder

### Thesis Coverage & Validation
- **ExportValidationGate** enhancements: Thesis coverage reporting (#354) verifying reconstructed thesis claims/equations are present and reachable in final sets
- **Claim-equation link symmetry checks**: Warnings for asymmetric backing relationships
- **Equation role conflict detection**: Across derivation stages

### Integration
- **Orchestrator updates**: Added symbol_registry and narrative_annotator to pipeline stages
- **Input builders** (thesis_reconstruction, dsl_linking, component_assembly): Integrated shared claim selection with excluded_claims tracking
- **Persistence layer**: Added narrative payload serialization to database
- **Frontend**: CSS styling for narrative reading layer, admin UI stage registration

## Implementation Details

- **Deterministic by design**: Symbol registry, claim selection, and content hashing use no LLM; all normalization rules are explicit and reproducible
- **Information preservation**: Unknown/unresolved values kept as `unknown`/`review_required` rather than dropped; exclusions explicitly tracked
- **Cartridge-aware**: Symbol aliases and domain vocabulary loaded from active cartridge context
- **Hard invariants**: NarrativeAnnotator graph immutability verified via snapshot comparison; layer linkage and cycle detection enforced as validation rules
- **Backward compatible**: Legacy atomicity aliases (compound, non_atomic, split_pending) normalized to canonical values; existing claims continue to work

## Tests

Comprehensive test coverage added:
- Graph health checks (cycles, layer linkage, coverage)
- Symbol

https://claude.ai/code/session_01HgUTN4ULR6qSLGHPEyxNie