### PR TITLE
Issue #366: Document completeness gate + boundary fixes

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -19,6 +19,7 @@ from core.postgres import get_session as _pg_session
 from routes.export_artifacts import (
     build_derivation_chains_export,
     build_document_boundary,
+    build_document_completeness,
     build_equation_candidates_export,
     build_equations_export,
     build_evidence_export,
@@ -383,6 +384,21 @@ def _build_document_boundaries(
         if not structure:
             continue
         out.append(build_document_boundary(structure, document_id=doc_id))
+    return out
+
+
+def _build_document_completeness_reports(
+    artifacts_by_doc: dict[str, dict],
+    document_ids: list[str],
+) -> list[dict]:
+    """Deterministic per-document completeness reports for export_validation (#366)."""
+    out: list[dict] = []
+    for doc_id in document_ids:
+        artifacts = artifacts_by_doc.get(doc_id, {})
+        structure = artifacts.get("document_structure")
+        if not structure:
+            continue
+        out.append(build_document_completeness(structure, document_id=doc_id))
     return out
 
 
@@ -1308,6 +1324,42 @@ def _component_equation_refs_export(comp: dict) -> list[str]:
     return sorted(set(values))
 
 
+def _build_completeness_report(completeness_reports: list[dict] | None) -> dict:
+    """Aggregate per-document completeness into the export_validation block (#366).
+
+    Returns a JSON-serialisable summary listing, per incomplete document, the
+    missing equation labels, the un-ingested page coverage, and whether a
+    terminal (Conclusion/Summary) section was found. Incomplete documents are
+    reported so they are not promoted to publish_ready.
+    """
+    reports = completeness_reports or []
+    documents: list[dict] = []
+    all_complete = True
+    for rep in reports:
+        if not isinstance(rep, dict):
+            continue
+        complete = bool(rep.get("complete", True))
+        all_complete = all_complete and complete
+        eq = rep.get("equation_label_continuity") or {}
+        terminal = rep.get("terminal_section") or {}
+        coverage = rep.get("page_coverage") or {}
+        documents.append({
+            "document_id": rep.get("document_id"),
+            "complete": complete,
+            "review_reasons": list(rep.get("review_reasons") or []),
+            "missing_equation_labels": list(eq.get("missing_labels") or []),
+            "terminal_section_present": bool(terminal.get("present")),
+            "ingested_pages": list(coverage.get("ingested_pages") or []),
+            "pages_total": coverage.get("pages_total"),
+            "page_coverage_ratio": coverage.get("coverage_ratio"),
+        })
+    return {
+        "checked": bool(documents),
+        "all_documents_complete": all_complete,
+        "documents": documents,
+    }
+
+
 def _validate_export_references(
     *,
     claims: list[dict],
@@ -1317,6 +1369,7 @@ def _validate_export_references(
     course_info: dict | None,
     evidence_snippets: list[dict],
     derivation_chains: list[dict] | None = None,
+    completeness_reports: list[dict] | None = None,
 ) -> dict:
     errors: list[dict] = []
     warnings: list[dict] = []
@@ -1462,12 +1515,51 @@ def _validate_export_references(
             check_refs(step_claims, claim_ids, "derivations/derivation_chains.json", f"{path}.claim_ids", "claim")
             check_refs(step_evidence, evidence_ids, "derivations/derivation_chains.json", f"{path}.source_evidence_ids", "evidence")
 
+    # Document completeness gate (#366): a truncated ingest (missing equation
+    # labels, absent Conclusion, low page coverage) is surfaced as warnings so
+    # the bundle is exportable for review but never promoted to publish_ready.
+    completeness = _build_completeness_report(completeness_reports)
+    for doc in completeness["documents"]:
+        if doc["complete"]:
+            continue
+        doc_id = doc.get("document_id") or ""
+        if doc["missing_equation_labels"]:
+            warn(
+                "DOCUMENT_EQUATION_LABEL_DISCONTINUITY",
+                f"document {doc_id!r} is missing equation labels {doc['missing_equation_labels']}",
+                "document_boundary.json",
+                "$.completeness.equation_label_continuity",
+                doc_id,
+            )
+        if not doc["terminal_section_present"]:
+            warn(
+                "DOCUMENT_TERMINAL_SECTION_MISSING",
+                f"document {doc_id!r} has no terminal (Conclusion/Summary) section; ingest may be truncated",
+                "document_boundary.json",
+                "$.completeness.terminal_section",
+                doc_id,
+            )
+        if "page_coverage_insufficient" in doc["review_reasons"]:
+            warn(
+                "DOCUMENT_PAGE_COVERAGE_INSUFFICIENT",
+                (
+                    f"document {doc_id!r} ingested pages {doc['ingested_pages']} cover only "
+                    f"{doc['page_coverage_ratio']} of {doc['pages_total']} pages"
+                ),
+                "document_boundary.json",
+                "$.completeness.page_coverage",
+                doc_id,
+            )
+
+    publish_ready = not errors and not warnings and completeness["all_documents_complete"]
+
     return {
         "status": "failed_validation" if errors else "passed",
         "exportable": not errors,
-        "publish_ready": not errors and not warnings,
+        "publish_ready": publish_ready,
         "errors": errors,
         "warnings": warnings,
+        "completeness": completeness,
         "summary": {"error_count": len(errors), "warning_count": len(warnings), "unresolved_reference_count": len(errors)},
     }
 
@@ -1550,7 +1642,8 @@ This ZIP contains machine-readable outputs generated by episteme-graph.
 - `equations/equations.json`: first-class equation registry. Each entry has `latex`, `plain_text`, `source_location`, `equation_type`, `defined_symbols`, `used_symbols`, `input_equation_ids`, `output_equation_ids`, `extraction_source`, `extraction_status`, `needs_math_review`, `review_reason`, `candidate_trace_ids`.
 - `equations/equation_candidates.json`: audit trail for equation candidate detection. Each entry records `raw_text`, `source_location`, `detection_method`, `matched_label`, `acceptance_status`, `accepted_equation_id`, `rejection_reason`.
 - `derivations/derivation_chains.json`: derivation steps linking equations / claims with `operation`, `input_equation_ids`, `output_equation_ids`, `assumption_refs`.
-- `document_boundary.json`: per-document active article boundary (page_start, page_end, confidence, needs_review). Useful for multi-article PDFs (journal scans, conference proceedings).
+- `document_boundary.json`: per-document active article boundary (page_start, page_end, confidence, needs_review). Useful for multi-article PDFs (journal scans, conference proceedings). A collapsed boundary (span ≪ pages_total) or reference-author contamination drops confidence below 1.0 and raises needs_review. A `completeness` block reports equation-label continuity, terminal-section presence, and page coverage.
+- `export_validation.json`: deterministic cross-artifact validation. The `completeness` section aggregates per-document ingest completeness (missing equation labels, un-ingested page coverage, terminal-section presence); an incomplete document keeps the bundle out of `publish_ready`.
 
 ## Data Model Summary
 
@@ -1714,6 +1807,7 @@ def export_course_bundle(
         equation_candidates = _build_equation_candidates_for_documents(artifacts_by_doc, document_ids)
         derivation_chains = _build_derivations_for_documents(artifacts_by_doc, document_ids)
         document_boundaries = _build_document_boundaries(artifacts_by_doc, document_ids)
+        completeness_reports = _build_document_completeness_reports(artifacts_by_doc, document_ids)
         course = _enrich_course_for_export(course, artifacts_by_doc, document_ids)
         _normalize_export_references(
             claims=claims,
@@ -1748,6 +1842,7 @@ def export_course_bundle(
             course_info=course,
             evidence_snippets=evidence_snippets,
             derivation_chains=derivation_chains,
+            completeness_reports=completeness_reports,
         )
 
         docs = _load_course_documents(session, course_id, document_ids)
@@ -1840,6 +1935,7 @@ def export_document_bundle(
         equation_candidates = _build_equation_candidates_for_documents(artifacts_by_doc, document_ids)
         derivation_chains = _build_derivations_for_documents(artifacts_by_doc, document_ids)
         document_boundaries = _build_document_boundaries(artifacts_by_doc, document_ids)
+        completeness_reports = _build_document_completeness_reports(artifacts_by_doc, document_ids)
         document = _enrich_course_for_export(document, artifacts_by_doc, document_ids)
         _normalize_export_references(
             claims=claims,
@@ -1874,6 +1970,7 @@ def export_document_bundle(
             course_info=document,
             evidence_snippets=evidence_snippets,
             derivation_chains=derivation_chains,
+            completeness_reports=completeness_reports,
         )
 
         eid = _export_id("document", document_id)

--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -383,7 +383,11 @@ def _build_document_boundaries(
         structure = artifacts.get("document_structure")
         if not structure:
             continue
-        out.append(build_document_boundary(structure, document_id=doc_id))
+        out.append(build_document_boundary(
+            structure,
+            document_id=doc_id,
+            evidence_artifact=artifacts.get("evidence_registry"),
+        ))
     return out
 
 
@@ -398,7 +402,11 @@ def _build_document_completeness_reports(
         structure = artifacts.get("document_structure")
         if not structure:
             continue
-        out.append(build_document_completeness(structure, document_id=doc_id))
+        out.append(build_document_completeness(
+            structure,
+            document_id=doc_id,
+            evidence_artifact=artifacts.get("evidence_registry"),
+        ))
     return out
 
 
@@ -1350,6 +1358,7 @@ def _build_completeness_report(completeness_reports: list[dict] | None) -> dict:
             "missing_equation_labels": list(eq.get("missing_labels") or []),
             "terminal_section_present": bool(terminal.get("present")),
             "ingested_pages": list(coverage.get("ingested_pages") or []),
+            "uningested_page_ranges": list(coverage.get("missing_pages") or []),
             "pages_total": coverage.get("pages_total"),
             "page_coverage_ratio": coverage.get("coverage_ratio"),
         })

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -949,223 +949,121 @@ def enrich_course_topics(
 # Document boundary + completeness (issue #366)
 # ---------------------------------------------------------------------------
 
+def _load_completeness_analyzer():
+    """Resolve ``analyze_document_completeness`` without forcing the heavy import.
+
+    Importing ``core.document_pipeline.completeness`` triggers the package
+    ``__init__`` (orchestrator → agents), which is not always importable from the
+    export route's environment. Try the package import first, then fall back to
+    loading the dependency-free leaf module directly by path.
+    """
+    try:
+        from core.document_pipeline.completeness import analyze_document_completeness
+        return analyze_document_completeness
+    except Exception:
+        import importlib.util
+        import os
+
+        path = os.path.normpath(os.path.join(
+            os.path.dirname(__file__), "..", "..",
+            "core", "document_pipeline", "completeness.py",
+        ))
+        spec = importlib.util.spec_from_file_location("_dp_completeness", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.analyze_document_completeness
+
+
 # A detected boundary spanning far fewer pages than the document total is a
 # collapsed boundary (issue #366: a 20-page paper reported as page 1..1). The
 # boundary must not pass at confidence 1.0 / needs_review=false in that case.
 _MIN_BOUNDARY_PAGE_SPAN_RATIO = 0.5
 
-# Ingested blocks clustered on a small fraction of the document's pages signal a
-# truncated ingest (issue #366: evidence only on pages 1 and 3 of 20).
-_MIN_PAGE_COVERAGE_RATIO = 0.5
-
-# Page-coverage is only meaningful once enough blocks were ingested; a 2-block
-# stub legitimately cannot cover many pages.
-_MIN_BLOCKS_FOR_PAGE_COVERAGE = 8
-
 # An author list far larger than any plausible byline indicates reference /
 # bibliography authors leaked into the document authors (issue #366).
 _MAX_PLAUSIBLE_AUTHORS = 25
 
-# Equation labels such as "(3.36)" / "3.36" / "(12)". Grouped by an optional
-# major section number so continuity is checked within each section.
-_EQUATION_LABEL_RE = re.compile(r"^\(?\s*(?:(\d+)\.)?(\d+)\s*\)?$")
 
-# Terminal / wrap-up section headings whose absence means the document tail was
-# not ingested (issue #366: the Conclusion section was missing entirely).
-_TERMINAL_SECTION_RE = re.compile(
-    r"\b(conclusion|conclusions|concluding|summary|discussion|outlook|"
-    r"final remarks|closing remarks)\b|結論|まとめ|結言|総括|考察",
-    re.IGNORECASE | re.UNICODE,
-)
+def _name_tokens(name: str) -> list[str]:
+    return [t for t in re.split(r"[^a-zà-öø-ÿ]+", str(name).lower()) if len(t) >= 2]
 
 
-def _reference_author_tokens(blocks: list) -> set[str]:
-    """Lower-cased word tokens appearing inside reference / bibliography blocks.
+def _block_author_tokens(blocks: list, *, reference_only: bool) -> set[str]:
+    """Lower-cased word tokens appearing in reference (or non-reference) blocks.
 
-    Used to strip bibliography authors that leaked into the document authors:
-    a real byline author normally does not appear verbatim inside the paper's
-    own reference list, while leaked citation authors do.
+    Used to strip bibliography authors that leaked into the document authors
+    while protecting names that also occur in the front matter / body (e.g. a
+    self-citing author), which must never be removed.
     """
     tokens: set[str] = set()
     for b in blocks if isinstance(blocks, list) else []:
         if not isinstance(b, dict):
             continue
-        if b.get("block_type") != "reference_entry":
+        is_ref = b.get("block_type") == "reference_entry"
+        if is_ref != reference_only:
             continue
-        text = str(b.get("text") or "").lower()
-        for tok in re.split(r"[^a-zà-öø-ÿ]+", text):
-            if len(tok) >= 2:
-                tokens.add(tok)
+        tokens.update(_name_tokens(str(b.get("text") or "")))
     return tokens
 
 
 def _filter_reference_authors(authors: list, blocks: list) -> tuple[list[str], bool]:
     """Drop bibliography authors that leaked into the document author list.
 
-    Returns the filtered authors and a flag indicating whether any contamination
-    was detected (either names matched against reference blocks or the raw list
-    exceeded any plausible byline size).
+    A name is dropped only when every alphabetic token appears in the reference
+    list *and* the name does not also appear in a non-reference block (so a
+    self-citing real author is kept). A non-empty author list never collapses to
+    empty: if filtering would remove everything, the original list is kept and
+    flagged for review instead of silently deleting all authors (#366 review).
     """
     raw = [str(a).strip() for a in (authors or []) if str(a).strip()]
     if not raw:
         return [], False
 
-    ref_tokens = _reference_author_tokens(blocks)
+    ref_tokens = _block_author_tokens(blocks, reference_only=True)
+    non_ref_tokens = _block_author_tokens(blocks, reference_only=False)
     filtered: list[str] = []
     for name in raw:
-        name_tokens = [
-            t for t in re.split(r"[^a-zà-öø-ÿ]+", name.lower()) if len(t) >= 2
-        ]
-        # A name whose every alphabetic token also appears in the reference list
-        # is treated as a leaked citation author and dropped.
-        if name_tokens and all(t in ref_tokens for t in name_tokens):
+        toks = _name_tokens(name)
+        in_references = bool(toks) and all(t in ref_tokens for t in toks)
+        in_document_body = bool(toks) and all(t in non_ref_tokens for t in toks)
+        if in_references and not in_document_body:
             continue
         filtered.append(name)
 
+    if not filtered:
+        # Never delete every author from a non-empty list; flag for review.
+        return raw, True
+
     contaminated = len(filtered) != len(raw) or len(raw) > _MAX_PLAUSIBLE_AUTHORS
-    # If the list is still implausibly large the boundary stays flagged; we keep
-    # the (already reference-filtered) names rather than guessing a cutoff.
     return filtered, contaminated
-
-
-def _parse_equation_label(label: Any) -> tuple[int, int] | None:
-    """Parse an equation label into a (major, minor) ordinal pair, or None."""
-    if label is None:
-        return None
-    m = _EQUATION_LABEL_RE.match(str(label).strip())
-    if not m:
-        return None
-    major = int(m.group(1)) if m.group(1) is not None else 0
-    minor = int(m.group(2))
-    return major, minor
 
 
 def build_document_completeness(
     structure_artifact: Any,
     *,
     document_id: str,
+    evidence_artifact: Any = None,
 ) -> dict:
     """Deterministic document-completeness report (issue #366).
 
-    Checks — without ground truth — whether the ingest looks truncated:
-      * equation label continuity: gaps in the per-section (N.1)…(N.k) sequence,
-      * terminal section presence: a Conclusion / Summary-like tail section,
-      * page coverage: ingested blocks should not cluster on a small fraction of
-        the document's pages.
-
-    Returns a JSON-serialisable report; ``complete`` is False (and
-    ``review_reasons`` is non-empty) when any check fails. No LLM is used.
+    Thin wrapper over ``core.document_pipeline.completeness`` so the export route
+    and the pipeline gate share one implementation. Imported lazily so importing
+    this module never hard-depends on the (sometimes stubbed) ``core`` package.
     """
-    structure = _coerce_dict(structure_artifact)
-    blocks = structure.get("blocks") or []
-    sections = structure.get("sections") or []
-    metadata = structure.get("metadata") or {}
-    pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
+    analyze_document_completeness = _load_completeness_analyzer()
 
-    # --- equation label continuity -----------------------------------------
-    by_major: dict[int, set[int]] = {}
-    observed_labels: list[str] = []
-    for b in blocks if isinstance(blocks, list) else []:
-        if not isinstance(b, dict):
-            continue
-        if b.get("block_type") != "equation_block":
-            continue
-        parsed = _parse_equation_label(b.get("equation_label"))
-        if parsed is None:
-            continue
-        major, minor = parsed
-        by_major.setdefault(major, set()).add(minor)
-        observed_labels.append(str(b.get("equation_label")).strip())
-
-    missing_labels: list[str] = []
-    for major, minors in by_major.items():
-        if not minors:
-            continue
-        for minor in range(1, max(minors)):
-            if minor not in minors:
-                missing_labels.append(
-                    f"({major}.{minor})" if major else f"({minor})"
-                )
-    missing_labels.sort()
-    equation_has_gaps = bool(missing_labels)
-
-    # --- terminal section presence ------------------------------------------
-    terminal_titles: list[str] = []
-    for s in sections if isinstance(sections, list) else []:
-        if isinstance(s, dict) and _TERMINAL_SECTION_RE.search(str(s.get("title") or "")):
-            terminal_titles.append(str(s.get("title")))
-    for b in blocks if isinstance(blocks, list) else []:
-        if not isinstance(b, dict):
-            continue
-        if b.get("block_type") in ("section_heading", "subsection_heading") and (
-            _TERMINAL_SECTION_RE.search(str(b.get("text") or ""))
-        ):
-            terminal_titles.append(str(b.get("text")).strip())
-    has_sections = bool(sections) or any(
-        isinstance(b, dict)
-        and b.get("block_type") in ("section_heading", "subsection_heading")
-        for b in (blocks if isinstance(blocks, list) else [])
+    return analyze_document_completeness(
+        _coerce_dict(structure_artifact),
+        _coerce_dict(evidence_artifact) if evidence_artifact is not None else None,
+        document_id=document_id,
     )
-    terminal_present = bool(terminal_titles)
-    # Only treat a missing terminal section as a completeness gap when the
-    # document is structured enough to be expected to have one.
-    terminal_missing = has_sections and not terminal_present
-
-    # --- page coverage ------------------------------------------------------
-    block_pages = sorted(
-        {
-            int(b["page"])
-            for b in (blocks if isinstance(blocks, list) else [])
-            if isinstance(b, dict) and isinstance(b.get("page"), int)
-        }
-    )
-    distinct_page_count = len(block_pages)
-    coverage_ratio = None
-    coverage_sufficient = True
-    if isinstance(pages_total, int) and pages_total > 0:
-        coverage_ratio = round(distinct_page_count / pages_total, 4)
-        # Coverage is only judged once enough blocks were ingested; a small stub
-        # legitimately cannot cover many pages.
-        block_count = sum(1 for b in blocks if isinstance(b, dict))
-        if block_count >= _MIN_BLOCKS_FOR_PAGE_COVERAGE:
-            coverage_sufficient = coverage_ratio >= _MIN_PAGE_COVERAGE_RATIO
-
-    review_reasons: list[str] = []
-    if equation_has_gaps:
-        review_reasons.append("equation_label_discontinuity")
-    if terminal_missing:
-        review_reasons.append("terminal_section_missing")
-    if not coverage_sufficient:
-        review_reasons.append("page_coverage_insufficient")
-
-    return {
-        "document_id": document_id,
-        "complete": not review_reasons,
-        "review_reasons": review_reasons,
-        "equation_label_continuity": {
-            "observed_labels": observed_labels,
-            "missing_labels": missing_labels,
-            "has_gaps": equation_has_gaps,
-        },
-        "terminal_section": {
-            "present": terminal_present,
-            "missing": terminal_missing,
-            "matched_titles": terminal_titles,
-        },
-        "page_coverage": {
-            "ingested_pages": block_pages,
-            "distinct_page_count": distinct_page_count,
-            "pages_total": pages_total,
-            "coverage_ratio": coverage_ratio,
-            "sufficient": coverage_sufficient,
-        },
-    }
 
 
 def build_document_boundary(
     structure_artifact: Any,
     *,
     document_id: str,
+    evidence_artifact: Any = None,
 ) -> dict:
     """Surface the active article boundary inside a (potentially multi-article) PDF.
 
@@ -1175,9 +1073,9 @@ def build_document_boundary(
     consumers can flag spans that fall outside the boundary.
 
     Issue #366: a collapsed boundary (span ≪ pages_total) or reference-author
-    contamination must drop confidence below 1.0 and raise needs_review instead
-    of passing silently. An equation-label discontinuity in the completeness
-    report also propagates to needs_review.
+    contamination drops confidence below 1.0 and raises needs_review. Every
+    completeness failure (equation discontinuity, missing terminal section, low
+    page coverage) also propagates to needs_review.
     """
     structure = _coerce_dict(structure_artifact)
     sections = structure.get("sections") or []
@@ -1201,7 +1099,9 @@ def build_document_boundary(
     raw_authors = list(metadata.get("authors") or []) if isinstance(metadata, dict) else []
     authors, authors_contaminated = _filter_reference_authors(raw_authors, blocks)
 
-    completeness = build_document_completeness(structure, document_id=document_id)
+    completeness = build_document_completeness(
+        structure, document_id=document_id, evidence_artifact=evidence_artifact
+    )
 
     review_reasons: list[str] = []
     have_pages = boundary_page_start is not None and boundary_page_end is not None
@@ -1219,8 +1119,10 @@ def build_document_boundary(
     if authors_contaminated:
         review_reasons.append("reference_authors_in_author_list")
 
-    if completeness["equation_label_continuity"]["has_gaps"]:
-        review_reasons.append("equation_label_discontinuity")
+    # Every completeness failure propagates to the boundary (#366 review).
+    for reason in completeness["review_reasons"]:
+        if reason not in review_reasons:
+            review_reasons.append(reason)
 
     if not have_pages:
         confidence = 0.5

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -20,6 +20,7 @@ Issue #242 acceptance criteria:
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 ARTIFACTS_KEY = "_artifacts"
@@ -945,8 +946,220 @@ def enrich_course_topics(
 
 
 # ---------------------------------------------------------------------------
-# Document boundary
+# Document boundary + completeness (issue #366)
 # ---------------------------------------------------------------------------
+
+# A detected boundary spanning far fewer pages than the document total is a
+# collapsed boundary (issue #366: a 20-page paper reported as page 1..1). The
+# boundary must not pass at confidence 1.0 / needs_review=false in that case.
+_MIN_BOUNDARY_PAGE_SPAN_RATIO = 0.5
+
+# Ingested blocks clustered on a small fraction of the document's pages signal a
+# truncated ingest (issue #366: evidence only on pages 1 and 3 of 20).
+_MIN_PAGE_COVERAGE_RATIO = 0.5
+
+# Page-coverage is only meaningful once enough blocks were ingested; a 2-block
+# stub legitimately cannot cover many pages.
+_MIN_BLOCKS_FOR_PAGE_COVERAGE = 8
+
+# An author list far larger than any plausible byline indicates reference /
+# bibliography authors leaked into the document authors (issue #366).
+_MAX_PLAUSIBLE_AUTHORS = 25
+
+# Equation labels such as "(3.36)" / "3.36" / "(12)". Grouped by an optional
+# major section number so continuity is checked within each section.
+_EQUATION_LABEL_RE = re.compile(r"^\(?\s*(?:(\d+)\.)?(\d+)\s*\)?$")
+
+# Terminal / wrap-up section headings whose absence means the document tail was
+# not ingested (issue #366: the Conclusion section was missing entirely).
+_TERMINAL_SECTION_RE = re.compile(
+    r"\b(conclusion|conclusions|concluding|summary|discussion|outlook|"
+    r"final remarks|closing remarks)\b|結論|まとめ|結言|総括|考察",
+    re.IGNORECASE | re.UNICODE,
+)
+
+
+def _reference_author_tokens(blocks: list) -> set[str]:
+    """Lower-cased word tokens appearing inside reference / bibliography blocks.
+
+    Used to strip bibliography authors that leaked into the document authors:
+    a real byline author normally does not appear verbatim inside the paper's
+    own reference list, while leaked citation authors do.
+    """
+    tokens: set[str] = set()
+    for b in blocks if isinstance(blocks, list) else []:
+        if not isinstance(b, dict):
+            continue
+        if b.get("block_type") != "reference_entry":
+            continue
+        text = str(b.get("text") or "").lower()
+        for tok in re.split(r"[^a-zà-öø-ÿ]+", text):
+            if len(tok) >= 2:
+                tokens.add(tok)
+    return tokens
+
+
+def _filter_reference_authors(authors: list, blocks: list) -> tuple[list[str], bool]:
+    """Drop bibliography authors that leaked into the document author list.
+
+    Returns the filtered authors and a flag indicating whether any contamination
+    was detected (either names matched against reference blocks or the raw list
+    exceeded any plausible byline size).
+    """
+    raw = [str(a).strip() for a in (authors or []) if str(a).strip()]
+    if not raw:
+        return [], False
+
+    ref_tokens = _reference_author_tokens(blocks)
+    filtered: list[str] = []
+    for name in raw:
+        name_tokens = [
+            t for t in re.split(r"[^a-zà-öø-ÿ]+", name.lower()) if len(t) >= 2
+        ]
+        # A name whose every alphabetic token also appears in the reference list
+        # is treated as a leaked citation author and dropped.
+        if name_tokens and all(t in ref_tokens for t in name_tokens):
+            continue
+        filtered.append(name)
+
+    contaminated = len(filtered) != len(raw) or len(raw) > _MAX_PLAUSIBLE_AUTHORS
+    # If the list is still implausibly large the boundary stays flagged; we keep
+    # the (already reference-filtered) names rather than guessing a cutoff.
+    return filtered, contaminated
+
+
+def _parse_equation_label(label: Any) -> tuple[int, int] | None:
+    """Parse an equation label into a (major, minor) ordinal pair, or None."""
+    if label is None:
+        return None
+    m = _EQUATION_LABEL_RE.match(str(label).strip())
+    if not m:
+        return None
+    major = int(m.group(1)) if m.group(1) is not None else 0
+    minor = int(m.group(2))
+    return major, minor
+
+
+def build_document_completeness(
+    structure_artifact: Any,
+    *,
+    document_id: str,
+) -> dict:
+    """Deterministic document-completeness report (issue #366).
+
+    Checks — without ground truth — whether the ingest looks truncated:
+      * equation label continuity: gaps in the per-section (N.1)…(N.k) sequence,
+      * terminal section presence: a Conclusion / Summary-like tail section,
+      * page coverage: ingested blocks should not cluster on a small fraction of
+        the document's pages.
+
+    Returns a JSON-serialisable report; ``complete`` is False (and
+    ``review_reasons`` is non-empty) when any check fails. No LLM is used.
+    """
+    structure = _coerce_dict(structure_artifact)
+    blocks = structure.get("blocks") or []
+    sections = structure.get("sections") or []
+    metadata = structure.get("metadata") or {}
+    pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
+
+    # --- equation label continuity -----------------------------------------
+    by_major: dict[int, set[int]] = {}
+    observed_labels: list[str] = []
+    for b in blocks if isinstance(blocks, list) else []:
+        if not isinstance(b, dict):
+            continue
+        if b.get("block_type") != "equation_block":
+            continue
+        parsed = _parse_equation_label(b.get("equation_label"))
+        if parsed is None:
+            continue
+        major, minor = parsed
+        by_major.setdefault(major, set()).add(minor)
+        observed_labels.append(str(b.get("equation_label")).strip())
+
+    missing_labels: list[str] = []
+    for major, minors in by_major.items():
+        if not minors:
+            continue
+        for minor in range(1, max(minors)):
+            if minor not in minors:
+                missing_labels.append(
+                    f"({major}.{minor})" if major else f"({minor})"
+                )
+    missing_labels.sort()
+    equation_has_gaps = bool(missing_labels)
+
+    # --- terminal section presence ------------------------------------------
+    terminal_titles: list[str] = []
+    for s in sections if isinstance(sections, list) else []:
+        if isinstance(s, dict) and _TERMINAL_SECTION_RE.search(str(s.get("title") or "")):
+            terminal_titles.append(str(s.get("title")))
+    for b in blocks if isinstance(blocks, list) else []:
+        if not isinstance(b, dict):
+            continue
+        if b.get("block_type") in ("section_heading", "subsection_heading") and (
+            _TERMINAL_SECTION_RE.search(str(b.get("text") or ""))
+        ):
+            terminal_titles.append(str(b.get("text")).strip())
+    has_sections = bool(sections) or any(
+        isinstance(b, dict)
+        and b.get("block_type") in ("section_heading", "subsection_heading")
+        for b in (blocks if isinstance(blocks, list) else [])
+    )
+    terminal_present = bool(terminal_titles)
+    # Only treat a missing terminal section as a completeness gap when the
+    # document is structured enough to be expected to have one.
+    terminal_missing = has_sections and not terminal_present
+
+    # --- page coverage ------------------------------------------------------
+    block_pages = sorted(
+        {
+            int(b["page"])
+            for b in (blocks if isinstance(blocks, list) else [])
+            if isinstance(b, dict) and isinstance(b.get("page"), int)
+        }
+    )
+    distinct_page_count = len(block_pages)
+    coverage_ratio = None
+    coverage_sufficient = True
+    if isinstance(pages_total, int) and pages_total > 0:
+        coverage_ratio = round(distinct_page_count / pages_total, 4)
+        # Coverage is only judged once enough blocks were ingested; a small stub
+        # legitimately cannot cover many pages.
+        block_count = sum(1 for b in blocks if isinstance(b, dict))
+        if block_count >= _MIN_BLOCKS_FOR_PAGE_COVERAGE:
+            coverage_sufficient = coverage_ratio >= _MIN_PAGE_COVERAGE_RATIO
+
+    review_reasons: list[str] = []
+    if equation_has_gaps:
+        review_reasons.append("equation_label_discontinuity")
+    if terminal_missing:
+        review_reasons.append("terminal_section_missing")
+    if not coverage_sufficient:
+        review_reasons.append("page_coverage_insufficient")
+
+    return {
+        "document_id": document_id,
+        "complete": not review_reasons,
+        "review_reasons": review_reasons,
+        "equation_label_continuity": {
+            "observed_labels": observed_labels,
+            "missing_labels": missing_labels,
+            "has_gaps": equation_has_gaps,
+        },
+        "terminal_section": {
+            "present": terminal_present,
+            "missing": terminal_missing,
+            "matched_titles": terminal_titles,
+        },
+        "page_coverage": {
+            "ingested_pages": block_pages,
+            "distinct_page_count": distinct_page_count,
+            "pages_total": pages_total,
+            "coverage_ratio": coverage_ratio,
+            "sufficient": coverage_sufficient,
+        },
+    }
 
 
 def build_document_boundary(
@@ -960,9 +1173,15 @@ def build_document_boundary(
     first section's page_start as the article start and the last section's
     page_end as the article end, plus the title block when present, so
     consumers can flag spans that fall outside the boundary.
+
+    Issue #366: a collapsed boundary (span ≪ pages_total) or reference-author
+    contamination must drop confidence below 1.0 and raise needs_review instead
+    of passing silently. An equation-label discontinuity in the completeness
+    report also propagates to needs_review.
     """
     structure = _coerce_dict(structure_artifact)
     sections = structure.get("sections") or []
+    blocks = structure.get("blocks") or []
     metadata = structure.get("metadata") or {}
     pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
 
@@ -979,18 +1198,52 @@ def build_document_boundary(
         if s.get("section_id"):
             section_ids.append(s["section_id"])
 
-    confidence = 1.0 if (boundary_page_start is not None and boundary_page_end is not None) else 0.5
-    needs_review = confidence < 0.8
+    raw_authors = list(metadata.get("authors") or []) if isinstance(metadata, dict) else []
+    authors, authors_contaminated = _filter_reference_authors(raw_authors, blocks)
+
+    completeness = build_document_completeness(structure, document_id=document_id)
+
+    review_reasons: list[str] = []
+    have_pages = boundary_page_start is not None and boundary_page_end is not None
+    if not have_pages:
+        review_reasons.append("incomplete_section_page_range")
+
+    # Collapsed boundary: detected span far smaller than the document total.
+    boundary_span_collapsed = False
+    if have_pages and isinstance(pages_total, int) and pages_total > 0:
+        span_pages = int(boundary_page_end) - int(boundary_page_start) + 1
+        if span_pages < pages_total * _MIN_BOUNDARY_PAGE_SPAN_RATIO:
+            boundary_span_collapsed = True
+            review_reasons.append("boundary_page_span_too_small")
+
+    if authors_contaminated:
+        review_reasons.append("reference_authors_in_author_list")
+
+    if completeness["equation_label_continuity"]["has_gaps"]:
+        review_reasons.append("equation_label_discontinuity")
+
+    if not have_pages:
+        confidence = 0.5
+    elif boundary_span_collapsed:
+        # A collapsed boundary must never pass at full confidence (issue #366).
+        confidence = 0.4
+    elif review_reasons:
+        confidence = 0.7
+    else:
+        confidence = 1.0
+
+    needs_review = bool(review_reasons) or confidence < 0.8
 
     return {
         "document_id": document_id,
         "title": metadata.get("title") if isinstance(metadata, dict) else None,
-        "authors": list(metadata.get("authors") or []) if isinstance(metadata, dict) else [],
+        "authors": authors,
         "boundary_page_start": boundary_page_start,
         "boundary_page_end": boundary_page_end,
         "pages_total": pages_total,
         "active_section_ids": section_ids,
         "confidence": confidence,
         "needs_review": needs_review,
-        "review_reason": ([] if not needs_review else ["incomplete_section_page_range"]),
+        "review_reason": review_reasons,
+        "completeness": completeness,
     }

--- a/backend/core/document_pipeline/completeness.py
+++ b/backend/core/document_pipeline/completeness.py
@@ -1,0 +1,232 @@
+"""Deterministic document-completeness analysis (issue #366).
+
+A truncated PDF ingest — where the document's central results never reach the
+pipeline — is detectable without ground truth. This module performs that check
+with no LLM so both the pipeline ExportValidationGate and the export route can
+reuse it:
+
+  * equation label continuity — internal gaps in the per-section (N.1)…(N.k)
+    sequence, *and* labels referenced in prose (e.g. "Eq. (3.40)") that were
+    never ingested as equations (catches a tail truncation at (3.36)),
+  * terminal section presence — a Conclusion / Summary-like tail section,
+  * page coverage — ingested content (evidence when available, else content
+    blocks) must not cluster on a small fraction of the document's pages, and
+    the un-ingested page ranges are reported.
+
+`core` must not import FastAPI / route modules; this module stays dependency-free
+so the orchestrator can call it at the DocumentStructure / EvidenceRegistry exit.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Ingested content clustered on a small fraction of the document's pages signals
+# a truncated ingest (issue #366: evidence only on pages 1 and 3 of 20).
+MIN_PAGE_COVERAGE_RATIO = 0.5
+
+# Coverage / terminal-section checks are only meaningful once enough content was
+# ingested; a small stub legitimately cannot cover many pages or carry a
+# dedicated conclusion.
+MIN_CONTENT_BLOCKS_FOR_CHECKS = 8
+
+# A parsed equation label token: "(3.36)" / "3.36" / "(12)".
+_EQ_LABEL_RE = re.compile(r"^\(?\s*(?:(\d+)\.)?(\d+)\s*\)?$")
+
+# An equation label referenced inside prose: a parenthesised "(major.minor)".
+_EQ_REF_RE = re.compile(r"\((\d+)\.(\d+)\)")
+
+# Terminal / wrap-up section headings whose absence means the document tail was
+# not ingested (issue #366: the Conclusion section was missing entirely).
+_TERMINAL_SECTION_RE = re.compile(
+    r"\b(conclusion|conclusions|concluding|summary|discussion|outlook|"
+    r"final remarks|closing remarks)\b|結論|まとめ|結言|総括|考察",
+    re.IGNORECASE | re.UNICODE,
+)
+
+# Block types that carry ingested document content (page coverage is judged on
+# these; section headings spread thinly and would mask a truncated body).
+_CONTENT_BLOCK_TYPES = {
+    "body_paragraph",
+    "equation_block",
+    "figure_caption",
+    "table_caption",
+}
+
+
+def parse_equation_label(label: Any) -> tuple[int, int] | None:
+    """Parse an equation label into a (major, minor) ordinal pair, or None."""
+    if label is None:
+        return None
+    m = _EQ_LABEL_RE.match(str(label).strip())
+    if not m:
+        return None
+    major = int(m.group(1)) if m.group(1) is not None else 0
+    minor = int(m.group(2))
+    return major, minor
+
+
+def _label_text(major: int, minor: int) -> str:
+    return f"({major}.{minor})" if major else f"({minor})"
+
+
+def _compress_ranges(pages: list[int]) -> list[list[int]]:
+    """Compress a sorted page list into [start, end] inclusive ranges."""
+    ranges: list[list[int]] = []
+    for p in sorted(pages):
+        if ranges and p == ranges[-1][1] + 1:
+            ranges[-1][1] = p
+        else:
+            ranges.append([p, p])
+    return ranges
+
+
+def _evidence_pages(evidence: dict | None) -> set[int]:
+    pages: set[int] = set()
+    if not isinstance(evidence, dict):
+        return pages
+    for rec in evidence.get("records") or []:
+        if not isinstance(rec, dict):
+            continue
+        src = rec.get("source") if isinstance(rec.get("source"), dict) else {}
+        page = src.get("page")
+        if isinstance(page, int):
+            pages.add(page)
+    return pages
+
+
+def analyze_document_completeness(
+    structure: Any,
+    evidence: Any = None,
+    *,
+    document_id: str,
+) -> dict:
+    """Return a JSON-serialisable document-completeness report (issue #366).
+
+    ``structure`` is a DocumentStructureResult dict; ``evidence`` is an optional
+    EvidenceRegistryResult dict used to judge page coverage from actually
+    ingested evidence (falling back to content blocks). ``complete`` is False —
+    and ``review_reasons`` non-empty — when any check fails.
+    """
+    structure = structure if isinstance(structure, dict) else {}
+    evidence = evidence if isinstance(evidence, dict) else None
+    blocks = structure.get("blocks") or []
+    sections = structure.get("sections") or []
+    metadata = structure.get("metadata") or {}
+    pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
+
+    block_list = [b for b in blocks if isinstance(b, dict)]
+    content_blocks = [b for b in block_list if b.get("block_type") in _CONTENT_BLOCK_TYPES]
+    enough_content = len(content_blocks) >= MIN_CONTENT_BLOCKS_FOR_CHECKS
+
+    # --- equation label continuity ------------------------------------------
+    defined: dict[int, set[int]] = {}
+    observed_labels: list[str] = []
+    for b in block_list:
+        if b.get("block_type") != "equation_block":
+            continue
+        parsed = parse_equation_label(b.get("equation_label"))
+        if parsed is None:
+            continue
+        major, minor = parsed
+        defined.setdefault(major, set()).add(minor)
+        observed_labels.append(str(b.get("equation_label")).strip())
+
+    defined_pairs = {(maj, mn) for maj, mns in defined.items() for mn in mns}
+
+    # Labels referenced in prose but never ingested as equations. Restrict to
+    # major sections that DO have defined equations so figure / citation numbers
+    # from unrelated schemes are not mistaken for missing equations.
+    referenced_missing: set[tuple[int, int]] = set()
+    for b in block_list:
+        if b.get("block_type") == "equation_block":
+            continue
+        for m in _EQ_REF_RE.finditer(str(b.get("text") or "")):
+            pair = (int(m.group(1)), int(m.group(2)))
+            if pair[0] in defined and pair not in defined_pairs:
+                referenced_missing.add(pair)
+
+    missing_pairs: set[tuple[int, int]] = set(referenced_missing)
+    for major, minors in defined.items():
+        for minor in range(1, max(minors)):
+            if minor not in minors:
+                missing_pairs.add((major, minor))
+    missing_labels = [_label_text(maj, mn) for maj, mn in sorted(missing_pairs)]
+    equation_has_gaps = bool(missing_labels)
+
+    # --- terminal section presence ------------------------------------------
+    terminal_titles: list[str] = []
+    for s in sections if isinstance(sections, list) else []:
+        if isinstance(s, dict) and _TERMINAL_SECTION_RE.search(str(s.get("title") or "")):
+            terminal_titles.append(str(s.get("title")))
+    for b in block_list:
+        if b.get("block_type") in ("section_heading", "subsection_heading") and (
+            _TERMINAL_SECTION_RE.search(str(b.get("text") or ""))
+        ):
+            terminal_titles.append(str(b.get("text")).strip())
+    has_sections = bool(sections) or any(
+        b.get("block_type") in ("section_heading", "subsection_heading")
+        for b in block_list
+    )
+    terminal_present = bool(terminal_titles)
+    # Only expect a terminal section once the document is substantial enough.
+    terminal_missing = enough_content and has_sections and not terminal_present
+
+    # --- page coverage ------------------------------------------------------
+    source = "evidence" if evidence is not None else "content_blocks"
+    ev_pages = _evidence_pages(evidence)
+    if evidence is not None:
+        ingested = ev_pages
+    else:
+        ingested = {
+            int(b["page"]) for b in content_blocks if isinstance(b.get("page"), int)
+        }
+    ingested_pages = sorted(ingested)
+    distinct_page_count = len(ingested_pages)
+    coverage_ratio = None
+    missing_pages: list[list[int]] = []
+    coverage_sufficient = True
+    if isinstance(pages_total, int) and pages_total > 0:
+        coverage_ratio = round(distinct_page_count / pages_total, 4)
+        missing_pages = _compress_ranges(
+            [p for p in range(1, pages_total + 1) if p not in ingested]
+        )
+        # Coverage is only judged once enough content was ingested.
+        if enough_content or (evidence is not None and distinct_page_count):
+            coverage_sufficient = coverage_ratio >= MIN_PAGE_COVERAGE_RATIO
+
+    review_reasons: list[str] = []
+    if equation_has_gaps:
+        review_reasons.append("equation_label_discontinuity")
+    if terminal_missing:
+        review_reasons.append("terminal_section_missing")
+    if not coverage_sufficient:
+        review_reasons.append("page_coverage_insufficient")
+
+    return {
+        "document_id": document_id,
+        "complete": not review_reasons,
+        "review_reasons": review_reasons,
+        "equation_label_continuity": {
+            "observed_labels": observed_labels,
+            "missing_labels": missing_labels,
+            "referenced_missing_labels": [
+                _label_text(maj, mn) for maj, mn in sorted(referenced_missing)
+            ],
+            "has_gaps": equation_has_gaps,
+        },
+        "terminal_section": {
+            "present": terminal_present,
+            "missing": terminal_missing,
+            "matched_titles": terminal_titles,
+        },
+        "page_coverage": {
+            "source": source,
+            "ingested_pages": ingested_pages,
+            "missing_pages": missing_pages,
+            "distinct_page_count": distinct_page_count,
+            "pages_total": pages_total,
+            "coverage_ratio": coverage_ratio,
+            "sufficient": coverage_sufficient,
+        },
+    }

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -609,21 +609,24 @@ class ExportValidationGate:
         the run cannot be promoted to publish_ready while its central results may
         be missing. Never a hard error.
         """
-        analyze_document_completeness = _load_completeness_analyzer()
-        if analyze_document_completeness is None:
-            return _empty_document_completeness()
-
         structure = artifacts.get("document_structure")
         if not isinstance(structure, dict) or not structure:
             return _empty_document_completeness()
         evidence = artifacts.get("evidence_registry")
         document_id = str(structure.get("document_id") or "")
 
-        report = analyze_document_completeness(
-            structure,
-            evidence if isinstance(evidence, dict) else None,
-            document_id=document_id,
-        )
+        # Prefer the report the orchestrator already computed at the stage exit;
+        # only recompute if it is absent (e.g. legacy / partial runs).
+        report = artifacts.get("document_completeness")
+        if not isinstance(report, dict) or not report:
+            analyze_document_completeness = _load_completeness_analyzer()
+            if analyze_document_completeness is None:
+                return _empty_document_completeness()
+            report = analyze_document_completeness(
+                structure,
+                evidence if isinstance(evidence, dict) else None,
+                document_id=document_id,
+            )
 
         result = _empty_document_completeness()
         result["checked"] = True

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -128,6 +128,46 @@ def _empty_teaching_output_validation() -> dict:
     }
 
 
+def _empty_document_completeness() -> dict:
+    # Document ingest completeness report (issue #366): aggregated per-document.
+    return {
+        "checked": False,
+        "all_documents_complete": True,
+        "documents": [],
+    }
+
+
+def _load_completeness_analyzer():
+    """Resolve analyze_document_completeness robustly (issue #366).
+
+    This module is imported both as part of the ``core.document_pipeline``
+    package (production) and as a standalone file via spec_from_file_location
+    (unit tests), where relative imports have no parent package. Try both, then
+    fall back to loading the sibling file directly by path.
+    """
+    try:
+        from .completeness import analyze_document_completeness
+        return analyze_document_completeness
+    except Exception:
+        pass
+    try:
+        from core.document_pipeline.completeness import analyze_document_completeness
+        return analyze_document_completeness
+    except Exception:
+        pass
+    try:
+        import importlib.util
+        import os
+
+        path = os.path.join(os.path.dirname(__file__), "completeness.py")
+        spec = importlib.util.spec_from_file_location("_dp_completeness", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.analyze_document_completeness
+    except Exception:
+        return None
+
+
 @dataclass
 class ExportValidationResult:
     status: str                          # one of EXPORT_STATUSES
@@ -151,6 +191,9 @@ class ExportValidationResult:
     # Thesis coverage report (issue #354): is the central thesis (and each
     # support_structure section) actually backed by the exported main graph?
     thesis_coverage: dict = field(default_factory=_empty_thesis_coverage)
+    # Document ingest completeness report (issue #366): did the source ingest
+    # capture the whole document (equations / terminal section / page coverage)?
+    document_completeness: dict = field(default_factory=_empty_document_completeness)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -504,6 +547,14 @@ class ExportValidationGate:
             artifacts, component_result, claim_objects, review_items
         )
 
+        # 7h. document completeness gate (#366): a truncated ingest (missing
+        # equations, no Conclusion, low page coverage) at the DocumentStructure /
+        # EvidenceRegistry exit. Reported as warnings so the run stays exportable
+        # for review but is never promoted to publish_ready.
+        document_completeness = self._check_document_completeness(
+            artifacts, warnings
+        )
+
         # 6. Determine status
         summary = ValidationSummary(
             error_count=len(errors),
@@ -543,11 +594,82 @@ class ExportValidationGate:
             theory_bundle_validation=theory_bundle_validation,
             teaching_output_validation=teaching_output_validation,
             thesis_coverage=thesis_coverage,
+            document_completeness=document_completeness,
         )
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _check_document_completeness(self, artifacts: dict, warnings: list) -> dict:
+        """Deterministic ingest-completeness check at the structure exit (#366).
+
+        Runs the shared completeness analysis on the document_structure (and
+        evidence_registry) artifacts. Each incomplete document adds warnings so
+        the run cannot be promoted to publish_ready while its central results may
+        be missing. Never a hard error.
+        """
+        analyze_document_completeness = _load_completeness_analyzer()
+        if analyze_document_completeness is None:
+            return _empty_document_completeness()
+
+        structure = artifacts.get("document_structure")
+        if not isinstance(structure, dict) or not structure:
+            return _empty_document_completeness()
+        evidence = artifacts.get("evidence_registry")
+        document_id = str(structure.get("document_id") or "")
+
+        report = analyze_document_completeness(
+            structure,
+            evidence if isinstance(evidence, dict) else None,
+            document_id=document_id,
+        )
+
+        result = _empty_document_completeness()
+        result["checked"] = True
+        result["all_documents_complete"] = bool(report.get("complete", True))
+        result["documents"] = [report]
+
+        if report.get("complete", True):
+            return result
+
+        eq = report.get("equation_label_continuity") or {}
+        coverage = report.get("page_coverage") or {}
+        if eq.get("missing_labels"):
+            warnings.append(ValidationEntry(
+                code="DOCUMENT_EQUATION_LABEL_DISCONTINUITY",
+                message=(
+                    f"document {document_id!r} is missing equation labels "
+                    f"{eq.get('missing_labels')}"
+                ),
+                artifact="document_structure",
+                path="$.completeness.equation_label_continuity",
+                source_stage="export_validation",
+            ))
+        if report.get("terminal_section", {}).get("missing"):
+            warnings.append(ValidationEntry(
+                code="DOCUMENT_TERMINAL_SECTION_MISSING",
+                message=(
+                    f"document {document_id!r} has no terminal (Conclusion/Summary) "
+                    "section; ingest may be truncated"
+                ),
+                artifact="document_structure",
+                path="$.completeness.terminal_section",
+                source_stage="export_validation",
+            ))
+        if not coverage.get("sufficient", True):
+            warnings.append(ValidationEntry(
+                code="DOCUMENT_PAGE_COVERAGE_INSUFFICIENT",
+                message=(
+                    f"document {document_id!r} ingested pages cover only "
+                    f"{coverage.get('coverage_ratio')} of {coverage.get('pages_total')} "
+                    f"pages; un-ingested ranges {coverage.get('missing_pages')}"
+                ),
+                artifact="evidence_registry" if evidence is not None else "document_structure",
+                path="$.completeness.page_coverage",
+                source_stage="export_validation",
+            ))
+        return result
 
     def _aggregate_artifact_issues(
         self,

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -567,8 +567,10 @@ def run_document_pipeline(
             "processed": 1,
         })
         # Document completeness check at the DocumentStructure / EvidenceRegistry
-        # exit (#366): record a deterministic ingest-completeness artifact so a
-        # truncated document is flagged before downstream stages consume it.
+        # exit (#366): record a deterministic ingest-completeness artifact and
+        # propagate failures into document_structure.validation_issues so the
+        # signal flows downstream (and a truncated document never silently
+        # reaches publish-ready).
         try:
             from .completeness import analyze_document_completeness
 
@@ -579,10 +581,12 @@ def run_document_pipeline(
             )
             save_artifact("document_completeness", completeness_report)
             if not completeness_report.get("complete", True):
+                reasons = completeness_report.get("review_reasons") or []
                 logger.warning(
-                    "document %s ingest looks incomplete: %s",
-                    document_id, completeness_report.get("review_reasons"),
+                    "document %s ingest looks incomplete: %s", document_id, reasons,
                 )
+                _propagate_completeness_to_structure(structure, reasons)
+                save_artifact("document_structure", structure)
         except Exception:
             logger.exception(
                 "document_completeness check failed (non-fatal): document=%s", document_id
@@ -1289,6 +1293,35 @@ def _to_plain_data(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: _to_plain_data(v) for k, v in value.items()}
     return value
+
+
+def _propagate_completeness_to_structure(structure: Any, review_reasons: list) -> None:
+    """Attach document-completeness failures to structure.validation_issues (#366).
+
+    Adds one warning ValidationIssue per completeness review reason (deduped by
+    rule_id) so the signal propagates to downstream stages and the export
+    validation gate instead of living only in a side artifact. Severity is
+    ``warning`` — an incomplete ingest blocks publish-ready but is not a hard
+    error. Best-effort: never raises into the pipeline.
+    """
+    issues = getattr(structure, "validation_issues", None)
+    if issues is None:
+        return
+    try:
+        from episteme_graph.agents.document_structure.schema import ValidationIssue
+    except Exception:
+        return
+    existing = {getattr(i, "rule_id", None) for i in issues}
+    for reason in review_reasons or []:
+        rule_id = f"document_completeness_{reason}"
+        if rule_id in existing:
+            continue
+        issues.append(ValidationIssue(
+            rule_id=rule_id,
+            severity="warning",
+            message=f"document ingest completeness: {reason}",
+        ))
+        existing.add(rule_id)
 
 
 def _from_source_chunks(value: list[dict]) -> list:

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -566,6 +566,27 @@ def run_document_pipeline(
             "total": 1,
             "processed": 1,
         })
+        # Document completeness check at the DocumentStructure / EvidenceRegistry
+        # exit (#366): record a deterministic ingest-completeness artifact so a
+        # truncated document is flagged before downstream stages consume it.
+        try:
+            from .completeness import analyze_document_completeness
+
+            completeness_report = analyze_document_completeness(
+                _to_plain_data(structure),
+                _to_plain_data(evidence),
+                document_id=document_id,
+            )
+            save_artifact("document_completeness", completeness_report)
+            if not completeness_report.get("complete", True):
+                logger.warning(
+                    "document %s ingest looks incomplete: %s",
+                    document_id, completeness_report.get("review_reasons"),
+                )
+        except Exception:
+            logger.exception(
+                "document_completeness check failed (non-fatal): document=%s", document_id
+            )
         if finish_target_stage("evidence_registry", {"records": len(getattr(evidence, "records", []) or []), "total": 1, "processed": 1}):
             return result
 

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -3,9 +3,13 @@
 Covers:
 - collapsed boundary detection (boundary_page_end ≪ pages_total) drops
   confidence below 1.0 and raises needs_review,
-- reference / bibliography authors are stripped from the document author list,
-- equation-label discontinuity, missing terminal section, and low page coverage
-  are surfaced in the completeness report,
+- bibliography authors leaked into the author list are stripped, while a
+  self-citing real author is preserved,
+- equation-label discontinuity (internal gaps AND tail truncation detected via
+  prose cross-references), missing terminal section, and low page coverage are
+  surfaced and propagate to the boundary needs_review,
+- page coverage is judged from EvidenceRegistry pages and reports un-ingested
+  page ranges,
 - a complete document produces no false positives,
 - export_validation.json carries the aggregated completeness report and is not
   promoted to publish_ready while a document is incomplete.
@@ -23,6 +27,18 @@ sys.path.insert(0, str(ROOT / "backend" / "api"))
 def _import_artifacts():
     from routes import export_artifacts  # type: ignore
     return export_artifacts
+
+
+def _import_completeness():
+    # Load the dependency-free leaf module directly so the test does not require
+    # the full pipeline package (orchestrator / agents) to be importable.
+    import importlib.util
+
+    path = ROOT / "backend" / "core" / "document_pipeline" / "completeness.py"
+    spec = importlib.util.spec_from_file_location("_dp_completeness_test", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.analyze_document_completeness
 
 
 def _import_export_module():
@@ -46,30 +62,25 @@ def _eq_block(block_id: str, page: int, label: str | None) -> dict:
     }
 
 
+def _para(block_id: str, page: int, text: str) -> dict:
+    return {"block_id": block_id, "page": page, "text": text,
+            "block_type": "body_paragraph", "section_id": "sec_body"}
+
+
 def _heading(block_id: str, page: int, text: str) -> dict:
-    return {
-        "block_id": block_id,
-        "page": page,
-        "text": text,
-        "block_type": "section_heading",
-        "section_id": block_id,
-    }
+    return {"block_id": block_id, "page": page, "text": text,
+            "block_type": "section_heading", "section_id": block_id}
 
 
 def _reference(block_id: str, page: int, text: str) -> dict:
-    return {
-        "block_id": block_id,
-        "page": page,
-        "text": text,
-        "block_type": "reference_entry",
-        "section_id": "sec_refs",
-    }
+    return {"block_id": block_id, "page": page, "text": text,
+            "block_type": "reference_entry", "section_id": "sec_refs"}
 
 
 def _complete_structure() -> dict:
     """A 6-page article: contiguous equations, a Conclusion, broad page coverage."""
     blocks = [_heading("h_intro", 1, "1 Introduction")]
-    # Contiguous equations (2.1)..(2.4) and (3.1)..(3.3) spread across pages.
+    blocks += [_para(f"p_{p}", p, "body text") for p in range(1, 7)]
     blocks += [_eq_block("eq_2_1", 2, "(2.1)"), _eq_block("eq_2_2", 2, "(2.2)")]
     blocks += [_eq_block("eq_2_3", 3, "(2.3)"), _eq_block("eq_2_4", 3, "(2.4)")]
     blocks += [_eq_block("eq_3_1", 4, "(3.1)"), _eq_block("eq_3_2", 4, "(3.2)")]
@@ -88,17 +99,24 @@ def _complete_structure() -> dict:
 
 
 def _truncated_structure() -> dict:
-    """Mirrors issue #366: 20-page paper truncated, all blocks on pages 1 & 3.
+    """Mirrors issue #366: a 20-page paper truncated at (3.36).
 
-    Equations stop at (3.36) with an internal gap, no Conclusion section, and the
-    document authors are contaminated with bibliography authors.
+    Equations (3.1)…(3.36) are ingested *contiguously* (no artificial internal
+    gap). The surviving introduction forward-references the kurtosis consistency
+    relations (3.38)–(3.40), which were never ingested — that is how the tail
+    truncation is detected. There is no Conclusion section and the author list is
+    contaminated with bibliography authors.
     """
     blocks = [_heading("h_intro", 1, "1 Introduction")]
-    # (3.1)..(3.36) but (3.5) is missing → discontinuity.
-    for minor in list(range(1, 5)) + list(range(6, 37)):
+    blocks.append(_para(
+        "p_intro", 1,
+        "We derive the skewness relation (3.38) and the kurtosis consistency "
+        "relations (3.39) and (3.40) below.",
+    ))
+    # Contiguous (3.1)..(3.36), all on pages 1 and 3 (truncated ingest).
+    for minor in range(1, 37):
         page = 1 if minor < 18 else 3
         blocks.append(_eq_block(f"eq_3_{minor}", page, f"(3.{minor})"))
-    # Bibliography authors leaked into the author list.
     blocks += [
         _reference("ref_1", 3, "Horndeski, G. W. Second-order scalar-tensor field equations."),
         _reference("ref_2", 3, "Lesgourgues, J. The Cosmic Linear Anisotropy Solving System."),
@@ -120,43 +138,75 @@ def _truncated_structure() -> dict:
     }
 
 
+def _evidence(pages: list[int]) -> dict:
+    return {
+        "document_id": "doc",
+        "records": [
+            {"evidence_id": f"ev_{i}", "source": {"page": p, "block_id": f"b_{i}"},
+             "evidence_text": "x"}
+            for i, p in enumerate(pages)
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
-# build_document_completeness
+# analyze_document_completeness (core)
 # ---------------------------------------------------------------------------
 
 class TestCompleteness:
     def test_complete_structure_has_no_false_positive(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        analyze = _import_completeness()
+        rep = analyze(_complete_structure(), None, document_id="doc_ok")
         assert rep["complete"] is True
         assert rep["review_reasons"] == []
         assert rep["equation_label_continuity"]["has_gaps"] is False
-        assert rep["equation_label_continuity"]["missing_labels"] == []
         assert rep["terminal_section"]["present"] is True
         assert rep["page_coverage"]["sufficient"] is True
 
-    def test_equation_label_gap_detected(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
-        assert rep["equation_label_continuity"]["has_gaps"] is True
-        assert "(3.5)" in rep["equation_label_continuity"]["missing_labels"]
+    def test_tail_truncation_detected_via_cross_reference(self):
+        analyze = _import_completeness()
+        rep = analyze(_truncated_structure(), None, document_id="doc_bad")
+        cont = rep["equation_label_continuity"]
+        # No internal gap exists; the gap is the un-ingested tail (3.37)..(3.40).
+        assert cont["has_gaps"] is True
+        for label in ("(3.38)", "(3.39)", "(3.40)"):
+            assert label in cont["missing_labels"]
+            assert label in cont["referenced_missing_labels"]
         assert "equation_label_discontinuity" in rep["review_reasons"]
 
+    def test_internal_gap_still_detected(self):
+        analyze = _import_completeness()
+        structure = _complete_structure()
+        # Drop (2.3) → internal gap.
+        structure["blocks"] = [b for b in structure["blocks"] if b.get("block_id") != "eq_2_3"]
+        rep = analyze(structure, None, document_id="doc_gap")
+        assert "(2.3)" in rep["equation_label_continuity"]["missing_labels"]
+
     def test_missing_terminal_section_detected(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        analyze = _import_completeness()
+        rep = analyze(_truncated_structure(), None, document_id="doc_bad")
         assert rep["terminal_section"]["present"] is False
         assert "terminal_section_missing" in rep["review_reasons"]
 
-    def test_low_page_coverage_detected(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+    def test_page_coverage_from_evidence_and_uningested_ranges(self):
+        analyze = _import_completeness()
+        # Evidence only on pages 1 and 3 of 20 → insufficient, ranges reported.
+        rep = analyze(_truncated_structure(), _evidence([1, 3]), document_id="doc_bad")
         cov = rep["page_coverage"]
-        assert cov["pages_total"] == 20
-        assert cov["distinct_page_count"] < 20
+        assert cov["source"] == "evidence"
+        assert cov["ingested_pages"] == [1, 3]
         assert cov["sufficient"] is False
+        assert [2, 2] in cov["missing_pages"]
+        assert [4, 20] in cov["missing_pages"]
         assert "page_coverage_insufficient" in rep["review_reasons"]
-        assert rep["complete"] is False
+
+    def test_wide_heading_spread_does_not_mask_truncated_evidence(self):
+        analyze = _import_completeness()
+        # Headings span every page, but evidence sits on pages 1 and 3 only.
+        structure = _truncated_structure()
+        structure["blocks"] += [_heading(f"h_{p}", p, f"Section {p}") for p in range(1, 21)]
+        rep = analyze(structure, _evidence([1, 3]), document_id="doc_bad")
+        assert rep["page_coverage"]["sufficient"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -180,10 +230,45 @@ class TestBoundaryFixes:
         assert "Horndeski" not in b["authors"]
         assert "reference_authors_in_author_list" in b["review_reason"]
 
-    def test_equation_gap_propagates_to_boundary_review(self):
+    def test_self_citing_author_is_preserved(self):
         ea = _import_artifacts()
-        b = ea.build_document_boundary(_truncated_structure(), document_id="doc_bad")
-        assert "equation_label_discontinuity" in b["review_reason"]
+        structure = {
+            "blocks": [
+                _para("byline", 1, "Alice Smith"),
+                _reference("r1", 9, "Alice Smith. A prior result. 2019."),
+                _reference("r2", 9, "Bob Other. Unrelated work. 2020."),
+            ],
+            "sections": [{"section_id": "s", "title": "Intro", "level": 1, "order": 0,
+                          "page_start": 1, "page_end": 9}],
+            "metadata": {"title": "T", "authors": ["Alice Smith"], "pages": 9},
+        }
+        b = ea.build_document_boundary(structure, document_id="doc_self")
+        assert b["authors"] == ["Alice Smith"]
+
+    def test_authors_never_emptied_from_nonempty_list(self):
+        ea = _import_artifacts()
+        # Author appears only in references (no byline block) — must not vanish.
+        structure = {
+            "blocks": [_reference("r1", 9, "Alice Smith. Prior result. 2019.")],
+            "sections": [{"section_id": "s", "title": "Intro", "level": 1, "order": 0,
+                          "page_start": 1, "page_end": 9}],
+            "metadata": {"title": "T", "authors": ["Alice Smith"], "pages": 9},
+        }
+        b = ea.build_document_boundary(structure, document_id="doc_self2")
+        assert b["authors"] == ["Alice Smith"]
+        assert "reference_authors_in_author_list" in b["review_reason"]
+
+    def test_all_completeness_failures_propagate_to_boundary(self):
+        ea = _import_artifacts()
+        # A doc that is complete on boundary span but missing a terminal section.
+        structure = _complete_structure()
+        structure["blocks"] = [b for b in structure["blocks"] if b.get("block_id") != "h_concl"]
+        structure["sections"] = [s for s in structure["sections"] if s["section_id"] != "h_concl"]
+        b = ea.build_document_boundary(structure, document_id="doc_noconcl")
+        assert b["completeness"]["complete"] is False
+        assert "terminal_section_missing" in b["review_reason"]
+        assert b["needs_review"] is True
+        assert b["confidence"] < 1.0
 
     def test_complete_boundary_stays_confident(self):
         ea = _import_artifacts()
@@ -213,17 +298,16 @@ class TestExportValidationCompleteness:
         )
 
     def test_export_validation_has_completeness_section(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        analyze = _import_completeness()
+        rep = analyze(_complete_structure(), None, document_id="doc_ok")
         ev = self._validate([rep])
-        assert "completeness" in ev
         assert ev["completeness"]["checked"] is True
         assert ev["completeness"]["all_documents_complete"] is True
         assert ev["publish_ready"] is True
 
     def test_incomplete_document_blocks_publish_ready(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        analyze = _import_completeness()
+        rep = analyze(_truncated_structure(), _evidence([1, 3]), document_id="doc_bad")
         ev = self._validate([rep])
         assert ev["completeness"]["all_documents_complete"] is False
         assert ev["publish_ready"] is False
@@ -231,17 +315,16 @@ class TestExportValidationCompleteness:
         assert "DOCUMENT_EQUATION_LABEL_DISCONTINUITY" in codes
         assert "DOCUMENT_TERMINAL_SECTION_MISSING" in codes
         assert "DOCUMENT_PAGE_COVERAGE_INSUFFICIENT" in codes
-        # The missing equation labels are reported for operators.
         doc = ev["completeness"]["documents"][0]
-        assert "(3.5)" in doc["missing_equation_labels"]
+        assert "(3.39)" in doc["missing_equation_labels"]
         assert doc["pages_total"] == 20
+        assert doc["uningested_page_ranges"]
 
     def test_complete_document_emits_no_completeness_warning(self):
-        ea = _import_artifacts()
-        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        analyze = _import_completeness()
+        rep = analyze(_complete_structure(), None, document_id="doc_ok")
         ev = self._validate([rep])
         completeness_codes = {
-            w["code"] for w in ev["warnings"]
-            if w["code"].startswith("DOCUMENT_")
+            w["code"] for w in ev["warnings"] if w["code"].startswith("DOCUMENT_")
         }
         assert completeness_codes == set()

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -1,0 +1,247 @@
+"""Tests for issue #366: document completeness gate + document_boundary fixes.
+
+Covers:
+- collapsed boundary detection (boundary_page_end ≪ pages_total) drops
+  confidence below 1.0 and raises needs_review,
+- reference / bibliography authors are stripped from the document author list,
+- equation-label discontinuity, missing terminal section, and low page coverage
+  are surfaced in the completeness report,
+- a complete document produces no false positives,
+- export_validation.json carries the aggregated completeness report and is not
+  promoted to publish_ready while a document is incomplete.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "backend"))
+sys.path.insert(0, str(ROOT / "backend" / "api"))
+
+
+def _import_artifacts():
+    from routes import export_artifacts  # type: ignore
+    return export_artifacts
+
+
+def _import_export_module():
+    sys.path.insert(0, str(ROOT / "backend" / "tests"))
+    from test_export_bundle import _import_export_module as _impl  # type: ignore
+    return _impl()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — a complete and a truncated structure artifact
+# ---------------------------------------------------------------------------
+
+def _eq_block(block_id: str, page: int, label: str | None) -> dict:
+    return {
+        "block_id": block_id,
+        "page": page,
+        "text": "equation",
+        "block_type": "equation_block",
+        "section_id": "sec_body",
+        "equation_label": label,
+    }
+
+
+def _heading(block_id: str, page: int, text: str) -> dict:
+    return {
+        "block_id": block_id,
+        "page": page,
+        "text": text,
+        "block_type": "section_heading",
+        "section_id": block_id,
+    }
+
+
+def _reference(block_id: str, page: int, text: str) -> dict:
+    return {
+        "block_id": block_id,
+        "page": page,
+        "text": text,
+        "block_type": "reference_entry",
+        "section_id": "sec_refs",
+    }
+
+
+def _complete_structure() -> dict:
+    """A 6-page article: contiguous equations, a Conclusion, broad page coverage."""
+    blocks = [_heading("h_intro", 1, "1 Introduction")]
+    # Contiguous equations (2.1)..(2.4) and (3.1)..(3.3) spread across pages.
+    blocks += [_eq_block("eq_2_1", 2, "(2.1)"), _eq_block("eq_2_2", 2, "(2.2)")]
+    blocks += [_eq_block("eq_2_3", 3, "(2.3)"), _eq_block("eq_2_4", 3, "(2.4)")]
+    blocks += [_eq_block("eq_3_1", 4, "(3.1)"), _eq_block("eq_3_2", 4, "(3.2)")]
+    blocks += [_eq_block("eq_3_3", 5, "(3.3)")]
+    blocks += [_heading("h_concl", 6, "5 Conclusion")]
+    return {
+        "blocks": blocks,
+        "sections": [
+            {"section_id": "h_intro", "title": "1 Introduction", "level": 1,
+             "order": 0, "page_start": 1, "page_end": 5},
+            {"section_id": "h_concl", "title": "5 Conclusion", "level": 1,
+             "order": 1, "page_start": 6, "page_end": 6},
+        ],
+        "metadata": {"title": "Complete paper", "authors": ["Alice", "Bob"], "pages": 6},
+    }
+
+
+def _truncated_structure() -> dict:
+    """Mirrors issue #366: 20-page paper truncated, all blocks on pages 1 & 3.
+
+    Equations stop at (3.36) with an internal gap, no Conclusion section, and the
+    document authors are contaminated with bibliography authors.
+    """
+    blocks = [_heading("h_intro", 1, "1 Introduction")]
+    # (3.1)..(3.36) but (3.5) is missing → discontinuity.
+    for minor in list(range(1, 5)) + list(range(6, 37)):
+        page = 1 if minor < 18 else 3
+        blocks.append(_eq_block(f"eq_3_{minor}", page, f"(3.{minor})"))
+    # Bibliography authors leaked into the author list.
+    blocks += [
+        _reference("ref_1", 3, "Horndeski, G. W. Second-order scalar-tensor field equations."),
+        _reference("ref_2", 3, "Lesgourgues, J. The Cosmic Linear Anisotropy Solving System."),
+        _reference("ref_3", 3, "Deffayet, C. and Steer, D. A formal introduction to Horndeski."),
+    ]
+    real_authors = ["Taro Yamada", "Hanako Suzuki", "Jiro Tanaka", "Saburo Kato"]
+    leaked = ["Horndeski", "Lesgourgues", "Deffayet", "Steer"]
+    return {
+        "blocks": blocks,
+        "sections": [
+            {"section_id": "h_intro", "title": "1 Introduction", "level": 1,
+             "order": 0, "page_start": 1, "page_end": 1},
+        ],
+        "metadata": {
+            "title": "Kurtosis consistency relation",
+            "authors": real_authors + leaked,
+            "pages": 20,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_document_completeness
+# ---------------------------------------------------------------------------
+
+class TestCompleteness:
+    def test_complete_structure_has_no_false_positive(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        assert rep["complete"] is True
+        assert rep["review_reasons"] == []
+        assert rep["equation_label_continuity"]["has_gaps"] is False
+        assert rep["equation_label_continuity"]["missing_labels"] == []
+        assert rep["terminal_section"]["present"] is True
+        assert rep["page_coverage"]["sufficient"] is True
+
+    def test_equation_label_gap_detected(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        assert rep["equation_label_continuity"]["has_gaps"] is True
+        assert "(3.5)" in rep["equation_label_continuity"]["missing_labels"]
+        assert "equation_label_discontinuity" in rep["review_reasons"]
+
+    def test_missing_terminal_section_detected(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        assert rep["terminal_section"]["present"] is False
+        assert "terminal_section_missing" in rep["review_reasons"]
+
+    def test_low_page_coverage_detected(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        cov = rep["page_coverage"]
+        assert cov["pages_total"] == 20
+        assert cov["distinct_page_count"] < 20
+        assert cov["sufficient"] is False
+        assert "page_coverage_insufficient" in rep["review_reasons"]
+        assert rep["complete"] is False
+
+
+# ---------------------------------------------------------------------------
+# build_document_boundary
+# ---------------------------------------------------------------------------
+
+class TestBoundaryFixes:
+    def test_collapsed_boundary_flags_review_and_lowers_confidence(self):
+        ea = _import_artifacts()
+        b = ea.build_document_boundary(_truncated_structure(), document_id="doc_bad")
+        assert b["pages_total"] == 20
+        assert b["boundary_page_end"] == 1
+        assert b["confidence"] < 1.0
+        assert b["needs_review"] is True
+        assert "boundary_page_span_too_small" in b["review_reason"]
+
+    def test_reference_authors_filtered_out(self):
+        ea = _import_artifacts()
+        b = ea.build_document_boundary(_truncated_structure(), document_id="doc_bad")
+        assert b["authors"] == ["Taro Yamada", "Hanako Suzuki", "Jiro Tanaka", "Saburo Kato"]
+        assert "Horndeski" not in b["authors"]
+        assert "reference_authors_in_author_list" in b["review_reason"]
+
+    def test_equation_gap_propagates_to_boundary_review(self):
+        ea = _import_artifacts()
+        b = ea.build_document_boundary(_truncated_structure(), document_id="doc_bad")
+        assert "equation_label_discontinuity" in b["review_reason"]
+
+    def test_complete_boundary_stays_confident(self):
+        ea = _import_artifacts()
+        b = ea.build_document_boundary(_complete_structure(), document_id="doc_ok")
+        assert b["confidence"] == 1.0
+        assert b["needs_review"] is False
+        assert b["review_reason"] == []
+        assert b["authors"] == ["Alice", "Bob"]
+
+
+# ---------------------------------------------------------------------------
+# export_validation.json completeness section
+# ---------------------------------------------------------------------------
+
+class TestExportValidationCompleteness:
+    def _validate(self, completeness_reports):
+        mod = _import_export_module()
+        return mod._validate_export_references(
+            claims=[],
+            equations=[],
+            components=[],
+            component_graph={"edges": []},
+            course_info=None,
+            evidence_snippets=[],
+            derivation_chains=[],
+            completeness_reports=completeness_reports,
+        )
+
+    def test_export_validation_has_completeness_section(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        ev = self._validate([rep])
+        assert "completeness" in ev
+        assert ev["completeness"]["checked"] is True
+        assert ev["completeness"]["all_documents_complete"] is True
+        assert ev["publish_ready"] is True
+
+    def test_incomplete_document_blocks_publish_ready(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_truncated_structure(), document_id="doc_bad")
+        ev = self._validate([rep])
+        assert ev["completeness"]["all_documents_complete"] is False
+        assert ev["publish_ready"] is False
+        codes = {w["code"] for w in ev["warnings"]}
+        assert "DOCUMENT_EQUATION_LABEL_DISCONTINUITY" in codes
+        assert "DOCUMENT_TERMINAL_SECTION_MISSING" in codes
+        assert "DOCUMENT_PAGE_COVERAGE_INSUFFICIENT" in codes
+        # The missing equation labels are reported for operators.
+        doc = ev["completeness"]["documents"][0]
+        assert "(3.5)" in doc["missing_equation_labels"]
+        assert doc["pages_total"] == 20
+
+    def test_complete_document_emits_no_completeness_warning(self):
+        ea = _import_artifacts()
+        rep = ea.build_document_completeness(_complete_structure(), document_id="doc_ok")
+        ev = self._validate([rep])
+        completeness_codes = {
+            w["code"] for w in ev["warnings"]
+            if w["code"].startswith("DOCUMENT_")
+        }
+        assert completeness_codes == set()

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -47,6 +47,19 @@ def _import_export_module():
     return _impl()
 
 
+def _import_gate():
+    # Load the gate standalone (no heavy package __init__); register in
+    # sys.modules so its dataclasses resolve their annotations.
+    import importlib.util
+
+    path = ROOT / "backend" / "core" / "document_pipeline" / "export_validation_gate.py"
+    spec = importlib.util.spec_from_file_location("export_validation_gate", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["export_validation_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
 # ---------------------------------------------------------------------------
 # Fixtures — a complete and a truncated structure artifact
 # ---------------------------------------------------------------------------
@@ -328,3 +341,66 @@ class TestExportValidationCompleteness:
             w["code"] for w in ev["warnings"] if w["code"].startswith("DOCUMENT_")
         }
         assert completeness_codes == set()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline ExportValidationGate runs the completeness check at the stage exit
+# ---------------------------------------------------------------------------
+
+class TestPipelineGateCompleteness:
+    def _struct_dict(self, structure: dict, document_id: str) -> dict:
+        d = dict(structure)
+        d["document_id"] = document_id
+        d.setdefault("validation_issues", [])
+        return d
+
+    def test_gate_flags_incomplete_document(self):
+        mod = _import_gate()
+        artifacts = {
+            "document_structure": self._struct_dict(_truncated_structure(), "doc_bad"),
+            "evidence_registry": _evidence([1, 3]),
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        dc = res["document_completeness"]
+        assert dc["checked"] is True
+        assert dc["all_documents_complete"] is False
+        assert res["publish_ready"] is False
+        codes = {w["code"] for w in res["warnings"]}
+        assert "DOCUMENT_EQUATION_LABEL_DISCONTINUITY" in codes
+        assert "DOCUMENT_TERMINAL_SECTION_MISSING" in codes
+        assert "DOCUMENT_PAGE_COVERAGE_INSUFFICIENT" in codes
+
+    def test_gate_passes_complete_document(self):
+        mod = _import_gate()
+        artifacts = {
+            "document_structure": self._struct_dict(_complete_structure(), "doc_ok"),
+            "evidence_registry": _evidence([1, 2, 3, 4, 5, 6]),
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        dc = res["document_completeness"]
+        assert dc["all_documents_complete"] is True
+        completeness_codes = {
+            w["code"] for w in res["warnings"] if w["code"].startswith("DOCUMENT_")
+        }
+        assert completeness_codes == set()
+
+    def test_gate_prefers_precomputed_completeness_artifact(self):
+        mod = _import_gate()
+        # A structure that would look complete, but an orchestrator-computed
+        # artifact marks it incomplete: the gate must honour the artifact.
+        precomputed = {
+            "document_id": "doc_pre",
+            "complete": False,
+            "review_reasons": ["terminal_section_missing"],
+            "equation_label_continuity": {"missing_labels": [], "has_gaps": False},
+            "terminal_section": {"present": False, "missing": True, "matched_titles": []},
+            "page_coverage": {"sufficient": True, "coverage_ratio": 1.0, "pages_total": 6,
+                              "ingested_pages": [1, 2, 3, 4, 5, 6], "missing_pages": []},
+        }
+        artifacts = {
+            "document_structure": self._struct_dict(_complete_structure(), "doc_pre"),
+            "document_completeness": precomputed,
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        assert res["document_completeness"]["all_documents_complete"] is False
+        assert "DOCUMENT_TERMINAL_SECTION_MISSING" in {w["code"] for w in res["warnings"]}


### PR DESCRIPTION
## Summary

Implements deterministic document-completeness detection (issue #366) to identify truncated ingests without ground truth. Adds three independent checks—equation-label continuity, terminal-section presence, and page coverage—and integrates them into the document boundary report. Also fixes reference-author contamination filtering and collapsed-boundary detection to prevent incomplete documents from passing at full confidence.

## Key Changes

### New Completeness Detection (`build_document_completeness`)
- **Equation-label continuity**: Detects gaps in per-section equation numbering (e.g., missing (3.5) in sequence (3.1)…(3.4)(3.6)…)
- **Terminal-section presence**: Checks for Conclusion/Summary/Discussion-like headings; flags their absence in structured documents
- **Page coverage**: Warns when ingested blocks cluster on <50% of document pages (e.g., all content on pages 1 & 3 of 20)
- Returns JSON report with `complete` flag and `review_reasons` list; no LLM required

### Document Boundary Enhancements (`build_document_boundary`)
- **Collapsed-boundary detection**: When detected span ≪ pages_total (e.g., pages 1–1 of 20), confidence drops to 0.4 and `needs_review` is raised
- **Reference-author filtering** (`_filter_reference_authors`): Strips bibliography authors that leaked into the document author list by matching against reference-block tokens; flags contamination
- **Completeness propagation**: Equation-label gaps from completeness report now propagate to boundary `review_reason`
- Confidence scoring: 1.0 (clean) → 0.7 (minor issues) → 0.4 (collapsed boundary) → 0.5 (no page range)

### Export Validation Integration
- New `_build_document_completeness_reports()` builds per-document completeness reports during export
- `_build_completeness_report()` aggregates reports into `export_validation.json` completeness section
- Incomplete documents (any `review_reason` present) block `publish_ready` promotion
- Warnings emitted for missing equation labels, absent terminal sections, and insufficient page coverage

### Test Coverage (`test_document_completeness.py`)
- Fixtures: complete 6-page article vs. truncated 20-page paper (issue #366 scenario)
- Tests for equation-gap detection, terminal-section presence, page-coverage ratio
- Boundary tests: collapsed-span detection, reference-author filtering, confidence scoring
- Export-validation tests: completeness section presence, publish_ready blocking, warning codes

## Implementation Details

- **Regex patterns**: `_EQUATION_LABEL_RE` matches (N.M) / N.M / (N) formats; `_TERMINAL_SECTION_RE` matches conclusion/summary/discussion in English and Japanese
- **Thresholds**: `_MIN_BOUNDARY_PAGE_SPAN_RATIO = 0.5`, `_MIN_PAGE_COVERAGE_RATIO = 0.5`, `_MIN_BLOCKS_FOR_PAGE_COVERAGE = 8`, `_MAX_PLAUSIBLE_AUTHORS = 25`
- **Author filtering**: Tokenizes author names and reference text (lowercase, alphabetic only, ≥2 chars); drops names whose every token appears in references
- **Deterministic**: No LLM calls; all checks are structural/statistical and reproducible

https://claude.ai/code/session_01RbfdcM5aXh7bCxbdgArPXU