### PR TITLE
Add deterministic equation reconstruction fidelity guards (issue #368)

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -137,6 +137,26 @@ def _empty_document_completeness() -> dict:
     }
 
 
+# Equation reconstruction fidelity reason codes (issue #368). Aggregated per
+# type with target ids + artifact paths in equation_fidelity.
+_EQUATION_FIDELITY_CODES = [
+    "latex_is_prose",
+    "invalid_equation_label",
+    "table_derived_equation_candidate",
+    "nonequation_id_in_links",
+    "symbol_loss_unverifiable",
+]
+
+
+def _empty_equation_fidelity() -> dict:
+    return {
+        "checked": False,
+        "total": 0,
+        "issue_counts": {code: 0 for code in _EQUATION_FIDELITY_CODES},
+        "issues": {code: [] for code in _EQUATION_FIDELITY_CODES},
+    }
+
+
 def _load_completeness_analyzer():
     """Resolve analyze_document_completeness robustly (issue #366).
 
@@ -194,6 +214,10 @@ class ExportValidationResult:
     # Document ingest completeness report (issue #366): did the source ingest
     # capture the whole document (equations / terminal section / page coverage)?
     document_completeness: dict = field(default_factory=_empty_document_completeness)
+    # Equation reconstruction fidelity report (issue #368): per-type counts,
+    # target equation/candidate ids and artifact paths for the fine-grained
+    # PDF math quality problems.
+    equation_fidelity: dict = field(default_factory=_empty_equation_fidelity)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -435,6 +459,13 @@ class ExportValidationGate:
         # 2. Equation consistency reporting
         self._check_equation_consistency_mismatches(artifacts, review_items, warnings)
         self._check_derivation_equation_confidence(artifacts, warnings, errors)
+        # 2b. Equation reconstruction fidelity reporting (issue #368): per-type
+        # counts + target ids + artifact paths for the fine-grained PDF math
+        # quality problems (prose LaTeX, invalid label, table-derived candidate,
+        # non-equation I/O link, unverifiable symbol loss).
+        equation_fidelity = self._check_equation_fidelity(
+            artifacts, review_items, warnings
+        )
 
         # 3. Cross-artifact ID validation
         if component_result and claim_objects and evidence:
@@ -595,6 +626,7 @@ class ExportValidationGate:
             teaching_output_validation=teaching_output_validation,
             thesis_coverage=thesis_coverage,
             document_completeness=document_completeness,
+            equation_fidelity=equation_fidelity,
         )
 
     # ------------------------------------------------------------------
@@ -1730,6 +1762,115 @@ class ExportValidationGate:
                 review_items.append(entry)
             else:
                 warnings.append(entry)
+
+    def _check_equation_fidelity(
+        self,
+        artifacts: dict,
+        review_items: list,
+        warnings: list,
+    ) -> dict:
+        """Aggregate equation reconstruction fidelity problems (issue #368).
+
+        Scans the equation_semantics artifact (accepted equations + candidates)
+        for the deterministic fidelity reason codes, producing per-type counts,
+        the target equation/candidate ids and the artifact path for each. The
+        underlying blocking (confidence_policy / equation_consistency) is decided
+        upstream; this is the cross-artifact observability report.
+
+        Codes that block confirmed downstream use are surfaced as review_items;
+        normalized / removed values (invalid_equation_label,
+        nonequation_id_in_links) are surfaced as warnings.
+        """
+        report = _empty_equation_fidelity()
+        raw = artifacts.get("equation_semantics")
+        if not isinstance(raw, dict):
+            return report
+        report["checked"] = True
+
+        # code -> bucket ("review_items" | "warnings")
+        bucket_for = {
+            "latex_is_prose": "review_items",
+            "table_derived_equation_candidate": "review_items",
+            "symbol_loss_unverifiable": "review_items",
+            "invalid_equation_label": "warnings",
+            "nonequation_id_in_links": "warnings",
+        }
+
+        def _record(code: str, target_kind: str, target_id: str, path: str) -> None:
+            if code not in report["issues"]:
+                return
+            report["issues"][code].append({
+                target_kind: target_id,
+                "artifact": "equation_semantics",
+                "path": path,
+            })
+            report["issue_counts"][code] += 1
+            report["total"] += 1
+            entry = ValidationEntry(
+                code=f"EQUATION_FIDELITY_{code.upper()}",
+                message=f"equation_semantics {target_kind} {target_id!r}: {code}",
+                artifact="equation_semantics",
+                path=path,
+                source_stage="export_validation",
+            )
+            if bucket_for.get(code) == "review_items":
+                review_items.append(entry)
+            else:
+                warnings.append(entry)
+
+        # --- accepted equations ---
+        equations = raw.get("equations") or []
+        if isinstance(equations, list):
+            for eq in equations:
+                if not isinstance(eq, dict):
+                    continue
+                eq_id = str(eq.get("equation_id") or "")
+                if not eq_id:
+                    continue
+                rec = eq.get("reconstruction") if isinstance(eq.get("reconstruction"), dict) else {}
+                consistency = (
+                    eq.get("equation_consistency")
+                    if isinstance(eq.get("equation_consistency"), dict)
+                    else {}
+                )
+                for code in self._codes_in(eq.get("review_reason")):
+                    if code in report["issues"]:
+                        _record(code, "equation_id", eq_id,
+                                f"$.equations[{eq_id}].review_reason")
+                for code in self._codes_in(rec.get("review_reason")):
+                    if code in report["issues"]:
+                        _record(code, "equation_id", eq_id,
+                                f"$.equations[{eq_id}].reconstruction.review_reason")
+                for code in self._codes_in(consistency.get("review_reason")):
+                    if code in report["issues"]:
+                        _record(code, "equation_id", eq_id,
+                                f"$.equations[{eq_id}].equation_consistency.review_reason")
+                for code in self._codes_in(eq.get("review_flags")):
+                    if code in report["issues"]:
+                        _record(code, "equation_id", eq_id,
+                                f"$.equations[{eq_id}].review_flags")
+
+        # --- candidates ---
+        candidates = raw.get("equation_candidates") or []
+        if isinstance(candidates, list):
+            for cand in candidates:
+                if not isinstance(cand, dict):
+                    continue
+                cand_id = str(cand.get("candidate_id") or "")
+                if not cand_id:
+                    continue
+                for code in self._codes_in(cand.get("review_reason")):
+                    if code in report["issues"]:
+                        _record(code, "candidate_id", cand_id,
+                                f"$.equation_candidates[{cand_id}].review_reason")
+
+        return report
+
+    @staticmethod
+    def _codes_in(values) -> list:
+        if not isinstance(values, list):
+            return []
+        return [str(v) for v in values if str(v) in _EQUATION_FIDELITY_CODES]
 
     def _check_dsl_edges(
         self,

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -72,9 +72,21 @@ class ComponentAssemblyAgent:
             evidence_registry=evidence_registry,
             derivations=derivations,
         )
-        diagnostics = {
-            "component_assembly_input_validation": _preflight_check(llm_input),
-        }
+        diagnostics: dict = {}
+        # Defensively strip dangling equation references (#368 follow-up): a
+        # claim / thesis / DSL ref to an equation absent from the final set must
+        # not collapse the whole assembly into a deterministic fallback.
+        equation_ref_cleanup = _strip_unavailable_equation_refs(llm_input)
+        if equation_ref_cleanup:
+            diagnostics["component_assembly_equation_ref_cleanup"] = equation_ref_cleanup
+            logger.warning(
+                "Stripped %d dangling equation reference(s) before component assembly: "
+                "document=%s equation_ids=%s",
+                len(equation_ref_cleanup),
+                qualified_claims.document_id,
+                sorted({r["equation_id"] for r in equation_ref_cleanup}),
+            )
+        diagnostics["component_assembly_input_validation"] = _preflight_check(llm_input)
         if diagnostics["component_assembly_input_validation"]["status"] == "failed":
             logger.warning(
                 "Component assembly input preflight failed: document=%s issue_codes=%s",
@@ -212,6 +224,75 @@ class ComponentAssemblyAgent:
                 "Cartridge '%s' not found; proceeding without cartridge", cartridge_id
             )
             return None
+
+
+def _strip_unavailable_equation_refs(llm_input: ComponentAssemblyLLMInput) -> list[dict]:
+    """Drop dangling equation_id references not present in available_equations.
+
+    A claim / thesis node / DSL node-or-edge may reference an equation_id that is
+    absent from the final equation set — e.g. LLM drift, or an equation that was
+    demoted / dropped upstream (table-derived candidate, prose reconstruction,
+    rejected label). Such a dangling reference must not collapse the whole
+    component assembly into a deterministic fallback (which then aborts the
+    pipeline at the export-validation gate). It is filtered out here and reported
+    in diagnostics, mirroring the equation_semantics I/O-link cleanup (#368).
+
+    Mutates ``llm_input`` in place and returns the removed references.
+    """
+    available = _ids(llm_input.available_equations, "equation_id")
+    if not available:
+        # No equation set to validate against — the preflight already skips the
+        # equation check in this case, so nothing is stripped.
+        return []
+
+    removed: list[dict] = []
+
+    def _filter(refs, location: str, owner_id) -> list:
+        kept = []
+        for ref in refs or []:
+            ref_str = str(ref)
+            if not ref_str:
+                continue
+            if ref_str in available:
+                kept.append(ref)
+            else:
+                removed.append({
+                    "location": location,
+                    "owner_id": owner_id,
+                    "equation_id": ref_str,
+                })
+        return kept
+
+    for claim in llm_input.accepted_claims or []:
+        if isinstance(claim, dict) and "equation_ids" in claim:
+            claim["equation_ids"] = _filter(
+                claim.get("equation_ids"), "accepted_claims.equation_ids", claim.get("claim_id")
+            )
+    for claim in llm_input.available_claims or []:
+        if isinstance(claim, dict) and "equation_ids" in claim:
+            claim["equation_ids"] = _filter(
+                claim.get("equation_ids"), "available_claims.equation_ids", claim.get("claim_id")
+            )
+    for node in llm_input.thesis_nodes or []:
+        if isinstance(node, dict) and "equation_ids" in node:
+            node["equation_ids"] = _filter(
+                node.get("equation_ids"), "thesis_nodes.equation_ids",
+                node.get("node_id") or node.get("id"),
+            )
+    for node in llm_input.dsl_nodes or []:
+        refs = node.get("source_refs") if isinstance(node, dict) else None
+        if isinstance(refs, dict) and "equation_ids" in refs:
+            refs["equation_ids"] = _filter(
+                refs.get("equation_ids"), "dsl_nodes.source_refs.equation_ids", node.get("node_id")
+            )
+    for edge in llm_input.dsl_edges or []:
+        refs = edge.get("evidence_refs") if isinstance(edge, dict) else None
+        if isinstance(refs, dict) and "equation_ids" in refs:
+            refs["equation_ids"] = _filter(
+                refs.get("equation_ids"), "dsl_edges.evidence_refs.equation_ids", edge.get("edge_id")
+            )
+
+    return removed
 
 
 def _preflight_check(llm_input: ComponentAssemblyLLMInput) -> dict:

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -346,7 +346,7 @@ def _preflight_check(llm_input: ComponentAssemblyLLMInput) -> dict:
             ))
 
     return {
-        "status": "failed" if issues else "passed",
+        "status": "failed" if _has_fatal_preflight_issue(issues) else "passed",
         "accepted_claim_count": len(accepted_claim_ids),
         "available_claim_count": len(available_claim_ids),
         "available_evidence_count": len(available_evidence_ids),
@@ -354,6 +354,18 @@ def _preflight_check(llm_input: ComponentAssemblyLLMInput) -> dict:
         "available_derivation_count": len(llm_input.available_derivation_ids or []),
         "issues": issues,
     }
+
+
+# Dangling equation references are a referential-cleanup concern (handled by
+# _strip_unavailable_equation_refs), not broken assembly input. They must never
+# collapse the whole assembly into a deterministic fallback that aborts the
+# pipeline at export validation (#368 follow-up). Only genuinely missing claim /
+# evidence inputs are fatal.
+_NON_FATAL_PREFLIGHT_CODES = {"accepted_equation_ids_not_available"}
+
+
+def _has_fatal_preflight_issue(issues: list[dict]) -> bool:
+    return any(issue.get("code") not in _NON_FATAL_PREFLIGHT_CODES for issue in issues)
 
 
 def _preflight_issue(code: str, field: str, invalid_values: list[str], allowed_values: set[str]) -> dict:

--- a/src/episteme_graph/agents/document_structure/grobid_parser.py
+++ b/src/episteme_graph/agents/document_structure/grobid_parser.py
@@ -311,6 +311,17 @@ class GROBIDTEIParser:
 
         formula_xml_id = formula_tag.get("xml:id") or formula_tag.get("n") or ""
         block_id = f"blk_{uuid.uuid4().hex[:8]}"
+        raw = {
+            "parser_source": "grobid_tei",
+            "tei_section_id": tei_section_id,
+            "tei_formula_id": formula_xml_id,
+        }
+        # Issue #368: preserve table / container provenance so the equation
+        # semantics acceptance gate does not auto-confirm a table-cell formula
+        # as a standalone independent equation.
+        table_provenance = self._table_container_provenance(formula_tag)
+        if table_provenance:
+            raw.update(table_provenance)
         blocks.append(TypedBlock(
             block_id=block_id,
             page=1,
@@ -319,13 +330,28 @@ class GROBIDTEIParser:
             block_type="equation_block",
             section_id=section_id,
             equation_label=equation_label,
-            raw={
-                "parser_source": "grobid_tei",
-                "tei_section_id": tei_section_id,
-                "tei_formula_id": formula_xml_id,
-            },
+            raw=raw,
         ))
         return block_order + 1
+
+    @staticmethod
+    def _table_container_provenance(formula_tag) -> dict | None:
+        """Return table provenance if the formula is inside a <figure type=table>.
+
+        Walks the TEI ancestors of the formula; a ``<figure type="table">``
+        container means the formula is a table cell, not a standalone numbered
+        equation (issue #368).
+        """
+        parent = getattr(formula_tag, "parent", None)
+        while parent is not None and getattr(parent, "name", None) is not None:
+            if parent.name == "figure" and (parent.get("type") or "").lower() == "table":
+                table_id = parent.get("xml:id") or parent.get("n") or ""
+                provenance: dict = {"container_type": "table", "in_table": True}
+                if table_id:
+                    provenance["table_id"] = str(table_id)
+                return provenance
+            parent = getattr(parent, "parent", None)
+        return None
 
     def _process_figure(
         self,
@@ -339,25 +365,38 @@ class GROBIDTEIParser:
 
         # figDesc = figure/table caption
         desc_tag = fig_tag.find("figDesc")
-        if not desc_tag:
-            return block_order
-        text = desc_tag.get_text(separator=" ", strip=True)
-        if not text:
-            return block_order
+        if desc_tag:
+            text = desc_tag.get_text(separator=" ", strip=True)
+            if text:
+                block_type = "table_caption" if fig_type == "table" else "figure_caption"
+                block_id = f"blk_{uuid.uuid4().hex[:8]}"
+                blocks.append(TypedBlock(
+                    block_id=block_id,
+                    page=1,
+                    order=block_order,
+                    text=text,
+                    block_type=block_type,
+                    section_id=section_id,
+                    raw={
+                        "parser_source": "grobid_tei",
+                        "tei_section_id": tei_section_id,
+                        "tei_fig_type": fig_type,
+                    },
+                ))
+                block_order += 1
 
-        block_type = "table_caption" if fig_type == "table" else "figure_caption"
-        block_id = f"blk_{uuid.uuid4().hex[:8]}"
-        blocks.append(TypedBlock(
-            block_id=block_id,
-            page=1,
-            order=block_order,
-            text=text,
-            block_type=block_type,
-            section_id=section_id,
-            raw={
-                "parser_source": "grobid_tei",
-                "tei_section_id": tei_section_id,
-                "tei_fig_type": fig_type,
-            },
-        ))
-        return block_order + 1
+        # Issue #368: formulas nested inside a <figure type="table"> are table
+        # cells, not standalone numbered equations. Emit them so they are not
+        # lost, but with table provenance (attached by _process_formula) so the
+        # equation semantics gate keeps them out of the auto-confirmed set.
+        if fig_type == "table":
+            for formula_tag in fig_tag.find_all("formula"):
+                block_order = self._process_formula(
+                    formula_tag=formula_tag,
+                    blocks=blocks,
+                    section_id=section_id,
+                    block_order=block_order,
+                    tei_section_id=tei_section_id,
+                )
+
+        return block_order

--- a/src/episteme_graph/agents/equation_semantics/__init__.py
+++ b/src/episteme_graph/agents/equation_semantics/__init__.py
@@ -1,5 +1,13 @@
 from .agent import EquationSemanticsAgent
+from .fidelity import (
+    apply_fidelity_guards,
+    apply_prose_latex_guard,
+    apply_symbol_loss_guard,
+    is_prose_latex,
+    validate_io_links,
+)
 from .schema import (
+    FIDELITY_REVIEW_CODES,
     CartridgeContext,
     DefinedSymbol,
     EquationCandidate,
@@ -16,6 +24,12 @@ from .schema import (
 
 __all__ = [
     "EquationSemanticsAgent",
+    "apply_fidelity_guards",
+    "apply_prose_latex_guard",
+    "apply_symbol_loss_guard",
+    "is_prose_latex",
+    "validate_io_links",
+    "FIDELITY_REVIEW_CODES",
     "CartridgeContext",
     "DefinedSymbol",
     "EquationCandidate",

--- a/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
+++ b/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
@@ -128,16 +128,20 @@ class EquationAcceptanceGate:
     # A row of bare numeric coefficients separated by whitespace / delimiters
     # with no relational equation structure. e.g. "0.12  0.34  0.56".
     _COEFF_ROW_RE = re.compile(r"^[\s\d.,;:+\-eE×x()]+$")
-    # A "decimal coefficient × parameter" product, e.g. "3.488 beta_2",
-    # "0.28 beta_K2", "1.2 \alpha". The parameter must be a multi-letter token
-    # (or a LaTeX command), so single-symbol coefficients like "2x" / "0.5 x"
-    # are not matched.
+    # A "decimal coefficient × subscripted parameter" product (issue #368). The
+    # parameter must carry a subscript and be one of:
+    #   - a LaTeX command:        \beta_2, \beta_{K2}, \alpha_{K2}
+    #   - a Unicode Greek letter: β_2, β_K2, α_3
+    #   - a multi-letter name:    beta_2, beta_K2
+    #   - a single ASCII letter:  G_F  (only with a subscript)
+    # The <base> group is the parameter family (sans subscript) used to require a
+    # repeated family — the strong signal that distinguishes a coefficient table
+    # from an ordinary regression / physics equation.
     _COEFF_PARAM_RE = re.compile(
-        r"\d+\.\d+\s*\*?\s*(?:\\[A-Za-z]+|[A-Za-z]{2,})(?:_\{?[A-Za-z0-9]+\}?)?"
+        r"[-+]?\d+\.\d+\s*\*?\s*"
+        r"(?P<base>\\[A-Za-z]+|[α-ωΑ-Ω]|[A-Za-z]{2,}|[A-Za-z])"
+        r"_\{?[A-Za-z0-9]+\}?"
     )
-    # Minimum number of coefficient×parameter products for a linear-combination
-    # table cell (issue #368 example has "3.488 beta_2 + 0.28 beta_K2 + ...").
-    _MIN_COEFF_PARAM_TERMS = 2
 
     @classmethod
     def _looks_like_coefficient_table(cls, text: str) -> bool:
@@ -149,10 +153,22 @@ class EquationAcceptanceGate:
             numbers = re.findall(r"[-+]?\d*\.\d+|[-+]?\d+", stripped)
             if len(numbers) >= 3 and cls._COEFF_ROW_RE.match(stripped):
                 return True
-        # 2) A linear combination of decimal-coefficient × parameter products,
-        #    even when it carries an "=" (the table lists an example formula).
-        if len(cls._COEFF_PARAM_RE.findall(stripped)) >= cls._MIN_COEFF_PARAM_TERMS:
-            return True
+        # 2) A linear combination of decimal-coefficient × subscripted parameter
+        #    products with a *repeated parameter family*. Requiring (a) subscripts
+        #    and (b) a repeated base excludes ordinary regression formulas with
+        #    natural-language variable names ("0.50 income + 1.20 education") and
+        #    single-coefficient physics relations ("1.16 G_F^2"), while catching
+        #    coefficient tables like "3.488β_2 + 0.28β_K2 + 0.11β_3".
+        bases = [
+            m.group("base").lstrip("\\").lower()
+            for m in cls._COEFF_PARAM_RE.finditer(stripped)
+        ]
+        if len(bases) >= 2:
+            counts: dict[str, int] = {}
+            for base in bases:
+                counts[base] = counts.get(base, 0) + 1
+            if max(counts.values()) >= 2:
+                return True
         return False
 
     @staticmethod

--- a/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
+++ b/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
@@ -118,24 +118,40 @@ class EquationAcceptanceGate:
     def _is_table_derived(cls, candidate: EquationCandidate, text: str) -> bool:
         """Table provenance or strong coefficient-table match (issue #368)."""
         src_loc = candidate.source_location or {}
+        # table provenance is authoritative — accept it unconditionally.
         if src_loc.get("table_provenance"):
             return True
         if "table_derived_equation_candidate" in (candidate.review_reason or []):
             return True
         return cls._looks_like_coefficient_table(text)
 
-    # A row of numeric coefficients / example values separated by whitespace or
-    # delimiters, with no relational equation structure. e.g. "0.12  0.34  0.56".
+    # A row of bare numeric coefficients separated by whitespace / delimiters
+    # with no relational equation structure. e.g. "0.12  0.34  0.56".
     _COEFF_ROW_RE = re.compile(r"^[\s\d.,;:+\-eE×x()]+$")
+    # A "decimal coefficient × parameter" product, e.g. "3.488 beta_2",
+    # "0.28 beta_K2", "1.2 \alpha". The parameter must be a multi-letter token
+    # (or a LaTeX command), so single-symbol coefficients like "2x" / "0.5 x"
+    # are not matched.
+    _COEFF_PARAM_RE = re.compile(
+        r"\d+\.\d+\s*\*?\s*(?:\\[A-Za-z]+|[A-Za-z]{2,})(?:_\{?[A-Za-z0-9]+\}?)?"
+    )
+    # Minimum number of coefficient×parameter products for a linear-combination
+    # table cell (issue #368 example has "3.488 beta_2 + 0.28 beta_K2 + ...").
+    _MIN_COEFF_PARAM_TERMS = 2
 
     @classmethod
     def _looks_like_coefficient_table(cls, text: str) -> bool:
         stripped = text.strip()
-        if not stripped or _RELATION_RE.search(stripped):
+        if not stripped:
             return False
-        numbers = re.findall(r"[-+]?\d*\.\d+|[-+]?\d+", stripped)
-        # Three or more bare numbers and (almost) nothing else → table row.
-        if len(numbers) >= 3 and cls._COEFF_ROW_RE.match(stripped):
+        # 1) A bare numeric row with no relation operator (pure table cells).
+        if not _RELATION_RE.search(stripped):
+            numbers = re.findall(r"[-+]?\d*\.\d+|[-+]?\d+", stripped)
+            if len(numbers) >= 3 and cls._COEFF_ROW_RE.match(stripped):
+                return True
+        # 2) A linear combination of decimal-coefficient × parameter products,
+        #    even when it carries an "=" (the table lists an example formula).
+        if len(cls._COEFF_PARAM_RE.findall(stripped)) >= cls._MIN_COEFF_PARAM_TERMS:
             return True
         return False
 

--- a/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
+++ b/src/episteme_graph/agents/equation_semantics/acceptance_gate.py
@@ -67,6 +67,16 @@ class EquationAcceptanceGate:
         if not text:
             return self._mark(candidate, "missing", "context_only", True, ["equation_body_missing"])
 
+        # Issue #368: a candidate with table provenance (or one strongly matching
+        # a coefficient table) must not auto-confirm as a standalone equation.
+        # High-signal candidates are kept review-required as provisional so the
+        # downstream reconstruction / review layer can still inspect them.
+        if self._is_table_derived(candidate, text):
+            reasons = ["table_derived_equation_candidate", "needs_math_review"]
+            if self._is_high_signal(candidate):
+                return self._mark(candidate, "partial", "provisional", True, reasons)
+            return self._mark(candidate, "partial", "context_only", True, reasons)
+
         if _LABEL_ONLY_RE.match(text):
             # High-signal: has a matched_label or display math → provisional (issue #259)
             if self._is_high_signal(candidate):
@@ -103,6 +113,31 @@ class EquationAcceptanceGate:
         if self._is_high_signal(candidate):
             return self._mark(candidate, "unparsed", "provisional", True, ["ambiguous_math_text"])
         return self._mark(candidate, "unparsed", "context_only", True, ["ambiguous_math_text"])
+
+    @classmethod
+    def _is_table_derived(cls, candidate: EquationCandidate, text: str) -> bool:
+        """Table provenance or strong coefficient-table match (issue #368)."""
+        src_loc = candidate.source_location or {}
+        if src_loc.get("table_provenance"):
+            return True
+        if "table_derived_equation_candidate" in (candidate.review_reason or []):
+            return True
+        return cls._looks_like_coefficient_table(text)
+
+    # A row of numeric coefficients / example values separated by whitespace or
+    # delimiters, with no relational equation structure. e.g. "0.12  0.34  0.56".
+    _COEFF_ROW_RE = re.compile(r"^[\s\d.,;:+\-eE×x()]+$")
+
+    @classmethod
+    def _looks_like_coefficient_table(cls, text: str) -> bool:
+        stripped = text.strip()
+        if not stripped or _RELATION_RE.search(stripped):
+            return False
+        numbers = re.findall(r"[-+]?\d*\.\d+|[-+]?\d+", stripped)
+        # Three or more bare numbers and (almost) nothing else → table row.
+        if len(numbers) >= 3 and cls._COEFF_ROW_RE.match(stripped):
+            return True
+        return False
 
     @staticmethod
     def _is_high_signal(candidate: EquationCandidate) -> bool:

--- a/src/episteme_graph/agents/equation_semantics/agent.py
+++ b/src/episteme_graph/agents/equation_semantics/agent.py
@@ -16,6 +16,7 @@ from episteme_graph.agents.rhetorical_role.schema import RhetoricalRoleResult
 
 from .acceptance_gate import EquationAcceptanceGate
 from .cartridge_loader import CartridgeLoader
+from .fidelity import apply_fidelity_guards
 from .image_extractor import EquationImageExtractor
 from .input_builder import EquationSemanticsInputBuilder
 from .llm_client import EquationSemanticsLLMClient
@@ -258,7 +259,11 @@ class EquationSemanticsAgent:
             equation_candidates=classified_candidates,
             equations=records,
         )
-        result.validation_issues = self._validator.validate(result, cartridge)
+        # Issue #368: deterministic fidelity guards (prose LaTeX, I/O link
+        # referential integrity, unverifiable symbol loss). Run before final
+        # validation so blocked policies are validated consistently.
+        fidelity_issues = apply_fidelity_guards(result)
+        result.validation_issues = self._validator.validate(result, cartridge) + fidelity_issues
         return result
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:

--- a/src/episteme_graph/agents/equation_semantics/fidelity.py
+++ b/src/episteme_graph/agents/equation_semantics/fidelity.py
@@ -1,0 +1,218 @@
+"""Deterministic equation reconstruction fidelity guards (issue #368).
+
+These post-validation passes run on the assembled EquationSemanticsResult after
+the LLM semantics step. They do not replace the blanket ``needs_math_review`` /
+``equation_consistency`` / ``confidence_policy`` safety gate; they add
+*per-problem* reason codes so each quality issue can be identified, blocked from
+downstream confirmed use, and aggregated by the ExportValidationGate.
+
+All logic is deterministic and never trusts LLM self-reports.
+"""
+from __future__ import annotations
+
+import re
+
+from .schema import (
+    FIDELITY_LATEX_IS_PROSE,
+    FIDELITY_NONEQUATION_ID,
+    FIDELITY_SYMBOL_LOSS_UNVERIFIABLE,
+    EquationConfidencePolicy,
+    EquationRecord,
+    EquationSemanticsResult,
+    ValidationIssue,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Prose-as-LaTeX detection
+# ---------------------------------------------------------------------------
+
+_TEXT_BLOCK_RE = re.compile(r"\\(?:text|textrm|textit|mbox)\s*\{([^{}]*)\}")
+_RELATION_RE = re.compile(
+    r"=|\\equiv|\\leq|\\geq|\\neq|\\approx|\\sim|\\propto|\\to|<|>|≤|≥|≈|≡|≠|∝"
+)
+_MATH_TOKEN_RE = re.compile(r"[A-Za-z]+|[α-ωΑ-Ω]+|\d+(?:\.\d+)?|[+\-*/^]")
+_PROSE_WORD_RE = re.compile(r"[A-Za-z]{2,}")
+
+# Minimum number of natural-language words inside \text{} for prose suspicion.
+_MIN_PROSE_WORDS = 4
+_PLACEHOLDER = " \x00MATHTEXT\x00 "
+
+
+def is_prose_latex(latex: str | None) -> bool:
+    """True if a reconstructed LaTeX body is prose rather than an expression.
+
+    Heuristic (deterministic): there is a long ``\\text{...}`` block (>= 4
+    natural-language words) AND the math *outside* the text blocks does not
+    itself form a complete relation (operands with real math on both sides).
+    A normal equation that merely annotates with ``\\text{subject to ...}`` is
+    not flagged because its math forms a complete relation on its own.
+    """
+    if not latex or not latex.strip():
+        return False
+    text_blocks = _TEXT_BLOCK_RE.findall(latex)
+    if not text_blocks:
+        return False
+    text_words = _PROSE_WORD_RE.findall(" ".join(text_blocks))
+    if len(text_words) < _MIN_PROSE_WORDS:
+        return False
+    skeleton = _TEXT_BLOCK_RE.sub(_PLACEHOLDER, latex)
+    if _has_complete_relation(skeleton):
+        return False
+    math_tokens = [t for t in _MATH_TOKEN_RE.findall(skeleton.replace("MATHTEXT", " ")) if t]
+    # Prose dominates the expression body.
+    return len(text_words) > len(math_tokens)
+
+
+def _has_complete_relation(skeleton: str) -> bool:
+    """A relation operator whose both sides carry real (non-placeholder) math."""
+    parts = _RELATION_RE.split(skeleton)
+    if len(parts) < 2:
+        return False
+    sides_with_math = 0
+    for part in parts:
+        cleaned = part.replace("MATHTEXT", " ")
+        if _MATH_TOKEN_RE.search(cleaned):
+            sides_with_math += 1
+    return sides_with_math >= 2
+
+
+def apply_prose_latex_guard(record: EquationRecord) -> bool:
+    """Flag a prose reconstruction and block its confirmed downstream use.
+
+    Returns True if the record was flagged.
+    """
+    rec = record.reconstruction
+    if rec.status == "none":
+        return False
+    if not is_prose_latex(rec.latex):
+        return False
+
+    rec.review_required = True
+    _add(rec.review_reason, FIDELITY_LATEX_IS_PROSE)
+
+    consistency = record.equation_consistency
+    consistency.review_required = True
+    _add(consistency.review_reason, FIDELITY_LATEX_IS_PROSE)
+
+    # Recompute confidence_policy so claim / derivation / final-formula use is
+    # blocked. The reconstructed prose LaTeX is never published as final math.
+    record.confidence_policy = EquationConfidencePolicy.derive(
+        record.source_extraction,
+        rec,
+        record.semantics,
+        consistency,
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# 4. I/O link referential integrity
+# ---------------------------------------------------------------------------
+
+def validate_io_links(records: list[EquationRecord]) -> list[ValidationIssue]:
+    """Verify input/output equation links by membership, not by ``eq_`` prefix.
+
+    Any link that is not a member of the document's final equation-id set (a
+    block id, candidate id, self-reference, or dangling id) is removed and the
+    removed values are recorded in a ValidationIssue. ``nonequation_id_in_links``
+    is added to the record's review_flags.
+    """
+    issues: list[ValidationIssue] = []
+    final_ids = {r.equation_id for r in records if r.equation_id}
+    for record in records:
+        sem = record.semantics
+        eid = record.equation_id
+        removed: list[str] = []
+
+        kept_in = []
+        for ref in sem.input_equation_ids:
+            if ref and ref != eid and ref in final_ids:
+                kept_in.append(ref)
+            elif ref:
+                removed.append(f"input:{ref}")
+        kept_out = []
+        for ref in sem.output_equation_ids:
+            if ref and ref != eid and ref in final_ids:
+                kept_out.append(ref)
+            elif ref:
+                removed.append(f"output:{ref}")
+
+        if removed:
+            sem.input_equation_ids = kept_in
+            sem.output_equation_ids = kept_out
+            _add(sem.review_flags, FIDELITY_NONEQUATION_ID)
+            issues.append(ValidationIssue(
+                rule_id="nonequation_id_in_links",
+                severity="warning",
+                message=(
+                    f"{eid} had non-equation / dangling derivation link(s) removed: "
+                    f"{', '.join(removed)}"
+                ),
+                field=f"{eid}.semantics.input_equation_ids/output_equation_ids",
+            ))
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# 5. Symbol-loss unverifiability
+# ---------------------------------------------------------------------------
+
+_IMAGE_UNAVAILABLE_HINTS = (
+    "vision_ocr_unavailable",
+    "vision_ocr_not_attempted",
+    "equation_image_unavailable",
+)
+
+
+def apply_symbol_loss_guard(record: EquationRecord) -> bool:
+    """Mark unverifiable symbol loss between raw text and reconstruction (#368).
+
+    When the deterministic symbol-overlap comparison already signals a raw↔latex
+    mismatch but the source image / Vision OCR provenance is unavailable, the
+    loss cannot be auto-confirmed or auto-repaired, so it is surfaced as
+    ``symbol_loss_unverifiable`` for review rather than treated as source-backed.
+    """
+    consistency = record.equation_consistency
+    if consistency.raw_text_latex_match != "mismatch":
+        return False
+    if "raw_text_latex_symbol_mismatch" not in consistency.review_reason:
+        return False
+    if not _image_unavailable(record):
+        return False
+    _add(consistency.review_reason, FIDELITY_SYMBOL_LOSS_UNVERIFIABLE)
+    consistency.review_required = True
+    return True
+
+
+def _image_unavailable(record: EquationRecord) -> bool:
+    if record.source_extraction.source_image:
+        return False
+    hints = list(record.reconstruction.review_reason) + list(
+        record.source_extraction.review_reason
+    )
+    return any(any(h in reason for h in _IMAGE_UNAVAILABLE_HINTS) for reason in hints)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def apply_fidelity_guards(
+    result: EquationSemanticsResult,
+) -> list[ValidationIssue]:
+    """Run all deterministic fidelity guards over an assembled result.
+
+    Mutates records in place (review reasons / flags / blocked policy) and
+    returns ValidationIssues for the removed I/O links. Idempotent.
+    """
+    issues: list[ValidationIssue] = []
+    for record in result.equations:
+        apply_prose_latex_guard(record)
+        apply_symbol_loss_guard(record)
+    issues += validate_io_links(result.equations)
+    return issues
+
+
+def _add(values: list[str], code: str) -> None:
+    if code not in values:
+        values.append(code)

--- a/src/episteme_graph/agents/equation_semantics/input_builder.py
+++ b/src/episteme_graph/agents/equation_semantics/input_builder.py
@@ -56,6 +56,7 @@ class EquationSemanticsInputBuilder:
     ) -> list[EquationCandidate]:
         """全 equation_block から EquationCandidate を生成する (acceptance gate 適用前)。"""
         cfg = config or {}
+        self._normalizer.set_extra_label_patterns(self._cartridge_label_patterns(cartridge))
         max_equations = int(cfg.get("max_equations", _MAX_EQUATIONS))
         ordered_blocks = sorted(structure.blocks, key=lambda b: (b.page, b.order))
 
@@ -96,6 +97,7 @@ class EquationSemanticsInputBuilder:
         _accepted = [c for c in accepted_candidates if c.acceptance_status in statuses]
         if not _accepted:
             return []
+        self._normalizer.set_extra_label_patterns(self._cartridge_label_patterns(cartridge))
         sections_by_id = {s.section_id: s for s in structure.sections}
         backbone_by_section = self._map_backbone_by_section(skeleton)
         spans_by_block = self._map_spans_by_block(roles)
@@ -213,18 +215,34 @@ class EquationSemanticsInputBuilder:
         if block.bbox:
             bbox_list = list(block.bbox)
 
+        source_location: dict = {
+            "page": block.page,
+            "section_id": block.section_id,
+            "block_id": block.block_id,
+            "span_start": 0,
+            "span_end": len(block.text),
+            "bbox": bbox_list,
+            "extraction_source": extraction_source,
+        }
+
+        review_reason: list[str] = []
+        # Issue #368: a rejected PDF/GROBID label is recorded for audit and the
+        # equation_label is normalized to None (matched_label stays None).
+        if not equation.label_is_valid and equation.rejected_label is not None:
+            review_reason.append("invalid_equation_label")
+            source_location["rejected_equation_label"] = equation.rejected_label
+
+        # Issue #368: table / table-cell provenance. The acceptance gate uses
+        # this to keep the candidate out of the auto-confirmed equation set.
+        table_provenance = self._table_provenance(block)
+        if table_provenance:
+            source_location["table_provenance"] = table_provenance
+            review_reason.append("table_derived_equation_candidate")
+
         return EquationCandidate(
             candidate_id=f"eqcand_{block.block_id}_{uuid.uuid4().hex[:8]}",
             document_id=document_id,
-            source_location={
-                "page": block.page,
-                "section_id": block.section_id,
-                "block_id": block.block_id,
-                "span_start": 0,
-                "span_end": len(block.text),
-                "bbox": bbox_list,
-                "extraction_source": extraction_source,
-            },
+            source_location=source_location,
             raw_text=block.text.strip(),
             matched_label=equation.label,
             detection_method=detection,
@@ -234,8 +252,30 @@ class EquationSemanticsInputBuilder:
             accepted_equation_id=None,
             merge_target_hint=None,
             needs_math_review=False,
-            review_reason=[],
+            review_reason=review_reason,
         )
+
+    @staticmethod
+    def _table_provenance(block: TypedBlock) -> dict | None:
+        """Detect table / table-cell provenance for an equation candidate (#368).
+
+        Best-effort: reads provenance hints that DocumentStructure may carry on
+        ``block.raw`` (no hard dependency on a schema change). Recognized hints:
+        ``table_id`` / ``table_cell`` / ``in_table`` / ``from_table`` /
+        ``container_type == 'table'`` / ``parent_block_type == 'table_*'``.
+        """
+        raw = block.raw if isinstance(block.raw, dict) else {}
+        provenance: dict = {}
+        for key in ("table_id", "table_cell", "row", "col"):
+            value = raw.get(key)
+            if value not in (None, "", []):
+                provenance[key] = value
+        if raw.get("in_table") or raw.get("from_table"):
+            provenance.setdefault("in_table", True)
+        container = str(raw.get("container_type") or raw.get("parent_block_type") or "")
+        if container.startswith("table"):
+            provenance.setdefault("container_type", container)
+        return provenance or None
 
     def _inline_candidates_for_block(self, block: TypedBlock, document_id: str) -> list[EquationCandidate]:
         candidates: list[EquationCandidate] = []
@@ -324,6 +364,17 @@ class EquationSemanticsInputBuilder:
         if direction < 0:
             texts.reverse()
         return texts
+
+    @staticmethod
+    def _cartridge_label_patterns(cartridge: CartridgeContext | None) -> list[str]:
+        """Cartridge-provided extra allowed equation label patterns (#368)."""
+        if not cartridge:
+            return []
+        rules = cartridge.validation_rules if isinstance(cartridge.validation_rules, dict) else {}
+        patterns = rules.get("equation_label_patterns")
+        if isinstance(patterns, list):
+            return [str(p) for p in patterns if p]
+        return []
 
     @staticmethod
     def _extraction_source(block: TypedBlock) -> str:

--- a/src/episteme_graph/agents/equation_semantics/normalizer.py
+++ b/src/episteme_graph/agents/equation_semantics/normalizer.py
@@ -9,11 +9,43 @@ from .schema import NormalizedEquation
 
 _TRAILING_LABEL_RE = re.compile(r"\((?P<label>[A-Za-z]?\d+(?:\.\d+)*|[A-Za-z]\.\d+)\)\s*$")
 
+# Issue #368: source-aware equation label validity.
+#
+# A PDF parser / GROBID can emit garbage labels such as "(", "(1) g , K (3)",
+# "1 3 ." or "(1) g and K". These must not be promoted into equation ids. The
+# allowed patterns below describe legitimate numeric / appendix equation
+# numbers; cartridges may extend them. Labels that match none of the patterns
+# are rejected (normalized to None). Note: a *missing* label is valid (an
+# unnumbered display equation), and trusted TeX `\label{...}` semantic keys are
+# accepted without being held to the numeric PDF patterns.
+DEFAULT_ALLOWED_LABEL_PATTERNS = [
+    r"^[A-Za-z]?\d+(?:\.\d+)*[A-Za-z]?$",   # 1, 12, 2.3.4, A1, 3a, A.2 -> "A2"? handled below
+    r"^[A-Za-z]\.\d+(?:\.\d+)*$",            # A.2, B.10, C.3.1
+    r"^[A-Za-z]+\d+(?:\.\d+)*$",             # eq12, S3 (semantic-ish numeric)
+]
+
 
 class EquationNormalizer:
+    def __init__(self, extra_label_patterns: list[str] | None = None) -> None:
+        self._allowed = [re.compile(p) for p in DEFAULT_ALLOWED_LABEL_PATTERNS]
+        self.set_extra_label_patterns(extra_label_patterns)
+
+    def set_extra_label_patterns(self, patterns: list[str] | None) -> None:
+        """Cartridge-provided additional allowed label patterns (issue #368)."""
+        self._extra: list[re.Pattern] = []
+        for pattern in patterns or []:
+            try:
+                self._extra.append(re.compile(pattern))
+            except re.error:
+                continue
+
     def normalize(self, equation_block: TypedBlock) -> NormalizedEquation:
         text = equation_block.text.strip()
-        label = equation_block.equation_label or self.extract_label(text)
+        raw_label = equation_block.equation_label or self.extract_label(text)
+        source_trusted = self._is_trusted_source(equation_block)
+        label, label_is_valid, rejected_label = self.validate_label(
+            raw_label, source_trusted=source_trusted
+        )
         equation_id = self.equation_id_from_label(label, equation_block.block_id)
         return NormalizedEquation(
             equation_id=equation_id,
@@ -23,6 +55,8 @@ class EquationNormalizer:
             text=text,
             latex=equation_block.raw.get("latex") if isinstance(equation_block.raw, dict) else None,
             plain_text=self._plain_text(text),
+            label_is_valid=label_is_valid,
+            rejected_label=rejected_label,
         )
 
     @staticmethod
@@ -30,11 +64,73 @@ class EquationNormalizer:
         match = _TRAILING_LABEL_RE.search(text.strip())
         return match.group("label") if match else None
 
+    def validate_label(
+        self,
+        label: str | None,
+        *,
+        source_trusted: bool = False,
+    ) -> tuple[str | None, bool, str | None]:
+        """Source-aware label validation (issue #368).
+
+        Returns ``(normalized_label, is_valid, rejected_label)``.
+
+        - A missing label is valid (legitimate unnumbered equation).
+        - Trusted TeX ``\\label{...}`` semantic keys are accepted as-is.
+        - PDF/GROBID labels must match an allowed numeric/appendix pattern;
+          otherwise they are rejected (normalized to None) and the original is
+          returned as ``rejected_label`` for audit.
+        """
+        if label is None:
+            return None, True, None
+        stripped = str(label).strip()
+        if not stripped:
+            # An empty / whitespace label is rejected (must not yield "eq_").
+            return None, False, str(label)
+        # A single clean surrounding parenthesis pair is part of the printed
+        # equation number, e.g. "(3.14)"; strip it before pattern matching.
+        inner = stripped
+        if inner.startswith("(") and inner.endswith(")") and inner.count("(") == 1 and inner.count(")") == 1:
+            inner = inner[1:-1].strip()
+        if not inner:
+            return None, False, stripped
+        if source_trusted:
+            # Trusted TeX semantic labels (e.g. \label{eq:dispersion}) are kept;
+            # only reject obviously broken values (whitespace runs / stray punct).
+            if self._is_clean_semantic_label(inner):
+                return inner, True, None
+            return None, False, stripped
+        if self._matches_allowed(inner):
+            return inner, True, None
+        return None, False, stripped
+
+    def _matches_allowed(self, label: str) -> bool:
+        return any(p.match(label) for p in self._allowed) or any(
+            p.match(label) for p in self._extra
+        )
+
+    @staticmethod
+    def _is_clean_semantic_label(label: str) -> bool:
+        # Single token (optionally with ':' or '-' or '.'), no spaces / commas /
+        # multiple parenthesised groups.
+        if any(ch in label for ch in (",", "(", ")")):
+            return False
+        if " " in label.strip():
+            return False
+        return bool(re.match(r"^[A-Za-z0-9][A-Za-z0-9:_.\-]*$", label))
+
+    @staticmethod
+    def _is_trusted_source(block: TypedBlock) -> bool:
+        raw = block.raw if isinstance(block.raw, dict) else {}
+        if str(raw.get("extraction_source") or "") == "tex_source":
+            return True
+        return raw.get("parser_source") == "tex_archive"
+
     @staticmethod
     def equation_id_from_label(label: str | None, block_id: str) -> str:
         if label:
             normalized = re.sub(r"[^A-Za-z0-9]+", "_", label).strip("_")
-            return f"eq_{normalized}"
+            if normalized:
+                return f"eq_{normalized}"
         return f"eq_{block_id}"
 
     @staticmethod

--- a/src/episteme_graph/agents/equation_semantics/repair.py
+++ b/src/episteme_graph/agents/equation_semantics/repair.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 
 from .llm_client import EquationSemanticsLLMClient
+from .normalizer import EquationNormalizer
 from .prompt import EquationSemanticsPromptFactory
 from .schema import (
     CartridgeContext,
@@ -26,6 +27,49 @@ from .schema import (
 logger = logging.getLogger(__name__)
 
 _MAX_REPAIR_ATTEMPTS = 2
+
+# Deterministic, source-aware label validation for the final record (#368).
+_LABEL_NORMALIZER = EquationNormalizer()
+
+
+def _resolve_label_and_id(
+    raw: dict,
+    llm_input: EquationLLMInput,
+) -> tuple[str | None, str, dict]:
+    """Re-validate the LLM-provided label / equation_id (issue #368).
+
+    ``llm_input.label`` / ``llm_input.equation_id`` are canonical (already
+    produced by the source-aware normalizer at input-build time). An LLM may
+    propose a different label; it is only adopted if it passes the same
+    source-aware validator, and the equation_id is always *derived* — never
+    taken verbatim from the LLM. Rejected LLM values are returned as audit
+    metadata so the validator can surface them.
+    """
+    final_label = llm_input.label
+    final_eq_id = llm_input.equation_id or _LABEL_NORMALIZER.equation_id_from_label(
+        final_label, llm_input.block_id
+    )
+    audit: dict = {}
+
+    llm_label = raw.get("label")
+    if llm_label is not None and str(llm_label).strip() != str(final_label or "").strip():
+        norm_label, valid, _rejected = _LABEL_NORMALIZER.validate_label(
+            str(llm_label), source_trusted=llm_input.source_is_trusted
+        )
+        if valid and norm_label:
+            final_label = norm_label
+            final_eq_id = EquationNormalizer.equation_id_from_label(
+                norm_label, llm_input.block_id
+            )
+        else:
+            audit["llm_rejected_label"] = str(llm_label)
+
+    llm_eq_id = raw.get("equation_id")
+    if llm_eq_id and str(llm_eq_id) != str(final_eq_id):
+        # The LLM equation_id is never trusted verbatim; keep the derived id.
+        audit["llm_rejected_equation_id"] = str(llm_eq_id)
+
+    return final_label, final_eq_id, audit
 
 
 class EquationSemanticsRepairer:
@@ -77,6 +121,9 @@ def _parse_record(
     if not isinstance(vision_meta, dict):
         vision_meta = None
 
+    # --- deterministic, source-aware label / equation_id re-validation (#368) ---
+    final_label, final_eq_id, label_audit = _resolve_label_and_id(raw, llm_input)
+
     # --- source_extraction ---
     extraction_status = llm_input.extraction_status if candidate else "complete"
     needs_review = candidate.needs_math_review if candidate else False
@@ -89,16 +136,20 @@ def _parse_record(
         bbox = list(candidate.source_location.get("bbox", []))
         page = candidate.source_location.get("page", 0)
 
+    source_location = {
+        "page": page,
+        "section_id": llm_input.section_id,
+        "block_id": llm_input.block_id,
+        "bbox": bbox,
+    }
+    # Preserve rejected LLM label / equation_id as audit metadata.
+    source_location.update(label_audit)
+
     source_extraction = EquationSourceExtraction(
         raw_text=llm_input.equation_text,
         latex=None if llm_input.needs_reconstruction else llm_input.latex,
         plain_text=None if llm_input.needs_reconstruction else llm_input.plain_text,
-        source_location={
-            "page": page,
-            "section_id": llm_input.section_id,
-            "block_id": llm_input.block_id,
-            "bbox": bbox,
-        },
+        source_location=source_location,
         extraction_source=llm_input.extraction_source,
         extraction_status=extraction_status,
         needs_math_review=needs_review,
@@ -184,7 +235,7 @@ def _parse_record(
     equation_consistency = EquationConsistency.derive(
         source_extraction=source_extraction,
         reconstruction=reconstruction,
-        label=raw.get("label", llm_input.label),
+        label=final_label,
         semantics=semantics,
     )
     confidence_policy = EquationConfidencePolicy.derive(
@@ -200,9 +251,9 @@ def _parse_record(
         candidate_trace_ids = [candidate.candidate_id]
 
     return EquationRecord(
-        equation_id=raw.get("equation_id", llm_input.equation_id),
+        equation_id=final_eq_id,
         document_id=llm_input.document_id,
-        label=raw.get("label", llm_input.label),
+        label=final_label,
         candidate_trace_ids=candidate_trace_ids,
         source_extraction=source_extraction,
         reconstruction=reconstruction,

--- a/src/episteme_graph/agents/equation_semantics/repair.py
+++ b/src/episteme_graph/agents/equation_semantics/repair.py
@@ -36,14 +36,14 @@ def _resolve_label_and_id(
     raw: dict,
     llm_input: EquationLLMInput,
 ) -> tuple[str | None, str, dict]:
-    """Re-validate the LLM-provided label / equation_id (issue #368).
+    """Pin the final label / equation_id to the canonical input (issue #368).
 
-    ``llm_input.label`` / ``llm_input.equation_id`` are canonical (already
-    produced by the source-aware normalizer at input-build time). An LLM may
-    propose a different label; it is only adopted if it passes the same
-    source-aware validator, and the equation_id is always *derived* — never
-    taken verbatim from the LLM. Rejected LLM values are returned as audit
-    metadata so the validator can surface them.
+    ``llm_input.label`` / ``llm_input.equation_id`` are canonical — already
+    produced by the source-aware normalizer at input-build time. The LLM's
+    proposed ``label`` / ``equation_id`` are *never* adopted as final values
+    (even if syntactically valid), so the deterministic ids stay stable and no
+    LLM output can collide ids or break existing references. A differing LLM
+    proposal is preserved as audit metadata that the validator surfaces.
     """
     final_label = llm_input.label
     final_eq_id = llm_input.equation_id or _LABEL_NORMALIZER.equation_id_from_label(
@@ -53,20 +53,10 @@ def _resolve_label_and_id(
 
     llm_label = raw.get("label")
     if llm_label is not None and str(llm_label).strip() != str(final_label or "").strip():
-        norm_label, valid, _rejected = _LABEL_NORMALIZER.validate_label(
-            str(llm_label), source_trusted=llm_input.source_is_trusted
-        )
-        if valid and norm_label:
-            final_label = norm_label
-            final_eq_id = EquationNormalizer.equation_id_from_label(
-                norm_label, llm_input.block_id
-            )
-        else:
-            audit["llm_rejected_label"] = str(llm_label)
+        audit["llm_rejected_label"] = str(llm_label)
 
     llm_eq_id = raw.get("equation_id")
     if llm_eq_id and str(llm_eq_id) != str(final_eq_id):
-        # The LLM equation_id is never trusted verbatim; keep the derived id.
         audit["llm_rejected_equation_id"] = str(llm_eq_id)
 
     return final_label, final_eq_id, audit

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -596,6 +596,14 @@ class EquationSemanticsResult:
                 latex = rec.latex
                 plain_text = rec.plain_text
 
+            # Issue #368: a prose reconstruction (latex_is_prose) is audit-only.
+            # Keep the reconstruction block for audit, but never publish the
+            # paraphrased text as display math; the confidence_gate below then
+            # blocks claim / derivation / final-formula use.
+            if FIDELITY_LATEX_IS_PROSE in (rec.review_reason or []):
+                latex = None
+                plain_text = None
+
             # defined / used / introduced symbols
             defined = [s.symbol for s in sem.defined_symbols if s.definition_status in ("defined", "redefined")]
             introduced = [s.symbol for s in sem.defined_symbols if s.definition_status == "defined"]

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -77,6 +77,9 @@ REVIEW_FLAGS = [
     "partial_extraction",
     # Issue #358: equation links a claim that does not link the equation back.
     "claim_link_asymmetry",
+    # Issue #368: an I/O derivation link referenced an id that is not a member
+    # of the document's final equation set (block id / candidate id / dangling).
+    "nonequation_id_in_links",
 ]
 
 CANDIDATE_REVIEW_REASONS = [
@@ -89,6 +92,47 @@ CANDIDATE_REVIEW_REASONS = [
     "ambiguous_math_text",
     "pdf_text_layer_untrusted",
     "inline_pdf_math_untrusted",
+    # Issue #368: PDF parser / GROBID supplied an equation_label that does not
+    # match the allowed label patterns; the label was normalized to None.
+    "invalid_equation_label",
+    # Issue #368: the candidate originates from a table / table-cell and must
+    # not be auto-confirmed as a standalone independent equation.
+    "table_derived_equation_candidate",
+]
+
+# ---------------------------------------------------------------------------
+# Issue #368: fidelity guard reason codes.
+#
+# These deterministic, post-validation reason codes identify *specific* PDF
+# equation reconstruction quality problems on top of the existing blanket
+# needs_math_review / equation_consistency / confidence_policy safety gate.
+# They are aggregated per-type by the ExportValidationGate.
+# ---------------------------------------------------------------------------
+
+# A reconstructed LaTeX whose body is prose (paraphrase of surrounding text)
+# rather than an actual mathematical expression. Stored in reconstruction /
+# equation_consistency review_reason.
+FIDELITY_LATEX_IS_PROSE = "latex_is_prose"
+# A PDF-supplied equation label that was rejected and normalized to None.
+# Stored in candidate / source_extraction review_reason.
+FIDELITY_INVALID_LABEL = "invalid_equation_label"
+# A candidate originating from a table that must not auto-confirm. Stored in
+# candidate review_reason.
+FIDELITY_TABLE_DERIVED = "table_derived_equation_candidate"
+# A non-equation id (block/candidate/dangling) found in I/O derivation links.
+# Stored in semantics.review_flags.
+FIDELITY_NONEQUATION_ID = "nonequation_id_in_links"
+# Symbol loss between raw text and reconstruction that cannot be verified
+# deterministically (image / OCR provenance unavailable). Stored in
+# equation_consistency review_reason.
+FIDELITY_SYMBOL_LOSS_UNVERIFIABLE = "symbol_loss_unverifiable"
+
+FIDELITY_REVIEW_CODES = [
+    FIDELITY_LATEX_IS_PROSE,
+    FIDELITY_INVALID_LABEL,
+    FIDELITY_TABLE_DERIVED,
+    FIDELITY_NONEQUATION_ID,
+    FIDELITY_SYMBOL_LOSS_UNVERIFIABLE,
 ]
 
 DETECTION_METHODS = [
@@ -150,6 +194,11 @@ class NormalizedEquation:
     text: str
     latex: str | None = None
     plain_text: str | None = None
+    # Issue #368: source-aware label validity. When a PDF-supplied label fails
+    # the allowed patterns it is normalized to label=None, label_is_valid=False,
+    # and the original value is preserved in rejected_label for audit.
+    label_is_valid: bool = True
+    rejected_label: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/episteme_graph/agents/equation_semantics/validator.py
+++ b/src/episteme_graph/agents/equation_semantics/validator.py
@@ -150,6 +150,32 @@ class EquationSemanticsValidator:
                 field=f"{eid}.candidate_trace_ids",
             ))
 
+        # Issue #368: a rejected LLM label / equation_id is kept as audit
+        # metadata; surface it as a warning so the override is traceable.
+        src_loc = record.source_extraction.source_location or {}
+        rejected_label = src_loc.get("llm_rejected_label")
+        if rejected_label is not None:
+            issues.append(ValidationIssue(
+                rule_id="llm_label_overridden",
+                severity="warning",
+                message=(
+                    f"{eid} LLM-proposed label {rejected_label!r} was rejected by the "
+                    "source-aware validator and normalized away"
+                ),
+                field=f"{eid}.source_extraction.source_location.llm_rejected_label",
+            ))
+        rejected_eq_id = src_loc.get("llm_rejected_equation_id")
+        if rejected_eq_id is not None:
+            issues.append(ValidationIssue(
+                rule_id="llm_equation_id_overridden",
+                severity="warning",
+                message=(
+                    f"{eid} LLM-proposed equation_id {rejected_eq_id!r} was discarded; "
+                    "the deterministic normalized id is used instead"
+                ),
+                field=f"{eid}.source_extraction.source_location.llm_rejected_equation_id",
+            ))
+
         # source_extraction.block_id must exist
         block_id = record.source_extraction.source_location.get("block_id", "")
         if not block_id:

--- a/src/tests/agents/component_assembly/test_agent.py
+++ b/src/tests/agents/component_assembly/test_agent.py
@@ -341,6 +341,69 @@ def test_empty_llm_components_triggers_repair_regeneration():
     assert "fallback_reason" not in result.diagnostics
 
 
+def test_strip_unavailable_equation_refs_covers_all_sources():
+    """The cleanup removes dangling equation refs from every source the preflight
+    inspects (claims, thesis nodes, DSL node source_refs, DSL edge evidence_refs)
+    and the preflight then passes (#368 follow-up)."""
+    from episteme_graph.agents.component_assembly.agent import (
+        _preflight_check,
+        _strip_unavailable_equation_refs,
+    )
+    from episteme_graph.agents.component_assembly.schema import ComponentAssemblyLLMInput
+
+    llm_input = ComponentAssemblyLLMInput(
+        document_id="doc",
+        cartridge_id=None,
+        accepted_claims=[{"claim_id": "c1", "equation_ids": ["eq_real", "eq_ghost1"]}],
+        equations=[],
+        thesis_nodes=[{"node_id": "t1", "equation_ids": ["eq_ghost2"]}],
+        dsl_nodes=[{"node_id": "n1", "source_refs": {"equation_ids": ["eq_ghost3", "eq_real"]}}],
+        dsl_edges=[{"edge_id": "e1", "evidence_refs": {"equation_ids": ["eq_ghost4"]}}],
+        allowed_component_types=[],
+        allowed_dependency_types=[],
+        available_claims=[{"claim_id": "c1", "equation_ids": ["eq_real", "eq_ghost1"]}],
+        available_equations=[{"equation_id": "eq_real"}],
+    )
+
+    removed = _strip_unavailable_equation_refs(llm_input)
+    assert {r["equation_id"] for r in removed} == {"eq_ghost1", "eq_ghost2", "eq_ghost3", "eq_ghost4"}
+    # valid reference preserved everywhere
+    assert llm_input.available_claims[0]["equation_ids"] == ["eq_real"]
+    assert llm_input.accepted_claims[0]["equation_ids"] == ["eq_real"]
+    assert llm_input.thesis_nodes[0]["equation_ids"] == []
+    assert llm_input.dsl_nodes[0]["source_refs"]["equation_ids"] == ["eq_real"]
+    assert llm_input.dsl_edges[0]["evidence_refs"]["equation_ids"] == []
+    # preflight passes after cleanup
+    pf = _preflight_check(llm_input)
+    assert pf["status"] == "passed"
+    assert not any(i["code"] == "accepted_equation_ids_not_available" for i in pf["issues"])
+
+
+def test_dangling_equation_ref_is_non_fatal_even_without_cleanup():
+    """Defense-in-depth: a dangling equation ref alone is non-fatal in the
+    preflight, so it can never trigger the deterministic fallback (#368)."""
+    from episteme_graph.agents.component_assembly.agent import _preflight_check
+    from episteme_graph.agents.component_assembly.schema import ComponentAssemblyLLMInput
+
+    llm_input = ComponentAssemblyLLMInput(
+        document_id="doc",
+        cartridge_id=None,
+        accepted_claims=[],
+        equations=[],
+        thesis_nodes=[{"node_id": "t1", "equation_ids": ["eq_ghost"]}],
+        dsl_nodes=[],
+        dsl_edges=[],
+        allowed_component_types=[],
+        allowed_dependency_types=[],
+        available_claims=[{"claim_id": "c1", "equation_ids": ["eq_ghost"]}],
+        available_equations=[{"equation_id": "eq_real"}],
+    )
+    pf = _preflight_check(llm_input)
+    # the issue is still reported (observability) but is non-fatal
+    assert any(i["code"] == "accepted_equation_ids_not_available" for i in pf["issues"])
+    assert pf["status"] == "passed"
+
+
 def test_dangling_equation_ref_is_stripped_not_fallback():
     """A dangling equation reference must not collapse assembly into a
     deterministic fallback (#368 follow-up). It is stripped from the input,

--- a/src/tests/agents/component_assembly/test_agent.py
+++ b/src/tests/agents/component_assembly/test_agent.py
@@ -341,6 +341,29 @@ def test_empty_llm_components_triggers_repair_regeneration():
     assert "fallback_reason" not in result.diagnostics
 
 
+def test_dangling_equation_ref_is_stripped_not_fallback():
+    """A dangling equation reference must not collapse assembly into a
+    deterministic fallback (#368 follow-up). It is stripped from the input,
+    recorded in diagnostics, and the LLM assembly proceeds normally."""
+    agent = ComponentAssemblyAgent()
+    dsl = _dsl()
+    # n2 references a non-existent equation alongside the valid eq_3_14.
+    dsl.nodes[1].source_refs["equation_ids"].append("eq_DOES_NOT_EXIST")
+
+    with patch.object(agent._llm_client, "generate", return_value=_valid_response()):
+        result = agent.run(_qualified(), equations=_equations(), thesis=_thesis(), dsl=dsl)
+
+    # LLM assembly ran — no deterministic fallback, no abort.
+    assert all(c.maturity_source != "deterministic_fallback" for c in result.components)
+    assert "fallback_reason" not in result.diagnostics
+    # Preflight passed once the dangling ref was removed.
+    assert result.diagnostics["component_assembly_input_validation"]["status"] == "passed"
+    # The dangling reference is recorded for audit.
+    cleanup = result.diagnostics["component_assembly_equation_ref_cleanup"]
+    assert any(r["equation_id"] == "eq_DOES_NOT_EXIST" for r in cleanup)
+    assert all(r["equation_id"] != "eq_3_14" for r in cleanup)
+
+
 def test_empty_llm_components_falls_back_after_repair_attempts():
     agent = ComponentAssemblyAgent()
 

--- a/src/tests/agents/document_structure/test_grobid_parser.py
+++ b/src/tests/agents/document_structure/test_grobid_parser.py
@@ -250,6 +250,26 @@ class TestGROBIDTEIParserFigures:
         assert tbl_blocks
         assert any("Table 1" in b.text for b in tbl_blocks)
 
+    def test_table_cell_formula_carries_table_provenance(self):
+        """Issue #368: a formula inside <figure type=table> keeps table provenance."""
+        tei = (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<TEI xmlns="http://www.tei-c.org/ns/1.0"><text><body>'
+            '<div n="1"><head>Results</head>'
+            '<figure type="table" xml:id="tab1">'
+            '<figDesc>Table 1. Coefficients.</figDesc>'
+            '<formula xml:id="t1f1">S = 3.488 beta_2 + 0.28 beta_K2</formula>'
+            '</figure></div></body></text></TEI>'
+        )
+        parser = GROBIDTEIParser()
+        result = parser.parse(tei)
+        eq_blocks = [b for b in result.blocks if b.block_type == "equation_block"]
+        assert len(eq_blocks) == 1
+        raw = eq_blocks[0].raw
+        assert raw.get("container_type") == "table"
+        assert raw.get("in_table") is True
+        assert raw.get("table_id") == "tab1"
+
 
 class TestGROBIDTEIParserProvenance:
     def test_parser_source_set_on_blocks(self):

--- a/src/tests/agents/equation_semantics/test_acceptance_gate.py
+++ b/src/tests/agents/equation_semantics/test_acceptance_gate.py
@@ -172,7 +172,23 @@ def test_coefficient_row_is_flagged_as_table_derived():
     assert "table_derived_equation_candidate" in result.review_reason
 
 
-def test_normal_equation_is_not_flagged_as_table():
-    c = _make_candidate("E = m c^2 (3.1)", block_id="blk_n1")
+def test_issue_coefficient_formula_is_not_accepted():
+    # The issue's example: a linear combination of decimal-coefficient products
+    # that carries an "=" must still be treated as table-derived.
+    text = "S_g^(0) = b_1^-1 (3.488 beta_2 + 0.28 beta_K2 + 0.11 beta_3)"
+    c = _make_candidate(text, block_id="blk_coef")
+    result = GATE.process([c])[0]
+    assert result.acceptance_status != "accepted"
+    assert "table_derived_equation_candidate" in result.review_reason
+
+
+@pytest.mark.parametrize("text", [
+    "E = m c^2 (3.1)",            # normal physics equation
+    r"\Gamma = 1.16 G_F^2 m^5",  # single-letter coefficients
+    r"\alpha_s = 0.118",          # single numeric coefficient
+    "y = 2 x + 3 z",             # integer linear combination
+])
+def test_normal_equation_is_not_flagged_as_table(text):
+    c = _make_candidate(text, block_id="blk_n1")
     result = GATE.process([c])[0]
     assert "table_derived_equation_candidate" not in result.review_reason

--- a/src/tests/agents/equation_semantics/test_acceptance_gate.py
+++ b/src/tests/agents/equation_semantics/test_acceptance_gate.py
@@ -5,7 +5,20 @@ from episteme_graph.agents.equation_semantics.acceptance_gate import EquationAcc
 from episteme_graph.agents.equation_semantics.schema import EquationCandidate
 
 
-def _make_candidate(raw_text: str, block_id: str = "blk_1", page: int = 1, section_id: str = "sec_1") -> EquationCandidate:
+def _make_candidate(
+    raw_text: str,
+    block_id: str = "blk_1",
+    page: int = 1,
+    section_id: str = "sec_1",
+    high_signal: bool = False,
+) -> EquationCandidate:
+    """Build a candidate.
+
+    By default this is a *non* high-signal candidate (no matched_label, low
+    candidate_score) so the acceptance-gate contract for label-only / fragment
+    candidates can be tested. Pass ``high_signal=True`` to exercise the
+    provisional-retention path (issue #259).
+    """
     return EquationCandidate(
         candidate_id=f"eqcand_{block_id}",
         document_id="doc_test",
@@ -13,7 +26,7 @@ def _make_candidate(raw_text: str, block_id: str = "blk_1", page: int = 1, secti
         raw_text=raw_text,
         matched_label=None,
         detection_method=["document_structure_equation_block"],
-        candidate_score=1.0,
+        candidate_score=1.0 if high_signal else 0.5,
         extraction_status="unparsed",
         acceptance_status="rejected",
         needs_math_review=False,
@@ -61,6 +74,24 @@ def test_fragment_only_is_needs_merge(text):
     assert result[0].extraction_status == "fragment_only"
     assert result[0].acceptance_status == "needs_merge"
     assert "fragment_only_candidate" in result[0].review_reason
+
+
+# ------------------------------------------------------------------
+# high-signal label-only / fragment-only → provisional (issue #259 contract)
+# ------------------------------------------------------------------
+
+def test_high_signal_label_only_is_provisional():
+    c = _make_candidate("(3.14)", high_signal=True)
+    result = GATE.process([c])[0]
+    assert result.extraction_status == "label_only"
+    assert result.acceptance_status == "provisional"
+
+
+def test_high_signal_fragment_only_is_provisional():
+    c = _make_candidate("+", high_signal=True)
+    result = GATE.process([c])[0]
+    assert result.extraction_status == "fragment_only"
+    assert result.acceptance_status == "provisional"
 
 
 # ------------------------------------------------------------------
@@ -172,10 +203,17 @@ def test_coefficient_row_is_flagged_as_table_derived():
     assert "table_derived_equation_candidate" in result.review_reason
 
 
-def test_issue_coefficient_formula_is_not_accepted():
-    # The issue's example: a linear combination of decimal-coefficient products
-    # that carries an "=" must still be treated as table-derived.
-    text = "S_g^(0) = b_1^-1 (3.488 beta_2 + 0.28 beta_K2 + 0.11 beta_3)"
+@pytest.mark.parametrize("text", [
+    # Unicode Greek with subscript
+    "S_g^(0) = b_1^-1 (3.488β_2 + 0.28β_K2 + 0.11β_3)",
+    # LaTeX command with braced subscript
+    r"S_g^(0) = b_1^-1 (3.488\beta_2 + 0.28\beta_{K2})",
+    # ASCII names with subscript
+    "S_g^(0) = b_1^-1 (3.488 beta_2 + 0.28 beta_K2)",
+])
+def test_issue_coefficient_formula_is_not_accepted(text):
+    # A linear combination of decimal coefficients × subscripted parameters of
+    # the same family must be treated as table-derived even with an "=".
     c = _make_candidate(text, block_id="blk_coef")
     result = GATE.process([c])[0]
     assert result.acceptance_status != "accepted"
@@ -183,10 +221,11 @@ def test_issue_coefficient_formula_is_not_accepted():
 
 
 @pytest.mark.parametrize("text", [
-    "E = m c^2 (3.1)",            # normal physics equation
-    r"\Gamma = 1.16 G_F^2 m^5",  # single-letter coefficients
-    r"\alpha_s = 0.118",          # single numeric coefficient
-    "y = 2 x + 3 z",             # integer linear combination
+    "y = 0.50 income + 1.20 education",  # natural-language regression vars
+    "E = m c^2 (3.1)",                    # normal physics equation
+    r"\Gamma = 1.16 G_F^2 m^5",          # single decimal-coefficient product
+    r"\alpha_s = 0.118",                  # single numeric coefficient
+    "y = 2 x + 3 z",                     # integer linear combination
 ])
 def test_normal_equation_is_not_flagged_as_table(text):
     c = _make_candidate(text, block_id="blk_n1")

--- a/src/tests/agents/equation_semantics/test_acceptance_gate.py
+++ b/src/tests/agents/equation_semantics/test_acceptance_gate.py
@@ -151,3 +151,28 @@ def test_process_returns_all_candidates():
     assert statuses["blk_0"] == "accepted"
     assert statuses["blk_1"] == "rejected"
     assert statuses["blk_2"] == "needs_merge"
+
+
+# ------------------------------------------------------------------
+# Issue #368: table-derived candidates must not auto-confirm
+# ------------------------------------------------------------------
+
+def test_table_provenance_candidate_is_not_auto_confirmed():
+    c = _make_candidate("a = b + c (2.1)", block_id="blk_t1")
+    c.source_location["table_provenance"] = {"table_id": "tbl_3", "row": 2}
+    result = GATE.process([c])[0]
+    assert result.acceptance_status != "accepted"
+    assert "table_derived_equation_candidate" in result.review_reason
+
+
+def test_coefficient_row_is_flagged_as_table_derived():
+    c = _make_candidate("0.12  0.34  0.56  0.78", block_id="blk_t2")
+    result = GATE.process([c])[0]
+    assert result.acceptance_status != "accepted"
+    assert "table_derived_equation_candidate" in result.review_reason
+
+
+def test_normal_equation_is_not_flagged_as_table():
+    c = _make_candidate("E = m c^2 (3.1)", block_id="blk_n1")
+    result = GATE.process([c])[0]
+    assert "table_derived_equation_candidate" not in result.review_reason

--- a/src/tests/agents/equation_semantics/test_agent.py
+++ b/src/tests/agents/equation_semantics/test_agent.py
@@ -71,6 +71,18 @@ def _response(equation_id, block_id, label, text, eq_type, summary, symbols=None
         "linked_text_spans": [],
         "summary": summary,
         "review_flags": [],
+        # PDF-derived equation candidates are mandatorily reconstructed (#245);
+        # a realistic LLM response therefore carries a reconstruction block.
+        # (Ignored for trusted tex_source equations.)
+        "reconstruction": {
+            "latex": text,
+            "plain_text": text,
+            "status": "reconstructed_from_neighbors",
+            "method": ["nearby_text_context"],
+            "supporting_refs": [block_id],
+            "confidence": 0.8,
+            "review_required": True,
+        },
     }
 
 
@@ -129,6 +141,11 @@ def test_candidate_trace_ids_in_record():
 
 def test_fragment_only_blocks_are_not_processed_by_llm():
     """Fragment-only equation blocks should be gated out before LLM call."""
+    # A low-confidence "+" fragment with no matched label is non high-signal,
+    # so the acceptance gate marks it needs_merge (not provisional) and it is
+    # never sent to the LLM (issue #259 contract).
+    fragment = _typed("e1", "+", "equation_block", 1)
+    fragment.confidence = 0.5
     structure = DocumentStructureResult(
         document_id="doc_test",
         source_file="/tmp/test.pdf",
@@ -137,7 +154,7 @@ def test_fragment_only_blocks_are_not_processed_by_llm():
         sections=[Section("sec_1", "Results", 1, 1, 1)],
         blocks=[
             _typed("b0", "the term is", "body_paragraph", 0),
-            _typed("e1", "+", "equation_block", 1),  # fragment-only
+            fragment,  # fragment-only, non high-signal
             _typed("e2", "N = a + b (1.1)", "equation_block", 2),  # valid
         ],
     )

--- a/src/tests/agents/equation_semantics/test_export.py
+++ b/src/tests/agents/equation_semantics/test_export.py
@@ -194,3 +194,67 @@ def test_export_reconstruction_fallback_for_latex():
     assert e["confidence_policy"]["display_requires_note"] is True
     assert e["confidence_policy"]["can_be_rendered_as_final_formula"] is False
     assert e["confidence_policy"]["allowed_downstream_use"] == "display_with_warning"
+
+
+def test_prose_reconstruction_is_excluded_from_export_display():
+    """Issue #368: a latex_is_prose reconstruction must not appear as display math."""
+    src = EquationSourceExtraction(
+        raw_text="xi_c is a specific combination",
+        latex=None,
+        plain_text=None,
+        source_location={"page": 1, "section_id": "sec_1", "block_id": "blk_p", "bbox": []},
+        extraction_source="pdf_text_layer",
+        extraction_status="partial",
+        needs_math_review=True,
+        review_reason=["partial_extraction"],
+    )
+    rec = EquationReconstruction(
+        latex=r"\xi_c \equiv \text{(a specific convolution symmetric combination of moments)}",
+        plain_text="xi_c is a specific combination of moments",
+        status="reconstructed_from_neighbors",
+        method=["text_context_fallback"],
+        supporting_refs=["blk_0"],
+        confidence=0.4,
+        review_required=True,
+        review_reason=["latex_is_prose"],
+    )
+    sem = EquationSemantics(
+        equation_type="definition",
+        secondary_types=[],
+        semantic_status="reconstruction_based",
+        confidence=0.4,
+        reason="prose",
+        defined_symbols=[],
+        used_symbols=["xi_c"],
+        assumptions=[],
+        input_equation_ids=[],
+        output_equation_ids=[],
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary="A prose definition.",
+        review_flags=["needs_reconstruction"],
+    )
+    cp = EquationConfidencePolicy.derive(src, rec, sem)
+    record = EquationRecord(
+        equation_id="eq_prose_1",
+        document_id="doc_test",
+        label=None,
+        candidate_trace_ids=["eqcand_blk_p"],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=cp,
+    )
+    result = EquationSemanticsResult("doc_test", None, [], [record])
+    e = result.to_equations_export()[0]
+    # Display fields nulled out — never publish the paraphrase as display math.
+    assert e["latex"] is None
+    assert e["plain_text"] is None
+    # Reconstruction retained as audit data, with the reason code preserved.
+    assert e["reconstruction"]["latex"].startswith(r"\xi_c")
+    assert "latex_is_prose" in e["reconstruction"]["review_reason"]
+    # Downstream confidence gate blocks claim / derivation / final formula.
+    assert e["confidence_policy"]["can_support_claim"] is False
+    assert e["confidence_policy"]["can_be_used_in_derivation"] is False
+    assert e["confidence_policy"]["can_be_rendered_as_final_formula"] is False

--- a/src/tests/agents/equation_semantics/test_fidelity.py
+++ b/src/tests/agents/equation_semantics/test_fidelity.py
@@ -1,0 +1,227 @@
+"""Tests for the equation reconstruction fidelity guards (issue #368)."""
+from episteme_graph.agents.equation_semantics.fidelity import (
+    apply_fidelity_guards,
+    apply_prose_latex_guard,
+    apply_symbol_loss_guard,
+    is_prose_latex,
+    validate_io_links,
+)
+from episteme_graph.agents.equation_semantics.schema import (
+    DefinedSymbol,
+    EquationConsistency,
+    EquationRecord,
+    EquationReconstruction,
+    EquationSemantics,
+    EquationSemanticsResult,
+    EquationSourceExtraction,
+)
+
+
+# ------------------------------------------------------------------
+# Builders
+# ------------------------------------------------------------------
+
+def _src(needs_review=True, image=None, review_reason=None):
+    return EquationSourceExtraction(
+        raw_text="r-q = a",
+        latex=None,
+        plain_text=None,
+        source_location={"page": 1, "section_id": "sec_1", "block_id": "blk_e1", "bbox": []},
+        extraction_source="pdf_text_layer",
+        extraction_status="partial",
+        needs_math_review=needs_review,
+        review_reason=list(review_reason or []),
+        source_image=image,
+    )
+
+
+def _rec(latex, status="reconstructed_from_neighbors", review_reason=None):
+    return EquationReconstruction(
+        latex=latex,
+        plain_text=None,
+        status=status,
+        method=["text_context_fallback"],
+        supporting_refs=["blk_0"],
+        confidence=0.6,
+        review_required=False,
+        review_reason=list(review_reason or []),
+    )
+
+
+def _sem(inputs=None, outputs=None):
+    return EquationSemantics(
+        equation_type="relation",
+        secondary_types=[],
+        semantic_status="reconstruction_based",
+        confidence=0.6,
+        reason="test",
+        defined_symbols=[DefinedSymbol("a", "defined", None)],
+        used_symbols=["r", "q"],
+        assumptions=[],
+        input_equation_ids=list(inputs or []),
+        output_equation_ids=list(outputs or []),
+        linked_text_spans=[],
+        source_evidence_ids=[],
+        linked_claim_ids=[],
+        summary="A relation.",
+        review_flags=[],
+    )
+
+
+def _record(eq_id="eq_1", src=None, rec=None, sem=None, consistency=None):
+    src = src if src is not None else _src()
+    rec = rec if rec is not None else _rec("a = b")
+    sem = sem if sem is not None else _sem()
+    consistency = consistency if consistency is not None else EquationConsistency.derive(
+        source_extraction=src, reconstruction=rec, label=None, semantics=sem,
+    )
+    return EquationRecord(
+        equation_id=eq_id,
+        document_id="doc",
+        label=None,
+        candidate_trace_ids=["eqcand_blk_e1"],
+        source_extraction=src,
+        reconstruction=rec,
+        semantics=sem,
+        confidence_policy=None,  # populated by guard / not needed for these asserts
+        equation_consistency=consistency,
+    )
+
+
+# ------------------------------------------------------------------
+# 1. prose-as-latex
+# ------------------------------------------------------------------
+
+def test_prose_latex_is_detected():
+    latex = r"\xi_c \equiv \text{(specific convolution-symmetric combination of moments)}"
+    assert is_prose_latex(latex) is True
+
+
+def test_normal_equation_with_subject_to_text_is_not_prose():
+    latex = r"\min_x f(x) \quad \text{subject to } g(x) \le 0"
+    assert is_prose_latex(latex) is False
+
+
+def test_real_equation_with_inline_annotation_is_not_prose():
+    latex = r"E = m c^2 \text{ where m is the rest mass and c the speed of light}"
+    assert is_prose_latex(latex) is False
+
+
+def test_equation_without_text_block_is_not_prose():
+    assert is_prose_latex(r"a^2 + b^2 = c^2") is False
+    assert is_prose_latex("") is False
+    assert is_prose_latex(None) is False
+
+
+def test_apply_prose_latex_guard_blocks_downstream_use():
+    rec = _rec(r"\xi_c \equiv \text{(a specific convolution symmetric combination)}")
+    record = _record(rec=rec)
+    flagged = apply_prose_latex_guard(record)
+    assert flagged is True
+    assert "latex_is_prose" in record.reconstruction.review_reason
+    assert "latex_is_prose" in record.equation_consistency.review_reason
+    assert record.equation_consistency.review_required is True
+    assert record.confidence_policy.can_support_claim is False
+    assert record.confidence_policy.can_be_used_in_derivation is False
+    assert record.confidence_policy.can_be_rendered_as_final_formula is False
+
+
+def test_apply_prose_latex_guard_leaves_real_equation_alone():
+    record = _record(rec=_rec("a = b + c"))
+    assert apply_prose_latex_guard(record) is False
+    assert "latex_is_prose" not in record.reconstruction.review_reason
+
+
+# ------------------------------------------------------------------
+# 4. I/O link referential integrity
+# ------------------------------------------------------------------
+
+def test_io_links_membership_filters_nonequation_ids():
+    eq1 = _record(eq_id="eq_1", sem=_sem(inputs=["eq_2", "blk_99", "eq_1"], outputs=["eq_3"]))
+    eq2 = _record(eq_id="eq_2")
+    issues = validate_io_links([eq1, eq2])
+    # eq_2 kept; blk_99 (not a final id) and eq_1 (self) removed; eq_3 dangling removed
+    assert eq1.semantics.input_equation_ids == ["eq_2"]
+    assert eq1.semantics.output_equation_ids == []
+    assert "nonequation_id_in_links" in eq1.semantics.review_flags
+    assert len(issues) == 1
+    assert "blk_99" in issues[0].message
+    assert "eq_3" in issues[0].message
+
+
+def test_io_links_all_valid_no_issue():
+    eq1 = _record(eq_id="eq_1", sem=_sem(inputs=["eq_2"]))
+    eq2 = _record(eq_id="eq_2")
+    issues = validate_io_links([eq1, eq2])
+    assert issues == []
+    assert eq1.semantics.input_equation_ids == ["eq_2"]
+    assert "nonequation_id_in_links" not in eq1.semantics.review_flags
+
+
+# ------------------------------------------------------------------
+# 5. unverifiable symbol loss
+# ------------------------------------------------------------------
+
+def test_symbol_loss_unverifiable_when_image_missing():
+    src = _src(review_reason=["vision_ocr_unavailable:equation_image_unavailable"])
+    consistency = EquationConsistency(
+        raw_text_latex_match="mismatch",
+        label_location_match="uncertain",
+        symbol_overlap_score=0.1,
+        source_span_quality="partial",
+        review_required=True,
+        review_reason=["raw_text_latex_symbol_mismatch"],
+    )
+    record = _record(src=src, consistency=consistency)
+    assert apply_symbol_loss_guard(record) is True
+    assert "symbol_loss_unverifiable" in record.equation_consistency.review_reason
+
+
+def test_symbol_loss_not_flagged_when_image_available():
+    consistency = EquationConsistency(
+        raw_text_latex_match="mismatch",
+        label_location_match="uncertain",
+        symbol_overlap_score=0.1,
+        source_span_quality="partial",
+        review_required=True,
+        review_reason=["raw_text_latex_symbol_mismatch"],
+    )
+    src = _src(image={"mime_type": "image/png", "data_base64": "x"})
+    record = _record(src=src, consistency=consistency)
+    assert apply_symbol_loss_guard(record) is False
+    assert "symbol_loss_unverifiable" not in record.equation_consistency.review_reason
+
+
+def test_symbol_loss_not_flagged_without_mismatch():
+    consistency = EquationConsistency(
+        raw_text_latex_match="match",
+        label_location_match="match",
+        symbol_overlap_score=0.9,
+        source_span_quality="clean",
+        review_required=False,
+        review_reason=[],
+    )
+    record = _record(consistency=consistency)
+    assert apply_symbol_loss_guard(record) is False
+
+
+# ------------------------------------------------------------------
+# orchestration
+# ------------------------------------------------------------------
+
+def test_apply_fidelity_guards_runs_all():
+    prose = _record(
+        eq_id="eq_1",
+        rec=_rec(r"x \equiv \text{(some long paraphrased prose combination here)}"),
+        sem=_sem(inputs=["blk_55"]),
+    )
+    result = EquationSemanticsResult(
+        document_id="doc",
+        cartridge_id=None,
+        equation_candidates=[],
+        equations=[prose],
+    )
+    issues = apply_fidelity_guards(result)
+    assert "latex_is_prose" in prose.reconstruction.review_reason
+    assert "nonequation_id_in_links" in prose.semantics.review_flags
+    assert any(i.rule_id == "nonequation_id_in_links" for i in issues)

--- a/src/tests/agents/equation_semantics/test_input_builder.py
+++ b/src/tests/agents/equation_semantics/test_input_builder.py
@@ -123,6 +123,29 @@ def test_build_candidates_flags_table_provenance():
     assert cand.source_location["table_provenance"]["table_id"] == "tbl_2"
 
 
+def test_table_provenance_propagates_to_acceptance_gate():
+    # Issue #368 integration: block.raw table provenance -> candidate -> gate
+    # keeps the equation out of the auto-confirmed set.
+    from episteme_graph.agents.equation_semantics.acceptance_gate import (
+        EquationAcceptanceGate,
+    )
+
+    structure = _structure()
+    tbl = _typed("e_tabcell", "a = b + c (9.1)", "equation_block", 9)
+    tbl.raw = {"container_type": "table", "in_table": True, "table_id": "tab1"}
+    structure.blocks.append(tbl)
+
+    candidates = BUILDER.build_candidates(structure)
+    classified = EquationAcceptanceGate().process(candidates)
+    cell = next(c for c in classified if c.source_location["block_id"] == "e_tabcell")
+    assert cell.acceptance_status != "accepted"
+    assert "table_derived_equation_candidate" in cell.review_reason
+
+    # a normal equation block in the same structure is still accepted
+    normal = next(c for c in classified if c.source_location["block_id"] == "e1")
+    assert normal.acceptance_status == "accepted"
+
+
 # ------------------------------------------------------------------
 # build_llm_inputs
 # ------------------------------------------------------------------

--- a/src/tests/agents/equation_semantics/test_input_builder.py
+++ b/src/tests/agents/equation_semantics/test_input_builder.py
@@ -98,6 +98,31 @@ def test_build_candidates_max_limit():
     assert candidates[0].source_location["block_id"] == "e1"
 
 
+def test_build_candidates_flags_invalid_label():
+    # Issue #368: a garbage GROBID label is rejected and recorded for audit.
+    structure = _structure()
+    bad = _typed("e_bad", "F = ma", "equation_block", 4)
+    bad.equation_label = "(1) g , K (3)"
+    structure.blocks.append(bad)
+    candidates = BUILDER.build_candidates(structure)
+    cand = next(c for c in candidates if c.source_location["block_id"] == "e_bad")
+    assert cand.matched_label is None
+    assert "invalid_equation_label" in cand.review_reason
+    assert cand.source_location["rejected_equation_label"] == "(1) g , K (3)"
+
+
+def test_build_candidates_flags_table_provenance():
+    # Issue #368: a block carrying table provenance is marked table-derived.
+    structure = _structure()
+    tbl = _typed("e_tbl", "a = b + c (5.1)", "equation_block", 5)
+    tbl.raw = {"table_id": "tbl_2", "row": 1}
+    structure.blocks.append(tbl)
+    candidates = BUILDER.build_candidates(structure)
+    cand = next(c for c in candidates if c.source_location["block_id"] == "e_tbl")
+    assert "table_derived_equation_candidate" in cand.review_reason
+    assert cand.source_location["table_provenance"]["table_id"] == "tbl_2"
+
+
 # ------------------------------------------------------------------
 # build_llm_inputs
 # ------------------------------------------------------------------

--- a/src/tests/agents/equation_semantics/test_normalizer.py
+++ b/src/tests/agents/equation_semantics/test_normalizer.py
@@ -38,3 +38,58 @@ def test_plain_text_replaces_common_symbols():
     assert "Gamma" in eq.plain_text
     assert "tau" in eq.plain_text
     assert "nu" in eq.plain_text
+
+
+# ------------------------------------------------------------------
+# Issue #368: source-aware label validation
+# ------------------------------------------------------------------
+
+def test_invalid_pdf_label_is_rejected_and_id_falls_back_to_block():
+    block = TypedBlock("blk_7", 1, 0, "F = ma", "equation_block", equation_label="(1) g , K (3)")
+    eq = EquationNormalizer().normalize(block)
+    assert eq.label is None
+    assert eq.label_is_valid is False
+    assert eq.rejected_label == "(1) g , K (3)"
+    # Equation id must not be derived from the garbage label.
+    assert eq.equation_id == "eq_blk_7"
+
+
+def test_stray_paren_label_is_rejected():
+    block = TypedBlock("blk_8", 1, 0, "F = ma", "equation_block", equation_label="(")
+    eq = EquationNormalizer().normalize(block)
+    assert eq.label is None
+    assert eq.label_is_valid is False
+    assert eq.equation_id == "eq_blk_8"
+
+
+def test_numeric_label_with_parens_is_accepted():
+    block = TypedBlock("blk_9", 1, 0, "F = ma", "equation_block", equation_label="(3.14)")
+    eq = EquationNormalizer().normalize(block)
+    assert eq.label == "3.14"
+    assert eq.label_is_valid is True
+    assert eq.equation_id == "eq_3_14"
+
+
+def test_missing_label_is_valid_unnumbered_equation():
+    block = TypedBlock("blk_10", 1, 0, "F = ma", "equation_block")
+    eq = EquationNormalizer().normalize(block)
+    assert eq.label is None
+    assert eq.label_is_valid is True
+    assert eq.rejected_label is None
+
+
+def test_tex_semantic_label_is_preserved():
+    raw = {"extraction_source": "tex_source"}
+    block = TypedBlock("blk_11", 1, 0, "F = ma", "equation_block", equation_label="eq:dispersion", raw=raw)
+    eq = EquationNormalizer().normalize(block)
+    assert eq.label == "eq:dispersion"
+    assert eq.label_is_valid is True
+    assert eq.equation_id == "eq_eq_dispersion"
+
+
+def test_cartridge_extra_pattern_accepts_custom_label():
+    block = TypedBlock("blk_12", 1, 0, "F = ma", "equation_block", equation_label="EQ-X42")
+    norm = EquationNormalizer(extra_label_patterns=[r"^EQ-[A-Z]\d+$"])
+    eq = norm.normalize(block)
+    assert eq.label == "EQ-X42"
+    assert eq.label_is_valid is True

--- a/src/tests/agents/equation_semantics/test_repair.py
+++ b/src/tests/agents/equation_semantics/test_repair.py
@@ -78,11 +78,30 @@ def test_invalid_llm_equation_id_keeps_normalized_id():
     assert any(i.rule_id == "llm_equation_id_overridden" for i in issues)
 
 
-def test_valid_llm_label_is_adopted_and_id_rederived():
-    raw = _base_raw(label="3.15", equation_id="whatever")
+def test_valid_llm_label_is_not_adopted_canonical_maintained():
+    # Even a syntactically valid different label must not replace the canonical
+    # input label / id (issue #368 follow-up): both stay pinned to llm_input.
+    raw = _base_raw(label="3.15", equation_id="eq_3_15")
     record = _parse_record(raw, _llm_input(label="3.14", equation_id="eq_3_14"), None)
-    assert record.label == "3.15"
-    assert record.equation_id == "eq_3_15"
+    assert record.label == "3.14"
+    assert record.equation_id == "eq_3_14"
+    assert record.source_extraction.source_location["llm_rejected_label"] == "3.15"
+    assert record.source_extraction.source_location["llm_rejected_equation_id"] == "eq_3_15"
+    issues = _validate(record)
+    assert any(i.rule_id == "llm_label_overridden" for i in issues)
+    assert any(i.rule_id == "llm_equation_id_overridden" for i in issues)
+
+
+def test_llm_output_cannot_collide_ids_across_records():
+    # Two records whose LLM outputs both claim "eq_x" must keep their distinct
+    # canonical ids — no LLM-driven id collision (issue #368 D.7).
+    raw_a = _base_raw(equation_id="eq_x", label="eq_x")
+    raw_b = _base_raw(equation_id="eq_x", label="eq_x")
+    rec_a = _parse_record(raw_a, _llm_input(label="3.14", equation_id="eq_3_14"), None)
+    rec_b = _parse_record(raw_b, _llm_input(label="3.15", equation_id="eq_3_15"), None)
+    assert rec_a.equation_id == "eq_3_14"
+    assert rec_b.equation_id == "eq_3_15"
+    assert rec_a.equation_id != rec_b.equation_id
 
 
 def test_trusted_tex_semantic_label_is_maintained():

--- a/src/tests/agents/equation_semantics/test_repair.py
+++ b/src/tests/agents/equation_semantics/test_repair.py
@@ -1,0 +1,107 @@
+"""Tests for repair._parse_record label / equation_id re-validation (issue #368)."""
+from episteme_graph.agents.equation_semantics.repair import _parse_record
+from episteme_graph.agents.equation_semantics.schema import EquationLLMInput
+from episteme_graph.agents.equation_semantics.validator import EquationSemanticsValidator
+from episteme_graph.agents.equation_semantics.schema import EquationSemanticsResult
+
+
+def _llm_input(label="3.14", equation_id="eq_3_14", block_id="blk_e1", source_is_trusted=False):
+    return EquationLLMInput(
+        document_id="doc",
+        cartridge_id=None,
+        equation_id=equation_id,
+        block_id=block_id,
+        section_id="sec_1",
+        section_title="Sec",
+        backbone_block_type=None,
+        label=label,
+        equation_text="N = a + b",
+        latex=None,
+        plain_text="N = a + b",
+        prev_texts=["ctx"],
+        next_texts=["ctx"],
+        nearby_span_annotations=[],
+        extraction_status="complete",
+        acceptance_status="accepted",
+        needs_reconstruction=False,
+        extraction_source="pdf_text_layer",
+        source_is_trusted=source_is_trusted,
+    )
+
+
+def _base_raw(**over):
+    raw = {
+        "equation_type": "definition",
+        "secondary_types": [],
+        "semantic_status": "source_backed",
+        "confidence": 0.9,
+        "reason": "ok",
+        "defined_symbols": [{"symbol": "N", "definition_status": "defined"}],
+        "used_symbols": ["a", "b"],
+        "assumptions": [],
+        "input_equation_ids": [],
+        "output_equation_ids": [],
+        "linked_text_spans": [],
+        "summary": "Definition of N.",
+        "review_flags": [],
+    }
+    raw.update(over)
+    return raw
+
+
+def _validate(record):
+    result = EquationSemanticsResult("doc", None, [], [record])
+    return EquationSemanticsValidator().validate(result)
+
+
+# ------------------------------------------------------------------
+# invalid LLM label
+# ------------------------------------------------------------------
+
+def test_invalid_llm_label_does_not_enter_final_record():
+    raw = _base_raw(label="(1) g , K (3)", equation_id="eq_3_14")
+    record = _parse_record(raw, _llm_input(label="3.14", equation_id="eq_3_14"), None)
+    # canonical label kept; garbage LLM label rejected
+    assert record.label == "3.14"
+    assert record.equation_id == "eq_3_14"
+    assert record.source_extraction.source_location["llm_rejected_label"] == "(1) g , K (3)"
+    issues = _validate(record)
+    assert any(i.rule_id == "llm_label_overridden" for i in issues)
+
+
+def test_invalid_llm_equation_id_keeps_normalized_id():
+    raw = _base_raw(label="3.14", equation_id="eq_ (1) g , K")
+    record = _parse_record(raw, _llm_input(label="3.14", equation_id="eq_3_14"), None)
+    assert record.equation_id == "eq_3_14"
+    assert record.source_extraction.source_location["llm_rejected_equation_id"] == "eq_ (1) g , K"
+    issues = _validate(record)
+    assert any(i.rule_id == "llm_equation_id_overridden" for i in issues)
+
+
+def test_valid_llm_label_is_adopted_and_id_rederived():
+    raw = _base_raw(label="3.15", equation_id="whatever")
+    record = _parse_record(raw, _llm_input(label="3.14", equation_id="eq_3_14"), None)
+    assert record.label == "3.15"
+    assert record.equation_id == "eq_3_15"
+
+
+def test_trusted_tex_semantic_label_is_maintained():
+    raw = _base_raw(label="eq:dispersion", equation_id="eq_eq_dispersion")
+    record = _parse_record(
+        raw,
+        _llm_input(label="eq:dispersion", equation_id="eq_eq_dispersion", source_is_trusted=True),
+        None,
+    )
+    assert record.label == "eq:dispersion"
+    assert record.equation_id == "eq_eq_dispersion"
+    # nothing rejected
+    assert "llm_rejected_label" not in record.source_extraction.source_location
+
+
+def test_no_llm_label_keeps_canonical():
+    raw = _base_raw()
+    raw.pop("label", None)
+    record = _parse_record(raw, _llm_input(label="2.1", equation_id="eq_2_1"), None)
+    assert record.label == "2.1"
+    assert record.equation_id == "eq_2_1"
+    assert "llm_rejected_label" not in record.source_extraction.source_location

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -665,6 +665,65 @@ def test_export_validation_lists_equation_consistency_mismatch_candidates():
 
 
 # ---------------------------------------------------------------------------
+# Tests: equation fidelity aggregation (issue #368)
+# ---------------------------------------------------------------------------
+
+def test_equation_fidelity_aggregates_all_problem_types():
+    artifacts = _make_artifacts(equation_semantics={
+        "equations": [
+            {
+                "equation_id": "eq_prose",
+                "review_reason": [],
+                "reconstruction": {"status": "reconstructed_from_neighbors",
+                                   "review_reason": ["latex_is_prose"]},
+                "equation_consistency": {"review_reason": ["latex_is_prose",
+                                                            "symbol_loss_unverifiable"]},
+                "review_flags": ["nonequation_id_in_links"],
+            },
+            {
+                "equation_id": "eq_lbl",
+                "review_reason": ["invalid_equation_label"],
+                "reconstruction": {"status": "none", "review_reason": []},
+                "equation_consistency": {"review_reason": []},
+                "review_flags": [],
+            },
+        ],
+        "equation_candidates": [
+            {"candidate_id": "cand_tab", "review_reason": ["table_derived_equation_candidate"]},
+            {"candidate_id": "cand_lbl", "review_reason": ["invalid_equation_label"]},
+        ],
+    })
+    result = _run_gate(artifacts=artifacts)
+    fidelity = result.equation_fidelity
+    assert fidelity["checked"] is True
+    counts = fidelity["issue_counts"]
+    assert counts["latex_is_prose"] == 2          # reconstruction + consistency
+    assert counts["symbol_loss_unverifiable"] == 1
+    assert counts["nonequation_id_in_links"] == 1
+    assert counts["table_derived_equation_candidate"] == 1
+    assert counts["invalid_equation_label"] == 2  # equation + candidate
+
+    # target ids + artifact paths are present
+    prose_targets = fidelity["issues"]["latex_is_prose"]
+    assert any(t.get("equation_id") == "eq_prose" for t in prose_targets)
+    assert all(t["artifact"] == "equation_semantics" for t in prose_targets)
+    assert all("path" in t for t in prose_targets)
+    tab_targets = fidelity["issues"]["table_derived_equation_candidate"]
+    assert tab_targets[0]["candidate_id"] == "cand_tab"
+    assert "equation_candidates" in tab_targets[0]["path"]
+
+    codes = [e.code for e in result.review_items] + [e.code for e in result.warnings]
+    assert "EQUATION_FIDELITY_LATEX_IS_PROSE" in codes
+    assert "EQUATION_FIDELITY_INVALID_EQUATION_LABEL" in codes
+
+
+def test_equation_fidelity_empty_when_no_equation_artifact():
+    result = _run_gate()
+    assert result.equation_fidelity["checked"] is False
+    assert result.equation_fidelity["total"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Tests: DSL edge validation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements deterministic post-validation passes on assembled `EquationSemanticsResult` to identify and block specific PDF equation reconstruction quality problems. These guards run after LLM semantics processing and add per-problem reason codes for downstream observability and blocking without replacing the existing blanket safety gates.

## Key Changes

### New Fidelity Guard Module (`src/episteme_graph/agents/equation_semantics/fidelity.py`)

- **Prose-as-LaTeX detection** (`is_prose_latex`): Identifies reconstructed LaTeX bodies that are prose paraphrases rather than mathematical expressions using heuristic analysis of `\text{...}` blocks and relation operators
- **Prose guard** (`apply_prose_latex_guard`): Flags prose reconstructions, blocks confirmed downstream use (claim support, derivation, final formula rendering), and recomputes confidence policy
- **I/O link validation** (`validate_io_links`): Verifies input/output equation links by membership in the document's final equation-id set; removes non-equation ids (block ids, candidate ids, self-references, dangling ids) and records them as warnings
- **Symbol-loss unverifiability guard** (`apply_symbol_loss_guard`): Marks symbol loss between raw text and reconstruction as unverifiable when source image/Vision OCR provenance is unavailable
- **Orchestration** (`apply_fidelity_guards`): Runs all guards over an assembled result, mutates records in place, and returns validation issues

### Source-Aware Label Validation (`src/episteme_graph/agents/equation_semantics/normalizer.py`)

- Added `EquationNormalizer.__init__` with configurable allowed label patterns (issue #368)
- Implemented `validate_label` method that:
  - Accepts missing labels as valid (unnumbered equations)
  - Preserves trusted TeX semantic labels (e.g., `\label{eq:dispersion}`)
  - Rejects PDF/GROBID labels that don't match allowed numeric/appendix patterns
  - Returns normalized label, validity flag, and rejected label for audit
- Added `set_extra_label_patterns` for cartridge-provided custom patterns
- Updated `normalize` to track `label_is_valid` and `rejected_label` in `NormalizedEquation`

### Candidate Flagging (`src/episteme_graph/agents/equation_semantics/input_builder.py`)

- Records invalid PDF/GROBID labels in `source_location["rejected_equation_label"]` with `invalid_equation_label` review reason
- Detects table/table-cell provenance via `_table_provenance` method and marks candidates with `table_derived_equation_candidate` review reason
- Stores table provenance metadata in `source_location["table_provenance"]`

### Acceptance Gate Updates (`src/episteme_graph/agents/equation_semantics/acceptance_gate.py`)

- Added `_is_table_derived` check to prevent auto-confirmation of table-derived candidates
- High-signal table candidates marked as provisional (review-required); low-signal marked as context-only
- Detects coefficient rows (numeric-only patterns) as table-derived

### Schema Extensions (`src/episteme_graph/agents/equation_semantics/schema.py`)

- Added fidelity guard reason codes as module constants:
  - `FIDELITY_LATEX_IS_PROSE`
  - `FIDELITY_INVALID_LABEL`
  - `FIDELITY_TABLE_DERIVED`
  - `FIDELITY_NONEQUATION_ID`
  - `FIDELITY_SYMBOL_LOSS_UNVERIFIABLE`
- Added `nonequation_id_in_links` to `EQUATION_REVIEW_REASONS`
- Added `invalid_equation_label` and `table_derived_equation_candidate` to `CANDIDATE_REVIEW_REASONS`

### Export Validation Integration (`backend/core/document_pipeline/export_validation_gate.py`)

- Added `_EQUATION_FIDELITY_CODES` list with all five fidelity problem types
- Implemented `_empty_equation_fidelity

https://claude.ai/code/session_01GuXUwe1B8oB55Aze2A8S7T