### PR TITLE
Async revision pipeline with structured status tracking (#412)

### DIFF
--- a/backend/api/routes/lecture_studio.py
+++ b/backend/api/routes/lecture_studio.py
@@ -1786,7 +1786,8 @@ def _material_pipeline_status(material_id: str, document_id: str) -> dict:
                 """
                 SELECT status, current_stage, error_message, stage_outputs
                 FROM document_analysis_runs
-                WHERE document_id = :document_id OR material_id = :material_id
+                WHERE (document_id = :document_id OR material_id = :material_id)
+                  AND (run_type IS NULL OR run_type <> 'revision')
                 ORDER BY created_at DESC
                 LIMIT 1
                 """

--- a/backend/api/routes/revisions.py
+++ b/backend/api/routes/revisions.py
@@ -21,9 +21,12 @@ from core.document_pipeline import persistence
 from core.document_pipeline.persistence import RevisionConflictError
 from core.document_pipeline.revision import coordinator
 from core.document_pipeline.revision.coordinator import AcceptBlockedError
+import time
+
 from services import (
     create_background_task,
     get_background_task,
+    get_latest_revision_task,
     update_background_task,
 )
 
@@ -100,6 +103,11 @@ def create_revision(
     }
 
 
+# Minimum seconds between throttled progress writes, so a 199-checkpoint audit
+# does not hammer the DB once per checkpoint (#414-3).
+_PROGRESS_MIN_INTERVAL = 1.0
+
+
 def _revision_run_worker(
     *,
     task_id: str,
@@ -110,17 +118,40 @@ def _revision_run_worker(
     """Background worker: run the whole revision pipeline off the HTTP request.
 
     Long-running LLM audit/proposal work no longer blocks the request (so Nginx
-    never 504s mid-run); progress is observable via the task + revision status
-    (#412 P0-2). Failures are recorded on the task so the UI can show a real
-    server error rather than a generic timeout.
+    never 504s mid-run); progress — including ``completed / total`` per stage —
+    is observable via the task + revision status (#412 P0-2 / #414-3). Failures
+    are recorded on the task so the UI can show a real server error rather than a
+    generic timeout.
     """
     def _result(**extra) -> dict:
         return {"document_id": document_id, "revision_run_id": revision_id, **extra}
 
+    state = {"last": 0.0}
+
+    def on_progress(stage: str, completed: int, total: int) -> None:
+        now = time.monotonic()
+        boundary = (completed == 0) or (total and completed >= total)
+        if not boundary and (now - state["last"]) < _PROGRESS_MIN_INTERVAL:
+            return
+        state["last"] = now
+        pct = int(completed * 100 / total) if total else 0
+        update_background_task(
+            task_id, "processing",
+            result_data=_result(stage=stage, label="反復改善",
+                                 completed_count=completed, total_count=total,
+                                 progress=pct),
+        )
+
     try:
-        update_background_task(task_id, "processing",
-                               result_data=_result(stage="audit", label="反復改善", progress=0))
-        result = coordinator.run_revision_pipeline(run_id=revision_id, operations=operations)
+        update_background_task(
+            task_id, "processing",
+            result_data=_result(stage="audit", label="反復改善",
+                                 completed_count=0, total_count=0, progress=0),
+        )
+        result = coordinator.run_revision_pipeline(
+            run_id=revision_id, operations=operations,
+            progress_callback=on_progress, task_id=task_id,
+        )
         update_background_task(
             task_id, "completed",
             result_data=_result(
@@ -169,22 +200,34 @@ def run_revision(
     rejected with 409.
     """
     _authorize_edit(document_id, current_user)
-    run = _require_run_for_document(document_id, revision_id)
-    # Only an actively-running worker blocks a re-run; a freshly-created
-    # ``pending`` revision is still startable (#412 P0-2).
-    if str(run.get("status") or "").lower() == "running":
+    _require_run_for_document(document_id, revision_id)
+    # Acquire the right to run atomically in the DB — not via a read-then-write
+    # check — so two concurrent POSTs cannot both start a worker (#414-1). The
+    # loser gets 409. Works across multiple API processes.
+    if not persistence.claim_revision_run(run_id=revision_id):
         raise HTTPException(status_code=409, detail="revision run already in progress")
 
     task_id = str(uuid.uuid4())[:12]
-    create_background_task(task_id, "revision_pipeline", _user_id(current_user))
-    update_background_task(task_id, "pending", result_data={
-        "document_id": document_id, "revision_run_id": revision_id,
-        "stage": "queued", "label": "反復改善", "progress": 0,
-    })
-    _launch_revision_worker(
-        task_id=task_id, document_id=document_id,
-        revision_id=revision_id, operations=body.operations,
-    )
+    try:
+        create_background_task(task_id, "revision_pipeline", _user_id(current_user))
+        update_background_task(task_id, "pending", result_data={
+            "document_id": document_id, "revision_run_id": revision_id,
+            "stage": "queued", "label": "反復改善",
+            "completed_count": 0, "total_count": 0, "progress": 0,
+        })
+        _launch_revision_worker(
+            task_id=task_id, document_id=document_id,
+            revision_id=revision_id, operations=body.operations,
+        )
+    except Exception as exc:  # noqa: BLE001
+        # Task/worker could not start: release the claim so the run is retryable
+        # rather than stuck in 'running' (#414-1).
+        persistence.release_revision_run(
+            run_id=revision_id,
+            error_message=coordinator._safe_error("worker_launch_failed", exc),
+        )
+        logger.exception("failed to launch revision worker: run=%s", revision_id)
+        raise HTTPException(status_code=500, detail="failed to start revision run")
     logger.info(
         "revision run accepted: task=%s run=%s document=%s source=%s",
         task_id, revision_id, document_id, "raw" if body.operations is not None else "generated",
@@ -220,11 +263,22 @@ def get_revision_run_status(
         "current_stage": run.get("current_stage"),
         "error_message": run.get("error_message") or "",
     }
-    if task_id:
-        task = get_background_task(task_id)
-        if task:
-            out["task"] = task
+    # Attach the explicitly-requested task only if it belongs to this revision;
+    # otherwise fall back to the latest revision task. Never leak another
+    # revision's task progress (#414-2 / #414-4).
+    task = get_background_task(task_id) if task_id else None
+    if not _task_belongs_to_revision(task, revision_id):
+        task = get_latest_revision_task(revision_id)
+    if task:
+        out["task"] = task
     return out
+
+
+def _task_belongs_to_revision(task: dict | None, revision_id: str) -> bool:
+    if not task:
+        return False
+    result_data = task.get("result_data") or {}
+    return str(result_data.get("revision_run_id") or "") == str(revision_id)
 
 
 # ---------------------------------------------------------------------------
@@ -260,9 +314,14 @@ def get_revision(
         "revision_status": run.get("revision_status"),
         "base_run_id": run.get("base_run_id"),
         "parent_revision_id": run.get("parent_revision_id"),
+        "current_stage": run.get("current_stage"),
+        "error_message": run.get("error_message") or "",
         "checkpoint_count": len(artifacts.get("audit_checkpoints") or []),
         "has_candidate": "candidate" in artifacts,
         "has_report": "diff_report" in artifacts,
+        # Latest revision task so the UI can restore running/failed/completed
+        # state and resume polling after a reload (#414-4).
+        "latest_task": get_latest_revision_task(revision_id),
         "decisions": persistence.get_revision_decisions(run_id=revision_id),
     }
 

--- a/backend/api/routes/revisions.py
+++ b/backend/api/routes/revisions.py
@@ -8,8 +8,11 @@ under optimistic concurrency (409 on base conflict).
 from __future__ import annotations
 
 import logging
+import threading
+import uuid
 
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from dependencies import _require_teacher
@@ -18,6 +21,11 @@ from core.document_pipeline import persistence
 from core.document_pipeline.persistence import RevisionConflictError
 from core.document_pipeline.revision import coordinator
 from core.document_pipeline.revision.coordinator import AcceptBlockedError
+from services import (
+    create_background_task,
+    get_background_task,
+    update_background_task,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +100,58 @@ def create_revision(
     }
 
 
+def _revision_run_worker(
+    *,
+    task_id: str,
+    document_id: str,
+    revision_id: str,
+    operations: list[dict] | None = None,
+) -> None:
+    """Background worker: run the whole revision pipeline off the HTTP request.
+
+    Long-running LLM audit/proposal work no longer blocks the request (so Nginx
+    never 504s mid-run); progress is observable via the task + revision status
+    (#412 P0-2). Failures are recorded on the task so the UI can show a real
+    server error rather than a generic timeout.
+    """
+    def _result(**extra) -> dict:
+        return {"document_id": document_id, "revision_run_id": revision_id, **extra}
+
+    try:
+        update_background_task(task_id, "processing",
+                               result_data=_result(stage="audit", label="反復改善", progress=0))
+        result = coordinator.run_revision_pipeline(run_id=revision_id, operations=operations)
+        update_background_task(
+            task_id, "completed",
+            result_data=_result(
+                stage="completed", revision_status="proposed", progress=100,
+                candidate_invalid=result.get("candidate_invalid"),
+                report_summary=result.get("report_summary"),
+                stage_summary=result.get("stage_summary"),
+            ),
+        )
+    except coordinator.ProposalValidationError as exc:
+        update_background_task(
+            task_id, "failed",
+            result_data=_result(stage="candidate_assembly",
+                                 rejected_operations=exc.rejected, progress=100),
+            error_message="proposal validation failed",
+        )
+    except Exception as exc:  # noqa: BLE001 — worker must record any failure
+        logger.exception("revision run worker failed: task=%s run=%s", task_id, revision_id)
+        update_background_task(
+            task_id, "failed",
+            result_data=_result(stage="failed", progress=100),
+            error_message=coordinator._safe_error(type(exc).__name__, exc),
+        )
+
+
+def _launch_revision_worker(**kwargs) -> None:
+    """Spawn the revision worker thread (indirection kept for testability)."""
+    thread = threading.Thread(target=_revision_run_worker, kwargs=kwargs, daemon=True)
+    thread.start()
+
+
 @router.post("/documents/{document_id}/revisions/{revision_id}/run")
 def run_revision(
     document_id: str,
@@ -99,47 +159,72 @@ def run_revision(
     body: RevisionRunRequest = Body(default=RevisionRunRequest()),
     current_user: dict = Depends(_require_teacher),
 ):
-    """Run source re-audit, build revision-operation proposals, assemble + validate.
+    """Start the revision pipeline asynchronously and return 202 + a task id.
 
-    Operations come from the audit-driven proposal generator by default (#410
-    P1-6); supplying ``operations`` is a debug/admin override (raw JSON), still
-    validated server-side during candidate assembly.
+    Source re-audit, audit-driven proposal generation (#410 P1-6), candidate
+    assembly and validation run in a background worker; the request returns
+    immediately so it can never exceed the proxy read timeout (#412 P0-2).
+    Supplying ``operations`` is a debug/admin override (raw JSON), still validated
+    server-side in the worker. A duplicate ``/run`` while one is in progress is
+    rejected with 409.
     """
     _authorize_edit(document_id, current_user)
-    _require_run_for_document(document_id, revision_id)
-    audit = coordinator.audit_revision_run(run_id=revision_id)
-    response = {"revision_run_id": revision_id, "audit": {
-        "verdict_counts": audit.get("verdict_counts"),
-        "revision_targets": audit.get("revision_targets"),
-    }}
+    run = _require_run_for_document(document_id, revision_id)
+    # Only an actively-running worker blocks a re-run; a freshly-created
+    # ``pending`` revision is still startable (#412 P0-2).
+    if str(run.get("status") or "").lower() == "running":
+        raise HTTPException(status_code=409, detail="revision run already in progress")
 
-    if body.operations is not None:
-        operations = body.operations
-        response["operation_source"] = "raw"
-    else:
-        proposals = coordinator.generate_proposals(run_id=revision_id)
-        operations = proposals.get("operations") or []
-        response["operation_source"] = "generated"
-        response["proposed_count"] = len(operations)
-        response["manual_review"] = proposals.get("manual_review") or []
+    task_id = str(uuid.uuid4())[:12]
+    create_background_task(task_id, "revision_pipeline", _user_id(current_user))
+    update_background_task(task_id, "pending", result_data={
+        "document_id": document_id, "revision_run_id": revision_id,
+        "stage": "queued", "label": "反復改善", "progress": 0,
+    })
+    _launch_revision_worker(
+        task_id=task_id, document_id=document_id,
+        revision_id=revision_id, operations=body.operations,
+    )
+    logger.info(
+        "revision run accepted: task=%s run=%s document=%s source=%s",
+        task_id, revision_id, document_id, "raw" if body.operations is not None else "generated",
+    )
+    return JSONResponse(status_code=202, content={
+        "task_id": task_id,
+        "revision_run_id": revision_id,
+        "revision_status": "running",
+        "status": "accepted",
+    })
 
-    try:
-        candidate = coordinator.assemble_candidate(
-            run_id=revision_id, operations=operations
-        )
-    except coordinator.ProposalValidationError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "message": str(exc),
-                "rejected_operations": exc.rejected,
-            },
-        )
-    report = coordinator.revalidate_and_report(run_id=revision_id)
-    response["candidate_invalid"] = candidate["invalid"]
-    response["report_summary"] = report["report"]["summary"]
-    response["revision_status"] = "proposed"
-    return response
+
+@router.get("/documents/{document_id}/revisions/{revision_id}/run-status")
+def get_revision_run_status(
+    document_id: str,
+    revision_id: str,
+    task_id: str | None = Query(default=None),
+    current_user: dict = Depends(_require_teacher),
+):
+    """Poll a revision run's state (+ optional background-task progress).
+
+    Lets the UI recover after a reload / dropped connection: the run's generic
+    status/current_stage is the source of truth, and the task carries live stage
+    progress while the worker is active (#412 P0-2 / P1-4).
+    """
+    _authorize_view(document_id, current_user)
+    run = _require_run_for_document(document_id, revision_id)
+    out = {
+        "revision_run_id": revision_id,
+        "document_id": document_id,
+        "status": run.get("status"),
+        "revision_status": run.get("revision_status"),
+        "current_stage": run.get("current_stage"),
+        "error_message": run.get("error_message") or "",
+    }
+    if task_id:
+        task = get_background_task(task_id)
+        if task:
+            out["task"] = task
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/backend/api/routes/revisions.py
+++ b/backend/api/routes/revisions.py
@@ -46,6 +46,7 @@ class RevisionRunRequest(BaseModel):
 class DecisionRequest(BaseModel):
     comment: str = ""
     confirm_protected: bool = False
+    accept_partial: bool = False
 
 
 def _user_id(current_user: dict) -> str | None:
@@ -360,6 +361,7 @@ def accept_revision(
             document_id=document_id, run_id=revision_id,
             changed_by=_user_id(current_user), comment=body.comment,
             confirm_protected=body.confirm_protected,
+            accept_partial=body.accept_partial,
         )
     except AcceptBlockedError as exc:
         raise HTTPException(status_code=422, detail=str(exc))

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -125,6 +125,7 @@ def get_background_task(task_id: str) -> dict | None:
                     SELECT status, current_stage, error_message, stage_outputs
                     FROM document_analysis_runs
                     WHERE document_id = :document_id
+                      AND (run_type IS NULL OR run_type <> 'revision')
                     ORDER BY created_at DESC
                     LIMIT 1
                     """

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -117,8 +117,17 @@ def get_background_task(task_id: str) -> dict | None:
         ).fetchone()
         if not row:
             return None
+        task_type = row[1]
         result_data = row[3] or {}
-        if isinstance(result_data, dict) and result_data.get("document_id"):
+        # Revision-pipeline tasks carry their own stage from the worker and must
+        # NOT be enriched from the latest initial/non-revision run, which would
+        # overwrite the revision stage with the initial run's current_stage
+        # (#414-2). Their progress is read via the revision status API instead.
+        is_revision_task = (
+            task_type == "revision_pipeline"
+            or (isinstance(result_data, dict) and result_data.get("revision_run_id"))
+        )
+        if isinstance(result_data, dict) and result_data.get("document_id") and not is_revision_task:
             run = session.execute(
                 sa_text(
                     """
@@ -151,6 +160,44 @@ def get_background_task(task_id: str) -> dict | None:
             "status": row[2],
             "result_data": result_data,
             "error_message": row[4] or (run[2] if 'run' in locals() and run else None),
+            "created_at": row[5].isoformat() if row[5] else "",
+            "updated_at": row[6].isoformat() if row[6] else "",
+        }
+    finally:
+        session.close()
+
+
+def get_latest_revision_task(revision_run_id: str) -> dict | None:
+    """Latest revision_pipeline task for a revision run (#414-4 reload restore).
+
+    Returns id/status/stage/progress so the UI can restore polling after a reload
+    without ever pulling in another revision's task. No initial-run enrichment is
+    applied (revision tasks carry their own stage).
+    """
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text("""
+                SELECT id, task_type, status, result_data, error_message, created_at, updated_at
+                FROM background_tasks
+                WHERE task_type = 'revision_pipeline'
+                  AND result_data IS NOT NULL
+                  AND result_data->>'revision_run_id' = :rev
+                ORDER BY created_at DESC
+                LIMIT 1
+            """),
+            {"rev": revision_run_id},
+        ).fetchone()
+        if not row:
+            return None
+        result_data = row[3] or {}
+        return {
+            "task_id": row[0],
+            "task_type": row[1],
+            "status": row[2],
+            "stage": (result_data or {}).get("stage") if isinstance(result_data, dict) else None,
+            "result_data": result_data,
+            "error_message": row[4],
             "created_at": row[5].isoformat() if row[5] else "",
             "updated_at": row[6].isoformat() if row[6] else "",
         }

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -2045,6 +2045,7 @@ def accept_revision(
     changed_by: str | None = None,
     comment: str = "",
     candidate_artifacts: dict | None = None,
+    decision_metadata: dict | None = None,
 ) -> dict:
     """Accept a candidate revision in a single transaction (#407 / #410 P1-5).
 
@@ -2167,7 +2168,10 @@ def accept_revision(
             session, run_id=run_id, old_status="proposed", new_status="accepted",
             changed_by=changed_by,
             metadata={"decision": "accept", "comment": comment,
-                      "document_id": document_id, "base_run_id": base_id},
+                      "document_id": document_id, "base_run_id": base_id,
+                      # Applied/excluded operation sets for the partial-adoption
+                      # audit trail (#415).
+                      **(decision_metadata or {})},
         )
         session.commit()
         return {"accepted": True, "active_run_id": run_id, "superseded_run_id": base_id}

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -1457,6 +1457,78 @@ def update_revision_status(
         session.close()
 
 
+def claim_revision_run(*, run_id: str, stage: str = "audit") -> bool:
+    """Atomically acquire the right to run a revision (#414-1).
+
+    Flips the run to ``status='running'`` only when it is not already running, in
+    a single ``UPDATE ... WHERE`` so two concurrent ``/run`` requests cannot both
+    win: under READ COMMITTED the second statement re-evaluates the predicate on
+    the row the first committed (now ``running``) and matches zero rows. Returns
+    True for the single winner, False for everyone else (→ 409). Works across
+    multiple API processes — it relies on the DB row, not an in-process lock.
+    """
+    session = _pg_session()
+    try:
+        row = session.execute(
+            sa_text(
+                """
+                UPDATE document_analysis_runs
+                SET status = 'running',
+                    revision_status = 'auditing',
+                    current_stage = :stage,
+                    error_message = '',
+                    started_at = COALESCE(started_at, now()),
+                    completed_at = NULL,
+                    updated_at = now()
+                WHERE id = CAST(:run_id AS uuid)
+                  AND run_type = 'revision'
+                  AND status IS DISTINCT FROM 'running'
+                RETURNING id::text
+                """
+            ),
+            {"run_id": run_id, "stage": stage},
+        ).fetchone()
+        session.commit()
+        return row is not None
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def release_revision_run(*, run_id: str, error_message: str = "") -> None:
+    """Release a claimed-but-not-started revision back to a re-runnable state (#414-1).
+
+    Called when task creation / worker launch fails after ``claim_revision_run``
+    succeeded, so the revision does not stay stuck in ``running``. ``failed`` is
+    re-claimable by a subsequent ``/run``.
+    """
+    session = _pg_session()
+    try:
+        session.execute(
+            sa_text(
+                """
+                UPDATE document_analysis_runs
+                SET status = 'failed',
+                    error_message = :err,
+                    completed_at = now(),
+                    updated_at = now()
+                WHERE id = CAST(:run_id AS uuid)
+                  AND run_type = 'revision'
+                  AND status = 'running'
+                """
+            ),
+            {"run_id": run_id, "err": error_message or "failed to start revision run"},
+        )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
 def set_active_analysis_run(
     *,
     document_id: str,

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -1942,10 +1942,22 @@ def _remap_revision_graph(
         ).strip()
         if not agent_id:
             raise ValueError("component graph node is missing an id")
+        graph_layer = str(node.get("graph_layer") or "").strip().lower()
+        component_type = str(node.get("component_type") or "").strip()
+        # TheoryOperationGraph contains graph-native aggregate/detail nodes whose
+        # ``component_id`` is a graph identifier (theory_op_*/eq_op_*), not a
+        # component_assembly entity.  Treating every node carrying component_id as
+        # a projection-backed component made valid revision candidates impossible
+        # to accept.  Explicit stored component nodes and ordinary component ids
+        # still fail closed when they cannot be resolved.
+        is_graph_native_node = (
+            component_type in ("TheoryOperationNode", "EquationOperationNode")
+            or graph_layer in ("equation_detail", "debug")
+        )
         is_component_node = (
-            bool(node.get("component_id"))
-            or agent_id in component_id_map
+            agent_id in component_id_map
             or str(node.get("type") or "").lower() == "component"
+            or (bool(node.get("component_id")) and not is_graph_native_node)
         )
         if is_component_node:
             db_id = component_id_map.get(agent_id)

--- a/backend/core/document_pipeline/persistence.py
+++ b/backend/core/document_pipeline/persistence.py
@@ -1398,6 +1398,7 @@ def update_revision_status(
     run_id: str,
     revision_status: str,
     status: str | None = None,
+    current_stage: str | None = None,
     error_message: str | None = None,
     stage_outputs: dict | None = None,
 ) -> None:
@@ -1421,6 +1422,7 @@ def update_revision_status(
                 UPDATE document_analysis_runs SET
                     revision_status = :revision_status,
                     status = COALESCE(:status, status),
+                    current_stage = COALESCE(:current_stage, current_stage),
                     error_message = COALESCE(:error_message, error_message),
                     stage_outputs = jsonb_set(
                         COALESCE(stage_outputs, '{{}}'::jsonb) || CAST(:other AS jsonb),
@@ -1428,6 +1430,8 @@ def update_revision_status(
                         COALESCE(stage_outputs->'{ARTIFACTS_KEY}', '{{}}'::jsonb)
                             || CAST(:artifacts AS jsonb)
                     ),
+                    started_at = CASE WHEN :status = 'running' AND started_at IS NULL
+                                      THEN now() ELSE started_at END,
                     completed_at = CASE WHEN :status IN ('completed', 'failed')
                                         THEN now() ELSE completed_at END,
                     updated_at = now()
@@ -1439,6 +1443,7 @@ def update_revision_status(
                 "run_id": run_id,
                 "revision_status": revision_status,
                 "status": status,
+                "current_stage": current_stage,
                 "error_message": error_message,
                 "other": _json_dumps(payload),
                 "artifacts": _json_dumps(artifacts_delta or {}),

--- a/backend/core/document_pipeline/revision/__init__.py
+++ b/backend/core/document_pipeline/revision/__init__.py
@@ -32,6 +32,7 @@ from .coordinator import (
     reject_revision,
     revalidate_and_report,
     revise_revision_run,
+    run_revision_pipeline,
     start_revision_run,
 )
 from .llm_audit import LLMAuditClient, build_default_audit_client, llm_enabled
@@ -91,6 +92,7 @@ __all__ = [
     "revalidate_and_report",
     "revise_revision_run",
     "run_export_validation",
+    "run_revision_pipeline",
     "run_source_audit",
     "start_revision_run",
 ]

--- a/backend/core/document_pipeline/revision/audit.py
+++ b/backend/core/document_pipeline/revision/audit.py
@@ -139,7 +139,8 @@ def _empty_result(checkpoint: dict) -> dict:
         "trigger_reason": checkpoint.get("trigger_reason"),
         "verdict": "ambiguous",
         "findings": [],
-        "evidence_refs": [],
+        "evidence_refs": [],     # EvidenceRegistry evidence_id refs only
+        "source_chunk_ids": [],  # chunks.id refs only — distinct ID space (#412 P0-6)
         "source_locations": [],
         "source_evidence": [],   # source-derived quotes only
         "analysis_notes": [],    # LLM commentary only — kept separate
@@ -160,6 +161,11 @@ def _deterministic_verdict(checkpoint: dict, retrieval: dict) -> dict:
          "page_start": r.get("page_start"), "page_end": r.get("page_end")}
         for r in retrieved
     ]
+    # Source chunk ids actually retrieved (chunks.id space). These are valid
+    # *source* references, kept separate from EvidenceRegistry evidence_ids.
+    result["source_chunk_ids"] = list(dict.fromkeys(
+        str(r.get("chunk_id")) for r in retrieved if r.get("chunk_id")
+    ))
     result["source_evidence"] = [
         {"chunk_id": r.get("chunk_id"), "text": r.get("text"),
          "match_reason": r.get("match_reason")}
@@ -238,9 +244,16 @@ def _coerce_llm_result(checkpoint: dict, retrieval: dict, raw: Any) -> dict:
             checkpoint, retrieval, failure_type="invalid_verdict"
         )
 
-    evidence_refs = [r for r in (raw.get("evidence_refs") or []) if r]
+    # Registry evidence ids and source chunk ids are kept in separate fields
+    # (#412 P0-6). ``evidence_ids`` is the typed field; ``evidence_refs`` is the
+    # legacy mixed list (routed to the correct space later by the validator).
+    evidence_refs = [r for r in (raw.get("evidence_ids") or raw.get("evidence_refs") or []) if r]
+    source_chunk_ids = list(dict.fromkeys(
+        [str(c) for c in (raw.get("source_chunk_ids") or []) if c]
+        + list(result.get("source_chunk_ids") or [])
+    ))
     # Safety rule: never mark valid without positive source evidence.
-    if verdict == "valid" and not (evidence_refs or result["source_evidence"]):
+    if verdict == "valid" and not (evidence_refs or source_chunk_ids or result["source_evidence"]):
         verdict = "ambiguous"
 
     confidence = float(raw.get("confidence") or 0.0)
@@ -257,6 +270,7 @@ def _coerce_llm_result(checkpoint: dict, retrieval: dict, raw: Any) -> dict:
         "verdict": verdict,
         "findings": list(raw.get("findings") or result["findings"]),
         "evidence_refs": evidence_refs,
+        "source_chunk_ids": source_chunk_ids,
         "analysis_notes": list(raw.get("analysis_notes") or raw.get("notes") or []),
         "confidence": confidence,
         "requires_revision": requires_revision,

--- a/backend/core/document_pipeline/revision/audit.py
+++ b/backend/core/document_pipeline/revision/audit.py
@@ -306,12 +306,20 @@ def run_source_audit(
     checkpoints: list[dict],
     chunk_index: list[dict],
     llm_client: Callable[[dict, dict], Any] | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> dict:
-    """Audit every checkpoint; return results + a revision worklist summary."""
-    results = [
-        audit_checkpoint(cp, chunk_index, llm_client=llm_client)
-        for cp in (checkpoints or [])
-    ]
+    """Audit every checkpoint; return results + a revision worklist summary.
+
+    ``progress_callback(completed, total)`` is invoked after each checkpoint so a
+    caller can publish real ``completed / total`` progress (#414-3).
+    """
+    checkpoints = checkpoints or []
+    total = len(checkpoints)
+    results = []
+    for index, cp in enumerate(checkpoints, start=1):
+        results.append(audit_checkpoint(cp, chunk_index, llm_client=llm_client))
+        if progress_callback:
+            progress_callback(index, total)
     revision_targets = [
         {"checkpoint_id": r["checkpoint_id"], "target_type": r["target_type"],
          "target_id": r["target_id"], "verdict": r["verdict"]}

--- a/backend/core/document_pipeline/revision/coordinator.py
+++ b/backend/core/document_pipeline/revision/coordinator.py
@@ -284,11 +284,12 @@ def assemble_candidate(
         checkpoints=run_artifacts.get(AUDIT_CHECKPOINTS_KEY) or [],
         known_chunk_ids=_trusted_chunk_ids(_load_chunk_index(str(run.get("document_id") or ""))),
     )
-    if validated["rejected"]:
-        raise ProposalValidationError(validated["rejected"])
 
+    # Partial adoption (#415): pre-rejected operations are excluded (not raised),
+    # so independent valid operations still produce an adoptable candidate.
     result = apply_operations(
-        base_artifacts, validated["operations"], base_inventory=base_inventory
+        base_artifacts, validated["operations"],
+        base_inventory=base_inventory, pre_excluded=validated["rejected"],
     )
 
     persistence.update_revision_status(
@@ -300,6 +301,9 @@ def assemble_candidate(
                 "candidate_artifacts": result["candidate_artifacts"],
                 "id_mapping": result["id_mapping"],
                 "operation_errors": result["operation_errors"],
+                "excluded_operations": result["excluded_operations"],
+                "operation_summary": result["operation_summary"],
+                "candidate_status": result["candidate_status"],
                 "protected_changes": result["protected_changes"],
                 "dropped_edges": result["dropped_edges"],
                 "carried_unresolved_references": result["carried_unresolved_references"],
@@ -387,6 +391,9 @@ def revalidate_and_report(*, run_id: str, base_run: dict | None = None) -> dict:
         audit_summary=audit_summary,
         proposal_summary=proposal_summary,
         new_unknown_reference_count=new_unknown_reference_count,
+        operation_candidate_status=candidate.get("candidate_status"),
+        operation_summary=candidate.get("operation_summary"),
+        excluded_operations=candidate.get("excluded_operations") or [],
     )
 
     persistence.update_revision_status(
@@ -411,11 +418,15 @@ def accept_revision(
     changed_by: str | None = None,
     comment: str = "",
     confirm_protected: bool = False,
+    accept_partial: bool = False,
 ) -> dict:
-    """Validate-then-accept a candidate revision (#407).
+    """Validate-then-accept a candidate revision (#407 / partial adoption #415).
 
-    Refuses candidates with hard errors / invalid status (AcceptBlockedError) and
-    candidates with unconfirmed protected changes. Delegates the atomic state
+    Refuses ``blocked`` candidates (hard errors / unattributable dangling) and
+    candidates with unconfirmed protected changes. A ``partially_adoptable``
+    candidate (some operations excluded) requires explicit ``accept_partial`` so a
+    teacher consciously adopts the reduced operation set. The applied/excluded
+    operation sets are recorded in the decision history. Delegates the atomic state
     switch to ``persistence.accept_revision`` (raises RevisionConflictError → 409).
     """
     run = persistence.get_analysis_run(run_id=run_id)
@@ -431,9 +442,21 @@ def accept_revision(
     if not report:
         raise AcceptBlockedError("candidate has not been validated; run report first")
     summary = report.get("summary") or {}
-    if not summary.get("acceptable", False) or summary.get("hard_error_count", 0) > 0:
+    candidate_status = summary.get("candidate_status") or (
+        "blocked" if summary.get("candidate_invalid") else "adoptable"
+    )
+    if candidate_status == "blocked" or summary.get("hard_error_count", 0) > 0:
         raise AcceptBlockedError(
-            f"candidate has {summary.get('hard_error_count', 0)} hard error(s) or is invalid"
+            f"candidate is blocked: {summary.get('hard_error_count', 0)} hard error(s) "
+            "or unresolved references remain after exclusion"
+        )
+    if candidate_status == "partially_adoptable" and not accept_partial:
+        op_sum = report.get("operation_summary") or {}
+        excluded = (op_sum.get("excluded_invalid_count", 0)
+                    + op_sum.get("excluded_dependency_count", 0))
+        raise AcceptBlockedError(
+            f"candidate is partially adoptable: {excluded} operation(s) will be "
+            "excluded; explicit partial-accept confirmation is required"
         )
     if summary.get("protected_change_count", 0) > 0 and not confirm_protected:
         raise AcceptBlockedError(
@@ -442,6 +465,12 @@ def accept_revision(
 
     candidate = run_artifacts.get(CANDIDATE_KEY) or {}
     candidate_artifacts = candidate.get("candidate_artifacts") or {}
+    op_summary = candidate.get("operation_summary") or {}
+    applied_operation_ids = [
+        rec.get("operation_id")
+        for rec in (run_artifacts.get(REVISION_OPERATIONS_KEY) or [])
+        if (rec.get("operation_status") or "applied") in ("applied", "requires_confirmation")
+    ]
 
     return persistence.accept_revision(
         document_id=str(run.get("document_id")),
@@ -450,6 +479,13 @@ def accept_revision(
         changed_by=changed_by,
         comment=comment,
         candidate_artifacts=candidate_artifacts,
+        decision_metadata={
+            "candidate_status": candidate_status,
+            "partial": candidate_status == "partially_adoptable",
+            "operation_summary": op_summary,
+            "applied_operation_ids": [oid for oid in applied_operation_ids if oid],
+            "excluded_operations": candidate.get("excluded_operations") or [],
+        },
     )
 
 
@@ -665,16 +701,47 @@ def revise_revision_run(
         document_id=document_id,
         projection_overlay=projection_overlay,
     )
-    if comment:
-        plan[AUDIT_CHECKPOINTS_KEY] = [
-            {
-                "checkpoint_id": f"ckpt_user_{parent_run_id[:8]}",
-                "target_type": "document", "target_id": document_id,
-                "question": comment, "trigger_reason": "user_comment",
-                "severity": "review_required", "expected_evidence_type": "source_text",
-                "source_scope": [], "verification_strategy": "user_directed",
-                "status": "planned",
+
+    # Carry the parent's excluded operations into the new revision as checkpoints so
+    # the failure reasons are not lost and the same bad change is not re-proposed
+    # blindly (#415: "再修正時に失敗理由が次revisionへ引き継がれる").
+    parent_artifacts = get_artifacts(parent.get("stage_outputs"))
+    parent_candidate = parent_artifacts.get(CANDIDATE_KEY) or {}
+    carried_checkpoints: list[dict] = []
+    for excluded in parent_candidate.get("excluded_operations") or []:
+        target_type = excluded.get("target_type") or "document"
+        target_id = excluded.get("target_id") or document_id
+        carried_checkpoints.append({
+            "checkpoint_id": f"ckpt_excluded_{parent_run_id[:8]}_{excluded.get('operation_id') or target_id}",
+            "target_type": target_type, "target_id": target_id,
+            "question": (
+                f"前回除外された操作 ({excluded.get('status')}: {excluded.get('reason')}) "
+                "を見直し、原文根拠のある修正に再構成する"
+            ),
+            "trigger_reason": "prior_exclusion",
+            "severity": "review_required", "expected_evidence_type": "source_text",
+            "source_scope": [], "verification_strategy": "user_directed",
+            "prior_exclusion": {
+                "operation_id": excluded.get("operation_id"),
+                "status": excluded.get("status"),
+                "reason": excluded.get("reason"),
             },
+            "status": "planned",
+        })
+
+    user_checkpoints: list[dict] = []
+    if comment:
+        user_checkpoints.append({
+            "checkpoint_id": f"ckpt_user_{parent_run_id[:8]}",
+            "target_type": "document", "target_id": document_id,
+            "question": comment, "trigger_reason": "user_comment",
+            "severity": "review_required", "expected_evidence_type": "source_text",
+            "source_scope": [], "verification_strategy": "user_directed",
+            "status": "planned",
+        })
+    if user_checkpoints or carried_checkpoints:
+        plan[AUDIT_CHECKPOINTS_KEY] = [
+            *user_checkpoints, *carried_checkpoints,
             *plan.get(AUDIT_CHECKPOINTS_KEY, []),
         ]
 

--- a/backend/core/document_pipeline/revision/coordinator.py
+++ b/backend/core/document_pipeline/revision/coordinator.py
@@ -31,8 +31,15 @@ logger = logging.getLogger(__name__)
 STAGE_AUDIT = "audit"
 STAGE_PROPOSAL = "proposal"
 STAGE_CANDIDATE_ASSEMBLY = "candidate_assembly"
+STAGE_VALIDATION = "validation"
 STAGE_REPORT = "report"
 STAGE_COMPLETED = "completed"
+
+# Canonical revision stage order (#414-3).
+REVISION_STAGES = (
+    STAGE_AUDIT, STAGE_PROPOSAL, STAGE_CANDIDATE_ASSEMBLY,
+    STAGE_VALIDATION, STAGE_REPORT, STAGE_COMPLETED,
+)
 
 # Revision artifact keys (stored under stage_outputs._artifacts of the run).
 BASELINE_INVENTORY_KEY = "baseline_inventory"
@@ -121,17 +128,31 @@ def start_revision_run(
     }
 
 
+def _load_chunk_index(document_id: str) -> list[dict]:
+    """Trusted source-chunk index from the chunks table (empty on any failure)."""
+    try:
+        return persistence.load_source_chunk_index(document_id=document_id) or []
+    except Exception:
+        return []
+
+
+def _trusted_chunk_ids(chunk_index: list[dict] | None) -> set[str]:
+    return {str(c.get("chunk_id")) for c in (chunk_index or []) if c.get("chunk_id")}
+
+
 def audit_revision_run(
     *,
     run_id: str,
     llm_client: Callable[[dict, dict], Any] | None = None,
     chunk_index: list[dict] | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> dict:
     """Run the source re-audit stage for a candidate run.
 
     Reads the run's planned checkpoints, re-reads the source per checkpoint, and
     stores audit results as a run artifact. This stage evaluates only — it never
     builds candidate artifacts nor touches the base/active run (AC #404).
+    ``progress_callback(completed, total)`` reports per-checkpoint progress (#414-3).
     """
     run = persistence.get_analysis_run(run_id=run_id)
     if not run:
@@ -152,15 +173,13 @@ def audit_revision_run(
         llm_client = build_default_audit_client(inventory)
 
     if chunk_index is None:
-        try:
-            chunk_index = persistence.load_source_chunk_index(document_id=document_id)
-        except Exception:
-            chunk_index = []
+        chunk_index = _load_chunk_index(document_id)
 
     audit = run_source_audit(
         checkpoints=checkpoints,
         chunk_index=chunk_index or [],
         llm_client=llm_client,
+        progress_callback=progress_callback,
     )
     persistence.update_revision_status(
         run_id=run_id,
@@ -174,6 +193,8 @@ def generate_proposals(
     *,
     run_id: str,
     generate: Callable[[list[dict]], str] | None = None,
+    chunk_index: list[dict] | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> dict:
     """Generate validated revision-operation proposals from the audit results (#410 P1-6).
 
@@ -181,6 +202,8 @@ def generate_proposals(
     configured) for one operation per ``requires_revision`` finding, validates each
     proposal server-side (schema / target / evidence / traceability), and stores
     the result as the ``proposed_operations`` artifact. Never auto-accepts.
+    ``source_chunk_ids`` are validated against the trusted chunks index (#414-5);
+    ``progress_callback(completed, total)`` reports per-target progress (#414-3).
     """
     run = persistence.get_analysis_run(run_id=run_id)
     if not run or run.get("run_type") != "revision":
@@ -188,13 +211,19 @@ def generate_proposals(
     artifacts = get_artifacts(run.get("stage_outputs"))
     inventory = artifacts.get(BASELINE_INVENTORY_KEY) or {}
     audit_results = (artifacts.get(AUDIT_RESULTS_KEY) or {}).get("audit_results") or []
+    if chunk_index is None:
+        chunk_index = _load_chunk_index(str(run.get("document_id") or ""))
 
     from .proposal import propose_operations
     if generate is None:
         from .llm_audit import _default_generate, llm_enabled
         generate = _default_generate if llm_enabled() else None
 
-    result = propose_operations(audit_results, inventory, generate=generate)
+    result = propose_operations(
+        audit_results, inventory, generate=generate,
+        known_chunk_ids=_trusted_chunk_ids(chunk_index),
+        progress_callback=progress_callback,
+    )
     persistence.update_revision_status(
         run_id=run_id, revision_status="auditing",
         stage_outputs={ARTIFACTS_KEY: {PROPOSED_OPERATIONS_KEY: result}},
@@ -244,13 +273,16 @@ def assemble_candidate(
     )
 
     # Generated, raw/debug, and user-edited operations all pass through the same
-    # fail-closed validator immediately before candidate assembly.
+    # fail-closed validator immediately before candidate assembly. The trusted
+    # chunks index is supplied so source_chunk_ids are validated against real DB
+    # chunks, not the LLM's own output (#414-5).
     from .proposal import validate_proposed_operations
     validated = validate_proposed_operations(
         operations or [],
         base_inventory,
         audit_results=audit_results,
         checkpoints=run_artifacts.get(AUDIT_CHECKPOINTS_KEY) or [],
+        known_chunk_ids=_trusted_chunk_ids(_load_chunk_index(str(run.get("document_id") or ""))),
     )
     if validated["rejected"]:
         raise ProposalValidationError(validated["rejected"])
@@ -439,21 +471,30 @@ def run_revision_pipeline(
     operations: list[dict] | None = None,
     llm_client: Callable[[dict, dict], Any] | None = None,
     generate: Callable[[list[dict]], str] | None = None,
+    progress_callback: Callable[[str, int, int], None] | None = None,
+    task_id: str | None = None,
 ) -> dict:
-    """Run audit → proposal → assembly → validation → report end-to-end.
+    """Run audit → proposal → candidate_assembly → validation → report end-to-end.
 
     Drives the revision run's generic state (``status`` / ``current_stage`` /
     ``completed_at``) and emits structured stage logs so progress/outcome can be
     judged from run state + logs alone, without inspecting artifacts (#412 P1-3 /
-    P1-5). Designed to run inside a background worker (#412 P0-2) — it never
-    touches the active run or projection tables. ``operations`` supplied means the
-    raw/debug override path (proposal generation is skipped).
+    P1-5). ``progress_callback(stage, completed, total)`` reports intra-stage
+    counts (#414-3); ``task_id`` is included in logs for correlation. Designed to
+    run inside a background worker (#412 P0-2) — it never touches the active run
+    or projection tables. ``operations`` supplied means the raw/debug override
+    path (proposal generation is skipped).
     """
     run = persistence.get_analysis_run(run_id=run_id)
     if not run or run.get("run_type") != "revision":
         raise ValueError(f"revision run {run_id} not found")
     document_id = str(run.get("document_id") or "")
-    log_ctx = "run_id=%s document_id=%s" % (run_id, document_id)
+    log_ctx = "run_id=%s document_id=%s task_id=%s" % (run_id, document_id, task_id or "-")
+
+    def _progress(stage: str, completed: int, total: int) -> None:
+        if progress_callback:
+            progress_callback(stage, completed, total)
+
     current_stage = STAGE_AUDIT
     try:
         # --- audit ---
@@ -464,12 +505,17 @@ def run_revision_pipeline(
             status="running", current_stage=STAGE_AUDIT,
         )
         logger.info("revision_started %s checkpoints=%d", log_ctx, checkpoints_total)
-        audit = audit_revision_run(run_id=run_id, llm_client=llm_client)
+        _progress(STAGE_AUDIT, 0, checkpoints_total)
+        audit = audit_revision_run(
+            run_id=run_id, llm_client=llm_client,
+            progress_callback=lambda done, total: _progress(STAGE_AUDIT, done, total),
+        )
         revision_targets = audit.get("revision_targets") or []
         review_items = audit.get("review_items") or []
         logger.info(
-            "revision_audit_completed %s checkpoints=%d targets=%d review_items=%d",
-            log_ctx, checkpoints_total, len(revision_targets), len(review_items),
+            "revision_audit_completed %s checkpoints=%d completed=%d targets=%d review_items=%d",
+            log_ctx, checkpoints_total, checkpoints_total,
+            len(revision_targets), len(review_items),
         )
 
         # --- proposal (skipped for the raw/debug override path) ---
@@ -478,7 +524,11 @@ def run_revision_pipeline(
             persistence.update_revision_status(
                 run_id=run_id, revision_status="auditing", current_stage=STAGE_PROPOSAL,
             )
-            proposals = generate_proposals(run_id=run_id, generate=generate)
+            _progress(STAGE_PROPOSAL, 0, len(revision_targets))
+            proposals = generate_proposals(
+                run_id=run_id, generate=generate,
+                progress_callback=lambda done, total: _progress(STAGE_PROPOSAL, done, total),
+            )
             ops = proposals.get("operations") or []
             rejected = proposals.get("rejected") or []
             manual_review = proposals.get("manual_review") or []
@@ -496,6 +546,7 @@ def run_revision_pipeline(
         persistence.update_revision_status(
             run_id=run_id, revision_status="auditing", current_stage=STAGE_CANDIDATE_ASSEMBLY,
         )
+        _progress(STAGE_CANDIDATE_ASSEMBLY, 0, 1)
         candidate = assemble_candidate(run_id=run_id, operations=ops)
         new_unknown = sum(
             len(err.get("details") or [])
@@ -508,11 +559,19 @@ def run_revision_pipeline(
             len(candidate.get("applied_operations") or []), new_unknown,
         )
 
-        # --- validation + report ---
+        # --- validation (explicit stage) ---
+        current_stage = STAGE_VALIDATION
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="proposed", current_stage=STAGE_VALIDATION,
+        )
+        _progress(STAGE_VALIDATION, 0, 1)
+
+        # --- report ---
         current_stage = STAGE_REPORT
         persistence.update_revision_status(
             run_id=run_id, revision_status="proposed", current_stage=STAGE_REPORT,
         )
+        _progress(STAGE_REPORT, 0, 1)
         report_out = revalidate_and_report(run_id=run_id)
         report = report_out["report"]
         summary = report.get("summary") or {}
@@ -521,6 +580,7 @@ def run_revision_pipeline(
             run_id=run_id, revision_status="proposed",
             status="completed", current_stage=STAGE_COMPLETED,
         )
+        _progress(STAGE_COMPLETED, 1, 1)
         logger.info(
             "revision_completed %s recommendation=%s outcome=%s changes=%d candidate_invalid=%s",
             log_ctx, report.get("recommendation"), summary.get("outcome"),

--- a/backend/core/document_pipeline/revision/coordinator.py
+++ b/backend/core/document_pipeline/revision/coordinator.py
@@ -8,6 +8,7 @@ ever touching projection tables or the adopted active run.
 """
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
 
 from .. import persistence
@@ -22,6 +23,16 @@ from .inventory import (
 )
 from .operations import apply_operations
 from .validation import run_export_validation
+
+logger = logging.getLogger(__name__)
+
+# Revision pipeline stages — values stored in document_analysis_runs.current_stage
+# so the generic run state reflects progress without inspecting artifacts (#412 P1-3).
+STAGE_AUDIT = "audit"
+STAGE_PROPOSAL = "proposal"
+STAGE_CANDIDATE_ASSEMBLY = "candidate_assembly"
+STAGE_REPORT = "report"
+STAGE_COMPLETED = "completed"
 
 # Revision artifact keys (stored under stage_outputs._artifacts of the run).
 BASELINE_INVENTORY_KEY = "baseline_inventory"
@@ -293,9 +304,36 @@ def revalidate_and_report(*, run_id: str, base_run: dict | None = None) -> dict:
     candidate_artifacts = candidate.get("candidate_artifacts") or {}
     applied_operations = run_artifacts.get(REVISION_OPERATIONS_KEY) or []
     audit_results = (run_artifacts.get(AUDIT_RESULTS_KEY) or {}).get("audit_results") or []
+    checkpoints = run_artifacts.get(AUDIT_CHECKPOINTS_KEY) or []
+    proposed = run_artifacts.get(PROPOSED_OPERATIONS_KEY) or {}
 
     gate_base = run_export_validation(base_artifacts)
     gate_candidate = run_export_validation(candidate_artifacts)
+
+    # Stage rollups so the report distinguishes "nothing to improve" from
+    # "improvements proposed but not adoptable" (#412 P1-8).
+    from .diff import summarize_rejections
+    revision_targets = [a for a in audit_results if a.get("requires_revision")]
+    manual_review = proposed.get("manual_review") or [
+        a for a in audit_results
+        if a.get("review_required") and not a.get("requires_revision")
+    ]
+    rejected_proposals = proposed.get("rejected") or []
+    audit_summary = {
+        "checkpoints_total": len(checkpoints) or len(audit_results),
+        "revision_target_count": len(revision_targets),
+        "manual_review_count": len(manual_review),
+    }
+    proposal_summary = {
+        "accepted_count": len(proposed.get("operations") or applied_operations),
+        "rejected_count": len(rejected_proposals),
+        "rejection_reasons": summarize_rejections(rejected_proposals),
+    }
+    new_unknown_reference_count = sum(
+        len(err.get("details") or [])
+        for err in (candidate.get("operation_errors") or [])
+        if isinstance(err, dict) and err.get("error") == "new_unknown_references"
+    )
 
     report = build_diff_report(
         base_run_id=str(base_run_id or ""),
@@ -312,8 +350,11 @@ def revalidate_and_report(*, run_id: str, base_run: dict | None = None) -> dict:
         audit_verifications=[
             {"checkpoint_id": a.get("checkpoint_id"), "target_id": a.get("target_id"),
              "verdict": a.get("verdict"), "source_locations": a.get("source_locations") or []}
-            for a in audit_results if a.get("requires_revision")
+            for a in revision_targets
         ],
+        audit_summary=audit_summary,
+        proposal_summary=proposal_summary,
+        new_unknown_reference_count=new_unknown_reference_count,
     )
 
     persistence.update_revision_status(
@@ -378,6 +419,146 @@ def accept_revision(
         comment=comment,
         candidate_artifacts=candidate_artifacts,
     )
+
+
+def _safe_error(code: str, exc: Exception) -> str:
+    """Bounded, structural error summary for persistence/logs.
+
+    Never includes provider response bodies, full source text, or secrets (#412
+    P1-5); only the error category and a short, truncated message.
+    """
+    detail = str(exc).replace("\n", " ").strip()
+    if len(detail) > 200:
+        detail = detail[:200] + "…"
+    return f"{code}: {detail}" if detail else code
+
+
+def run_revision_pipeline(
+    *,
+    run_id: str,
+    operations: list[dict] | None = None,
+    llm_client: Callable[[dict, dict], Any] | None = None,
+    generate: Callable[[list[dict]], str] | None = None,
+) -> dict:
+    """Run audit → proposal → assembly → validation → report end-to-end.
+
+    Drives the revision run's generic state (``status`` / ``current_stage`` /
+    ``completed_at``) and emits structured stage logs so progress/outcome can be
+    judged from run state + logs alone, without inspecting artifacts (#412 P1-3 /
+    P1-5). Designed to run inside a background worker (#412 P0-2) — it never
+    touches the active run or projection tables. ``operations`` supplied means the
+    raw/debug override path (proposal generation is skipped).
+    """
+    run = persistence.get_analysis_run(run_id=run_id)
+    if not run or run.get("run_type") != "revision":
+        raise ValueError(f"revision run {run_id} not found")
+    document_id = str(run.get("document_id") or "")
+    log_ctx = "run_id=%s document_id=%s" % (run_id, document_id)
+    current_stage = STAGE_AUDIT
+    try:
+        # --- audit ---
+        artifacts = get_artifacts(run.get("stage_outputs"))
+        checkpoints_total = len(artifacts.get(AUDIT_CHECKPOINTS_KEY) or [])
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="auditing",
+            status="running", current_stage=STAGE_AUDIT,
+        )
+        logger.info("revision_started %s checkpoints=%d", log_ctx, checkpoints_total)
+        audit = audit_revision_run(run_id=run_id, llm_client=llm_client)
+        revision_targets = audit.get("revision_targets") or []
+        review_items = audit.get("review_items") or []
+        logger.info(
+            "revision_audit_completed %s checkpoints=%d targets=%d review_items=%d",
+            log_ctx, checkpoints_total, len(revision_targets), len(review_items),
+        )
+
+        # --- proposal (skipped for the raw/debug override path) ---
+        if operations is None:
+            current_stage = STAGE_PROPOSAL
+            persistence.update_revision_status(
+                run_id=run_id, revision_status="auditing", current_stage=STAGE_PROPOSAL,
+            )
+            proposals = generate_proposals(run_id=run_id, generate=generate)
+            ops = proposals.get("operations") or []
+            rejected = proposals.get("rejected") or []
+            manual_review = proposals.get("manual_review") or []
+            logger.info(
+                "revision_proposal_completed %s accepted=%d rejected=%d manual_review=%d",
+                log_ctx, len(ops), len(rejected), len(manual_review),
+            )
+            operation_source = "generated"
+        else:
+            ops = operations
+            operation_source = "raw"
+
+        # --- candidate assembly ---
+        current_stage = STAGE_CANDIDATE_ASSEMBLY
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="auditing", current_stage=STAGE_CANDIDATE_ASSEMBLY,
+        )
+        candidate = assemble_candidate(run_id=run_id, operations=ops)
+        new_unknown = sum(
+            len(err.get("details") or [])
+            for err in (candidate.get("operation_errors") or [])
+            if isinstance(err, dict) and err.get("error") == "new_unknown_references"
+        )
+        logger.info(
+            "revision_candidate_validated %s invalid=%s applied=%d new_unknown_references=%d",
+            log_ctx, bool(candidate.get("invalid")),
+            len(candidate.get("applied_operations") or []), new_unknown,
+        )
+
+        # --- validation + report ---
+        current_stage = STAGE_REPORT
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="proposed", current_stage=STAGE_REPORT,
+        )
+        report_out = revalidate_and_report(run_id=run_id)
+        report = report_out["report"]
+        summary = report.get("summary") or {}
+
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="proposed",
+            status="completed", current_stage=STAGE_COMPLETED,
+        )
+        logger.info(
+            "revision_completed %s recommendation=%s outcome=%s changes=%d candidate_invalid=%s",
+            log_ctx, report.get("recommendation"), summary.get("outcome"),
+            summary.get("entity_change_count"), summary.get("candidate_invalid"),
+        )
+        return {
+            "revision_run_id": run_id,
+            "operation_source": operation_source,
+            "audit": {
+                "verdict_counts": audit.get("verdict_counts"),
+                "revision_targets": audit.get("revision_targets"),
+            },
+            "candidate_invalid": bool(candidate.get("invalid")),
+            "report_summary": summary,
+            "stage_summary": report.get("stage_summary"),
+            "revision_status": "proposed",
+        }
+    except ProposalValidationError as exc:
+        # Not a worker crash: the audit found targets but no adoptable candidate
+        # could be assembled. Persist a failed state with the offending stage.
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="proposed",
+            status="failed", current_stage=STAGE_CANDIDATE_ASSEMBLY,
+            error_message=_safe_error("proposal_validation_failed", exc),
+        )
+        logger.warning(
+            "revision_failed %s stage=%s reason=proposal_validation rejected=%d",
+            log_ctx, STAGE_CANDIDATE_ASSEMBLY, len(exc.rejected),
+        )
+        raise
+    except Exception as exc:
+        persistence.update_revision_status(
+            run_id=run_id, revision_status="failed",
+            status="failed", current_stage=current_stage,
+            error_message=_safe_error(type(exc).__name__, exc),
+        )
+        logger.exception("revision_failed %s stage=%s", log_ctx, current_stage)
+        raise
 
 
 def reject_revision(*, run_id: str, changed_by: str | None = None, comment: str = "") -> dict:

--- a/backend/core/document_pipeline/revision/diff.py
+++ b/backend/core/document_pipeline/revision/diff.py
@@ -251,8 +251,17 @@ def build_diff_report(
     audit_summary: dict | None = None,
     proposal_summary: dict | None = None,
     new_unknown_reference_count: int = 0,
+    operation_candidate_status: str | None = None,
+    operation_summary: dict | None = None,
+    excluded_operations: list[dict] | None = None,
 ) -> dict:
-    """Assemble the before/after diff report (schema per #406, sections per #412)."""
+    """Assemble the before/after diff report (schema per #406, sections per #412).
+
+    ``operation_candidate_status`` / ``operation_summary`` / ``excluded_operations``
+    carry the partial-adoption verdict (#415); the report's final
+    ``candidate_status`` downgrades that operation-level verdict to ``blocked`` when
+    the ExportValidationGate still reports hard errors after exclusion.
+    """
     quality_before = compute_quality_metrics(base_artifacts, gate_result=gate_base)
     quality_after = compute_quality_metrics(candidate_artifacts, gate_result=gate_candidate)
 
@@ -270,10 +279,26 @@ def build_diff_report(
     protected_changes = protected_changes or []
 
     hard_error_count = quality_after.get("hard_error_count", 0)
-    acceptable = (
-        not candidate_invalid
-        and hard_error_count == 0
+
+    # Final candidate status (#415): start from the operation-level verdict, then
+    # downgrade to blocked if the gate still has hard errors / the candidate is
+    # invalid after exclusion. A partially_adoptable candidate with no hard errors
+    # is acceptable, but only via explicit partial confirmation at accept time.
+    op_status = operation_candidate_status or (
+        "blocked" if candidate_invalid else "adoptable"
     )
+    if candidate_invalid or hard_error_count > 0:
+        candidate_status = "blocked"
+    else:
+        candidate_status = op_status
+    excluded_operations = excluded_operations or []
+    operation_summary = operation_summary or {
+        "applied_count": len(entity_changes),
+        "excluded_invalid_count": 0,
+        "excluded_dependency_count": 0,
+        "requires_confirmation_count": len(protected_changes),
+    }
+    acceptable = candidate_status in ("adoptable", "partially_adoptable")
 
     recommendation = _recommendation(
         quality_after, candidate_invalid, introduced_errors,
@@ -298,11 +323,15 @@ def build_diff_report(
             "introduced_error_count": introduced_errors,
             "protected_change_count": len(protected_changes),
             "candidate_invalid": bool(candidate_invalid),
+            "candidate_status": candidate_status,
             "hard_error_count": hard_error_count,
             "acceptable": acceptable,
             "requires_confirmation": bool(requires_confirmation),
             "outcome": stage_summary["outcome"],
         },
+        "candidate_status": candidate_status,
+        "operation_summary": operation_summary,
+        "excluded_operations": excluded_operations,
         "stage_summary": stage_summary,
         "entity_changes": entity_changes,
         "structural_summary": structural_summary,

--- a/backend/core/document_pipeline/revision/diff.py
+++ b/backend/core/document_pipeline/revision/diff.py
@@ -133,6 +133,7 @@ def _entity_change_from_operation(op: dict) -> dict:
         "reason": op.get("reason"),
         "checkpoint_ids": op.get("checkpoint_ids") or [],
         "evidence_refs": op.get("evidence_refs") or [],
+        "source_chunk_ids": op.get("source_chunk_ids") or [],
         "source_locations": op.get("source_locations") or [],
         "confidence": op.get("confidence"),
         "protected": bool(op.get("protected_target")),
@@ -173,6 +174,66 @@ def _recommendation(quality_after: dict, candidate_invalid: bool,
     return "manual_review"
 
 
+def summarize_rejections(rejected: list[dict]) -> list[dict]:
+    """Aggregate rejected-proposal reasons by their leading reason code (#412 P1-8)."""
+    counts: dict[str, int] = {}
+    for item in rejected or []:
+        reason = str((item or {}).get("reason") or "unknown")
+        code = reason.split(":", 1)[0]
+        counts[code] = counts.get(code, 0) + 1
+    return [
+        {"reason": code, "count": counts[code]}
+        for code in sorted(counts, key=lambda c: (-counts[c], c))
+    ]
+
+
+def build_stage_summary(
+    *,
+    audit_summary: dict | None,
+    proposal_summary: dict | None,
+    candidate_invalid: bool,
+    new_unknown_reference_count: int,
+    applied_change_count: int,
+) -> dict:
+    """Three-stage rollup (audit / candidate generation / candidate evaluation).
+
+    Distinguishes "no improvement found" from "improvements proposed but could not
+    be validated/adopted" so a 1-change diff over 59 targets is not misread as
+    "nothing to improve" (#412 P1-8).
+    """
+    audit_summary = audit_summary or {}
+    proposal_summary = proposal_summary or {}
+    accepted = int(proposal_summary.get("accepted_count") or 0)
+    rejected = int(proposal_summary.get("rejected_count") or 0)
+    audit_targets = int(audit_summary.get("revision_target_count") or 0)
+    if audit_targets == 0:
+        outcome = "no_audit_targets"
+    elif applied_change_count == 0 and accepted == 0:
+        outcome = "proposals_failed"   # targets found, but no adoptable change
+    elif candidate_invalid:
+        outcome = "candidate_invalid"
+    else:
+        outcome = "changes_proposed"
+    return {
+        "audit": {
+            "checkpoints_total": int(audit_summary.get("checkpoints_total") or 0),
+            "revision_target_count": audit_targets,
+            "manual_review_count": int(audit_summary.get("manual_review_count") or 0),
+        },
+        "candidate_generation": {
+            "accepted_count": accepted,
+            "rejected_count": rejected,
+            "rejection_reasons": list(proposal_summary.get("rejection_reasons") or []),
+        },
+        "candidate_evaluation": {
+            "applied_change_count": applied_change_count,
+            "candidate_invalid": bool(candidate_invalid),
+            "new_unknown_reference_count": int(new_unknown_reference_count),
+        },
+        "outcome": outcome,
+    }
+
+
 def build_diff_report(
     *,
     base_run_id: str,
@@ -187,8 +248,11 @@ def build_diff_report(
     requires_confirmation: bool = False,
     id_mapping: dict | None = None,
     audit_verifications: list[dict] | None = None,
+    audit_summary: dict | None = None,
+    proposal_summary: dict | None = None,
+    new_unknown_reference_count: int = 0,
 ) -> dict:
-    """Assemble the before/after diff report (schema per #406)."""
+    """Assemble the before/after diff report (schema per #406, sections per #412)."""
     quality_before = compute_quality_metrics(base_artifacts, gate_result=gate_base)
     quality_after = compute_quality_metrics(candidate_artifacts, gate_result=gate_candidate)
 
@@ -216,6 +280,14 @@ def build_diff_report(
         len(finding_diff["resolved_issues"]), requires_confirmation,
     )
 
+    stage_summary = build_stage_summary(
+        audit_summary=audit_summary,
+        proposal_summary=proposal_summary,
+        candidate_invalid=candidate_invalid,
+        new_unknown_reference_count=new_unknown_reference_count,
+        applied_change_count=len(entity_changes),
+    )
+
     return {
         "base_run_id": base_run_id,
         "candidate_run_id": candidate_run_id,
@@ -229,7 +301,9 @@ def build_diff_report(
             "hard_error_count": hard_error_count,
             "acceptable": acceptable,
             "requires_confirmation": bool(requires_confirmation),
+            "outcome": stage_summary["outcome"],
         },
+        "stage_summary": stage_summary,
         "entity_changes": entity_changes,
         "structural_summary": structural_summary,
         "id_mapping": id_mapping or {},

--- a/backend/core/document_pipeline/revision/inventory.py
+++ b/backend/core/document_pipeline/revision/inventory.py
@@ -193,15 +193,22 @@ def _index_derivations(artifacts: dict) -> dict[str, dict]:
             continue
         steps = _as_list(chain.get("steps"))
         equation_ids: list[str] = []
+        step_ids: list[str] = []
         for s in steps:
             if isinstance(s, dict):
                 equation_ids.extend(_str_list(s.get("input_equation_ids")) + _str_list(s.get("output_equation_ids")))
                 equation_ids.extend(_str_list(s.get("inputs")) + _str_list(s.get("outputs")))
+                sid = str(s.get("step_id") or s.get("id") or "").strip()
+                if sid:
+                    step_ids.append(sid)
         out[did] = {
             "entity_id": did,
             "entity_type": "derivation",
             "label": chain.get("label") or chain.get("name") or "",
             "step_count": len(steps),
+            # Derivation *step* ids live alongside the chain id; refs may point at
+            # either, so both are tracked and the resolver accepts both (#412 P1-7).
+            "step_ids": list(dict.fromkeys(step_ids)),
             "review_status": chain.get("review_status") or "",
             "equation_ids": list(dict.fromkeys(equation_ids)),
             "source_locations": _source_locations(chain),
@@ -268,6 +275,10 @@ def _index_graph(artifacts: dict) -> tuple[dict[str, dict], dict[str, dict]]:
             "equation_ids": _str_list(n.get("linked_equation_ids")),
             "evidence_ids": _str_list(n.get("linked_evidence_ids")),
             "derivation_ids": _str_list(n.get("linked_derivation_ids")),
+            # member_component_ids reference other graph nodes (aggregated detail
+            # nodes) — falling back to component ids. Schema-defined so the same
+            # resolver classifies them for base + candidate alike (#412 P1-7).
+            "member_component_ids": _str_list(n.get("member_component_ids")),
             "protected": _is_protected(n),
         }
     edges: dict[str, dict] = {}
@@ -343,8 +354,20 @@ def _build_relations(entities: dict[str, dict[str, dict]]) -> tuple[list[dict], 
     relations: list[dict] = []
     unresolved: list[dict] = []
 
+    # Derivation *step* ids resolve a ``derivation_ids`` reference just as a chain
+    # id does, so step refs are not mis-flagged as dangling (#412 P1-7).
+    derivation_step_ids: set[str] = set()
+    for d in entities.get("derivations", {}).values():
+        derivation_step_ids.update(d.get("step_ids") or [])
+    graph_node_ids = set(entities.get("graph_nodes", {}))
+    component_ids = set(entities.get("components", {}))
+
     def _bucket_has(bucket: str, _id: str) -> bool:
-        return _id in entities.get(bucket, {})
+        if _id in entities.get(bucket, {}):
+            return True
+        if bucket == "derivations" and _id in derivation_step_ids:
+            return True
+        return False
 
     def _emit(source_type, source_id, rel_type, target_bucket, target_id, field):
         target_singular = target_bucket.rstrip("s") if target_bucket != "evidence" else "evidence"
@@ -373,6 +396,28 @@ def _build_relations(entities: dict[str, dict[str, dict]]) -> tuple[list[dict], 
                 for target_id in ent.get(field, []) or []:
                     _emit(ent["entity_type"], ent_id, f"{ent['entity_type']}_{field}",
                           target_bucket, target_id, field)
+
+    # Graph node membership: a node aggregates other graph nodes (detail nodes),
+    # falling back to component ids. Resolved against both spaces (#412 P1-7).
+    for node_id, node in entities.get("graph_nodes", {}).items():
+        for target_id in node.get("member_component_ids", []) or []:
+            if target_id in graph_node_ids or target_id in component_ids:
+                relations.append({
+                    "type": "graph_node_member_component_ids",
+                    "source_type": "graph_node",
+                    "source_id": node_id,
+                    "target_type": "graph_node",
+                    "target_id": target_id,
+                })
+            else:
+                unresolved.append({
+                    "source_type": "graph_node",
+                    "source_id": node_id,
+                    "ref_field": "member_component_ids",
+                    "target_type": "graph_node",
+                    "target_id": target_id,
+                    "reason": "missing_member",
+                })
 
     # Graph edges → node endpoints.
     for edge_id, edge in entities.get("graph_edges", {}).items():

--- a/backend/core/document_pipeline/revision/llm_audit.py
+++ b/backend/core/document_pipeline/revision/llm_audit.py
@@ -87,10 +87,14 @@ class LLMAuditClient:
         instruction = (
             "あなたは学術論文の校閲者です。既存の抽出成果物(entity)を、取得した原文(source)と"
             "比較し、妥当性を判定してください。原文に根拠が無い場合は valid にしないこと。"
-            "LLMの推測(analysis_notes)と原文由来の根拠(evidence_refs/source由来)を必ず分けること。"
+            "LLMの推測(analysis_notes)と原文由来の根拠を必ず分けること。"
+            "根拠IDは2つのID空間に分けて出力する: "
+            "evidence_ids は related に出てくる EvidenceRegistry の evidence_id、"
+            "source_chunk_ids は source に出てくる chunk_id。混在させないこと。"
             "出力は次のJSONのみ: {\"verdict\": one of [valid, incorrect, incomplete, "
             "unsupported, ambiguous], \"findings\": [{\"kind\":..,\"detail\":..}], "
-            "\"evidence_refs\": [evidence_id|chunk_id ...], \"analysis_notes\": [..], "
+            "\"evidence_ids\": [evidence_id ...], \"source_chunk_ids\": [chunk_id ...], "
+            "\"analysis_notes\": [..], "
             "\"confidence\": 0.0-1.0, \"requires_revision\": bool, \"review_required\": bool}"
         )
         payload = {

--- a/backend/core/document_pipeline/revision/operations.py
+++ b/backend/core/document_pipeline/revision/operations.py
@@ -511,81 +511,346 @@ def _canonical_order(operations: list[dict]) -> list[tuple[int, dict]]:
     )
 
 
+# ---------------------------------------------------------------------------
+# Partial-adoption support (#415): per-operation dependency analysis so a single
+# bad operation excludes only itself + its dependents, not the whole candidate.
+# ---------------------------------------------------------------------------
+
+# Operation status taxonomy (#415).
+OP_APPLIED = "applied"
+OP_EXCLUDED_INVALID = "excluded_invalid"
+OP_EXCLUDED_DEPENDENCY = "excluded_dependency"
+OP_REQUIRES_CONFIRMATION = "requires_confirmation"
+
+# Candidate status taxonomy (#415).
+CAND_ADOPTABLE = "adoptable"
+CAND_PARTIALLY_ADOPTABLE = "partially_adoptable"
+CAND_BLOCKED = "blocked"
+
+
+def _all_base_ids(base_inventory: dict | None, base_artifacts: dict) -> set[str]:
+    """Every entity id present in the base (the ids an operation may safely consume)."""
+    inv = base_inventory
+    if not inv or "entities" not in inv:
+        from .inventory import build_baseline_inventory
+        inv = build_baseline_inventory(base_artifacts or {}, base_run_id="")
+    ids: set[str] = set()
+    for bucket in (inv.get("entities") or {}).values():
+        ids.update(str(k) for k in (bucket or {}).keys())
+    return ids
+
+
+def _produced_ids(op: dict) -> list[str]:
+    """Entity ids an operation *creates* (so dependents can be tracked)."""
+    operation = op.get("operation")
+    target_type = op.get("target_type")
+    _, _, idf = ENTITY_REGISTRY.get(target_type, (None, None, None))
+    after = op.get("after_json")
+    if operation == "add_entity" and isinstance(after, dict):
+        nid = _record_id(after, idf) or str(op.get("target_id") or "")
+        return [nid] if nid else []
+    if operation == "split_entity" and isinstance(after, list):
+        return [_record_id(p, idf) for p in after
+                if isinstance(p, dict) and _record_id(p, idf)]
+    if operation == "merge_entities" and isinstance(after, dict):
+        mid = _record_id(after, idf)
+        return [mid] if mid else []
+    return []
+
+
+def _after_json_ref_ids(op: dict) -> list[str]:
+    """Reference-list ids embedded in an add/update after_json (e.g. equation_ids)."""
+    fields = REFERENCE_FIELDS.get(op.get("target_type"), [])
+    after = op.get("after_json")
+    records = after if isinstance(after, list) else [after]
+    out: list[str] = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        for field, _t in fields:
+            out.extend(str(v) for v in _as_list(rec.get(field)) if v)
+    return out
+
+
+def _consumed_ids(op: dict) -> list[str]:
+    """Entity ids an operation *references* and therefore depends upon (#415)."""
+    operation = op.get("operation")
+    target_type = op.get("target_type")
+    out: list[str] = []
+    if operation == "merge_entities":
+        for sid in (op.get("source_ids") or op.get("target_ids") or []):
+            if sid:
+                out.append(str(sid))
+        if op.get("target_id"):
+            out.append(str(op["target_id"]))
+    elif operation in ("update_entity", "split_entity", "remove_entity",
+                       "relink_evidence", "remove_relation", "add_relation"):
+        if target_type == "graph_edge":
+            after = op.get("after_json") if operation == "add_relation" else None
+            if isinstance(after, dict):
+                for key in ("source", "target", "source_component_id",
+                            "target_component_id", "from", "to"):
+                    if after.get(key):
+                        out.append(str(after[key]))
+            if operation == "remove_relation" and op.get("target_id"):
+                out.append(str(op["target_id"]))
+        else:
+            if op.get("target_id"):
+                out.append(str(op["target_id"]))
+            if op.get("relation_target_id"):
+                out.append(str(op["relation_target_id"]))
+    if operation in ("add_entity", "update_entity", "split_entity"):
+        out.extend(_after_json_ref_ids(op))
+    return list(dict.fromkeys(out))
+
+
+def _op_introduces(op: dict, dangling: dict) -> bool:
+    """Whether ``op`` is responsible for a specific new dangling reference."""
+    source_id = str(dangling.get("source_id") or "")
+    target_id = str(dangling.get("target_id") or "")
+    if source_id and source_id == str(op.get("target_id") or ""):
+        return True
+    if source_id and source_id in _produced_ids(op):
+        return True
+    if op.get("operation") in ("add_relation", "relink_evidence"):
+        if target_id and (target_id == str(op.get("relation_target_id") or "")
+                          or target_id in [str(v) for v in (op.get("evidence_refs") or [])]):
+            return True
+    if op.get("operation") == "add_relation" and op.get("target_type") == "graph_edge":
+        after = op.get("after_json") or {}
+        if isinstance(after, dict) and source_id == str(after.get("edge_id") or ""):
+            return True
+    return False
+
+
+def _normalize_excluded(raw: dict) -> dict:
+    """Minimal normalization of a pre-rejected op so it can still be analysed."""
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        "operation_id": raw.get("operation_id") or "",
+        "operation": raw.get("operation"),
+        "target_type": raw.get("target_type"),
+        "target_id": raw.get("target_id"),
+        "after_json": raw.get("after_json"),
+        "source_ids": raw.get("source_ids") or raw.get("target_ids") or [],
+        "relation_target_id": raw.get("relation_target_id"),
+        "evidence_refs": raw.get("evidence_refs") or [],
+    }
+
+
+def _excluded_record(op: dict, status: str, reason: str) -> dict:
+    return {
+        "operation_id": op.get("operation_id") or "",
+        "status": status,
+        "reason": reason,
+        "operation": op.get("operation"),
+        "target_type": op.get("target_type"),
+        "target_id": op.get("target_id"),
+    }
+
+
+def _apply_included(base_artifacts: dict, included: list[dict]):
+    """Apply the included ops on a fresh copy; return (candidate, id_mapping, failure).
+
+    ``failure`` is ``(op_index, reason)`` for the first op whose handler raised, or
+    None when all applied cleanly.
+    """
+    candidate = copy.deepcopy(base_artifacts) if isinstance(base_artifacts, dict) else {}
+    id_mapping: dict[str, list[str]] = {}
+    for _idx, op in _canonical_order(included):
+        handler = _DISPATCH.get(op.get("operation"))
+        if handler is None:
+            return candidate, id_mapping, (op["_idx"], f"unknown operation {op.get('operation')}")
+        try:
+            handler(candidate, op, id_mapping)
+        except _OpError as exc:
+            return candidate, id_mapping, (op["_idx"], str(exc))
+    return candidate, id_mapping, None
+
+
 def apply_operations(
     base_artifacts: dict,
     operations: list[dict],
     *,
     base_inventory: dict | None = None,
+    pre_excluded: list[dict] | None = None,
 ) -> dict:
-    """Apply revision operations to immutable base artifacts → candidate set."""
-    candidate = copy.deepcopy(base_artifacts) if isinstance(base_artifacts, dict) else {}
-    id_mapping: dict[str, list[str]] = {}
-    applied: list[dict] = []
-    errors: list[dict] = []
-    protected_changes: list[dict] = []
-    dropped_edges: list[str] = []
+    """Apply revision operations, excluding only the bad ones (#415, partial adoption).
 
-    # Server-side source of truth for protected entities (never trust the client
-    # flag). Computed once from the base inventory / artifacts.
+    Invalid operations (failed pre-validation, missing target, or one that would
+    introduce a new dangling reference) are excluded as ``excluded_invalid``;
+    operations that depend on an excluded operation's output are excluded as
+    ``excluded_dependency``. The candidate is rebuilt from the surviving ops, so
+    independent valid changes remain adoptable even when a sibling op is bad.
+
+    ``pre_excluded`` carries operations already rejected upstream (typed evidence /
+    checkpoint validation, #414) as ``{"op"|"raw": <op>, "reason": str}`` so their
+    dependents are excluded too.
+    """
+    base_artifacts = base_artifacts or {}
+    ops = [copy.deepcopy(o) for o in (operations or [])]
+    for i, o in enumerate(ops):
+        o["_idx"] = i
+
+    # Pre-rejected ops keep their reason and still register produced ids so their
+    # dependents are detected, but are never applied.
+    extra_excluded: list[dict] = []
+    for j, rej in enumerate(pre_excluded or []):
+        xo = _normalize_excluded(rej.get("op") or rej.get("raw") or rej)
+        xo["_idx"] = len(ops) + j
+        xo["_pre_reason"] = rej.get("reason") or "invalid_operation"
+        extra_excluded.append(xo)
+
+    all_ops = {o["_idx"]: o for o in ops}
+    all_ops.update({xo["_idx"]: xo for xo in extra_excluded})
+
+    base_ids = _all_base_ids(base_inventory, base_artifacts)
+    produced_by: dict[str, list[int]] = {}
+    for o in all_ops.values():
+        for pid in _produced_ids(o):
+            produced_by.setdefault(pid, []).append(o["_idx"])
+
+    # excluded: _idx -> {"status", "reason"}
+    excluded: dict[int, dict] = {
+        xo["_idx"]: {"status": OP_EXCLUDED_INVALID, "reason": xo["_pre_reason"]}
+        for xo in extra_excluded
+    }
     protected_ids = _protected_ids(base_inventory, base_artifacts)
 
-    for _idx, op in _canonical_order(operations or []):
-        op = copy.deepcopy(op)
-        handler = _DISPATCH.get(op.get("operation"))
-        if handler is None:
-            op["validation_result"] = {"status": "failed", "error": f"unknown operation {op.get('operation')}"}
-            errors.append({"operation_id": op.get("operation_id"), "error": op["validation_result"]["error"]})
-            applied.append(op)
+    def _propagate() -> None:
+        again = True
+        while again:
+            again = False
+            for o in ops:
+                idx = o["_idx"]
+                if idx in excluded:
+                    continue
+                for cid in _consumed_ids(o):
+                    if cid in base_ids:
+                        continue
+                    producers = produced_by.get(cid, [])
+                    if not producers:
+                        excluded[idx] = {"status": OP_EXCLUDED_INVALID,
+                                         "reason": f"unknown_reference:{cid}"}
+                        again = True
+                        break
+                    if all(p in excluded for p in producers):
+                        excluded[idx] = {"status": OP_EXCLUDED_DEPENDENCY,
+                                         "reason": f"depends_on_excluded:{cid}"}
+                        again = True
+                        break
+
+    blocked_dangling: list[dict] = []
+    candidate: dict = {}
+    id_mapping: dict[str, list[str]] = {}
+    dropped_edges: list[str] = []
+    carried: list[dict] = []
+    # Iterate: exclude dependents, apply, exclude handler failures / new danglers,
+    # repeat until the surviving set applies cleanly. Bounded — each pass excludes
+    # at least one op.
+    for _guard in range(len(ops) + 2):
+        _propagate()
+        included = [o for o in ops if o["_idx"] not in excluded]
+        candidate, id_mapping, failure = _apply_included(base_artifacts, included)
+        if failure is not None:
+            excluded[failure[0]] = {"status": OP_EXCLUDED_INVALID, "reason": failure[1]}
             continue
-        try:
-            handler(candidate, op, id_mapping)
-            op["validation_result"] = {"status": "applied"}
-            # Determine protected status server-side and overwrite the (untrusted)
-            # client flag so the report and accept gate use the authoritative value.
-            server_protected = _op_protected_targets(op, protected_ids)
-            op["protected_target"] = bool(server_protected)
-            op["protected_target_source"] = "server"
+        dropped_edges = _apply_id_mapping(candidate, id_mapping)
+        if base_inventory is not None:
+            base_keys = _base_unresolved_keys(base_inventory)
+        else:
+            from .inventory import build_baseline_inventory
+            base_keys = _base_unresolved_keys(
+                build_baseline_inventory(base_artifacts or {}, base_run_id="")
+            )
+        candidate_unresolved = _candidate_unresolved_references(candidate)
+        new_dangling = [d for d in candidate_unresolved if _ref_key(d) not in base_keys]
+        carried = [d for d in candidate_unresolved if _ref_key(d) in base_keys]
+        if new_dangling:
+            culprits = {o["_idx"] for o in included
+                        for d in new_dangling if _op_introduces(o, d)}
+            if culprits:
+                for idx in culprits:
+                    excluded[idx] = {"status": OP_EXCLUDED_INVALID,
+                                     "reason": "introduces_unknown_reference"}
+                continue
+            blocked_dangling = new_dangling  # unattributable → candidate is blocked
+        break
+
+    # Build the final per-operation records, protected-change flags, and summary.
+    included_idx = {o["_idx"] for o in ops if o["_idx"] not in excluded}
+    protected_changes: list[dict] = []
+    applied_operations: list[dict] = []
+    excluded_operations: list[dict] = []
+    counts = {OP_APPLIED: 0, OP_EXCLUDED_INVALID: 0,
+              OP_EXCLUDED_DEPENDENCY: 0, OP_REQUIRES_CONFIRMATION: 0}
+
+    for o in sorted(all_ops.values(), key=lambda x: x["_idx"]):
+        idx = o["_idx"]
+        record = {k: v for k, v in o.items() if not k.startswith("_")}
+        if idx in excluded:
+            status = excluded[idx]["status"]
+            reason = excluded[idx]["reason"]
+            record["validation_result"] = {"status": "failed", "error": reason}
+            record["operation_status"] = status
+            excluded_operations.append(_excluded_record(record, status, reason))
+            counts[status] = counts.get(status, 0) + 1
+        else:
+            record["validation_result"] = {"status": "applied"}
+            server_protected = _op_protected_targets(o, protected_ids)
+            record["protected_target"] = bool(server_protected)
+            record["protected_target_source"] = "server"
             if server_protected:
+                record["operation_status"] = OP_REQUIRES_CONFIRMATION
+                counts[OP_REQUIRES_CONFIRMATION] += 1
                 protected_changes.append({
-                    "operation_id": op.get("operation_id"),
-                    "operation": op.get("operation"),
-                    "target_type": op.get("target_type"),
-                    "target_id": op.get("target_id"),
+                    "operation_id": o.get("operation_id"),
+                    "operation": o.get("operation"),
+                    "target_type": o.get("target_type"),
+                    "target_id": o.get("target_id"),
                     "protected_entity_ids": server_protected,
                 })
-        except _OpError as exc:
-            op["validation_result"] = {"status": "failed", "error": str(exc)}
-            errors.append({"operation_id": op.get("operation_id"), "error": str(exc)})
-        applied.append(op)
+            else:
+                record["operation_status"] = OP_APPLIED
+            counts[OP_APPLIED] += 1
+        applied_operations.append(record)
 
-    # Follow id changes from split/merge/remove across all references.
-    dropped_edges = _apply_id_mapping(candidate, id_mapping)
-
-    # Integrity: any NEW dangling reference (not pre-existing in base) is fatal.
-    # Base keys come from the same inventory resolver, so references that already
-    # dangled in the base are carried, never re-counted as new errors (#412 P1-7).
-    if base_inventory is not None:
-        base_keys = _base_unresolved_keys(base_inventory)
+    operation_summary = {
+        "applied_count": counts[OP_APPLIED],
+        "excluded_invalid_count": counts[OP_EXCLUDED_INVALID],
+        "excluded_dependency_count": counts[OP_EXCLUDED_DEPENDENCY],
+        "requires_confirmation_count": counts[OP_REQUIRES_CONFIRMATION],
+    }
+    total_excluded = counts[OP_EXCLUDED_INVALID] + counts[OP_EXCLUDED_DEPENDENCY]
+    if blocked_dangling or (counts[OP_APPLIED] == 0 and total_excluded > 0):
+        candidate_status = CAND_BLOCKED
+    elif total_excluded > 0:
+        candidate_status = CAND_PARTIALLY_ADOPTABLE
     else:
-        from .inventory import build_baseline_inventory
-        base_keys = _base_unresolved_keys(
-            build_baseline_inventory(base_artifacts or {}, base_run_id="")
-        )
-    candidate_unresolved = _candidate_unresolved_references(candidate)
-    new_dangling = [d for d in candidate_unresolved if _ref_key(d) not in base_keys]
-    carried = [d for d in candidate_unresolved if _ref_key(d) in base_keys]
-    if new_dangling:
-        errors.append({"error": "new_unknown_references", "details": new_dangling})
+        candidate_status = CAND_ADOPTABLE
 
-    invalid = bool(errors)
+    operation_errors = [
+        {"operation_id": rec["operation_id"], "error": rec["reason"]}
+        for rec in excluded_operations
+    ]
+    if blocked_dangling:
+        operation_errors.append({"error": "new_unknown_references",
+                                 "details": blocked_dangling})
+
     return {
         "candidate_artifacts": candidate,
         "id_mapping": {k: v for k, v in id_mapping.items()},
-        "applied_operations": applied,
-        "operation_errors": errors,
+        "applied_operations": applied_operations,
+        "operation_errors": operation_errors,
+        "excluded_operations": excluded_operations,
+        "operation_summary": operation_summary,
+        "candidate_status": candidate_status,
         "protected_changes": protected_changes,
         "dropped_edges": dropped_edges,
         "carried_unresolved_references": carried,
-        "invalid": invalid,
+        # ``invalid`` retains its meaning of "cannot be adopted as-is"; with partial
+        # adoption that is only the fully-blocked case (#415).
+        "invalid": candidate_status == CAND_BLOCKED,
         "requires_confirmation": bool(protected_changes),
     }
+

--- a/backend/core/document_pipeline/revision/operations.py
+++ b/backend/core/document_pipeline/revision/operations.py
@@ -97,6 +97,7 @@ def make_operation(
     reason: str = "",
     checkpoint_ids: list[str] | None = None,
     evidence_refs: list[str] | None = None,
+    source_chunk_ids: list[str] | None = None,
     source_locations: list | None = None,
     confidence: float = 0.0,
     protected_target: bool = False,
@@ -114,7 +115,10 @@ def make_operation(
         "after_json": after_json,
         "reason": reason,
         "checkpoint_ids": list(checkpoint_ids or []),
+        # Registry evidence ids and source chunk ids are kept in separate fields
+        # because they live in different ID spaces (#412 P0-6).
         "evidence_refs": list(evidence_refs or []),
+        "source_chunk_ids": list(source_chunk_ids or []),
         "source_locations": list(source_locations or []),
         "confidence": float(confidence or 0.0),
         "protected_target": bool(protected_target),
@@ -157,18 +161,6 @@ def _find_record(lst: list, id_field: str | None, target_id: str) -> dict | None
         if isinstance(r, dict) and _record_id(r, id_field) == target_id:
             return r
     return None
-
-
-def _collect_ids(candidate: dict) -> dict[str, set]:
-    ids: dict[str, set] = {}
-    for etype, (akey, lkey, idf) in ENTITY_REGISTRY.items():
-        bucket = ids.setdefault(etype, set())
-        for r in _as_list((candidate.get(akey) or {}).get(lkey)):
-            if isinstance(r, dict):
-                rid = _record_id(r, idf)
-                if rid:
-                    bucket.add(rid)
-    return ids
 
 
 # ---------------------------------------------------------------------------
@@ -433,37 +425,28 @@ _DISPATCH = {
 # Integrity check
 # ---------------------------------------------------------------------------
 
+def _ref_key(ref: dict) -> tuple:
+    return (ref.get("source_id"), ref.get("ref_field"), ref.get("target_id"))
+
+
 def _base_unresolved_keys(base_inventory: dict | None) -> set[tuple]:
     keys: set[tuple] = set()
     for u in (base_inventory or {}).get("unresolved_references", []) or []:
-        keys.add((u.get("source_id"), u.get("ref_field"), u.get("target_id")))
+        keys.add(_ref_key(u))
     return keys
 
 
-def _candidate_dangling(candidate: dict) -> list[dict]:
-    ids = _collect_ids(candidate)
-    dangling: list[dict] = []
-    for entity_type, fields in REFERENCE_FIELDS.items():
-        akey, lkey, idf = ENTITY_REGISTRY[entity_type]
-        for r in _as_list((candidate.get(akey) or {}).get(lkey)):
-            if not isinstance(r, dict):
-                continue
-            sid = _record_id(r, idf)
-            for field, target_type in fields:
-                for tid in _as_list(r.get(field)):
-                    if str(tid) not in ids.get(target_type, set()):
-                        dangling.append({"source_id": sid, "ref_field": field, "target_id": str(tid)})
-    # graph edge endpoints
-    node_ids = ids.get("graph_node", set())
-    for e in _as_list((candidate.get("component_graph") or {}).get("edges")):
-        if not isinstance(e, dict):
-            continue
-        eid = str(e.get("edge_id") or "")
-        for role in ("source", "target"):
-            v = e.get(role) or e.get(f"{role}_component_id")
-            if v and str(v) not in node_ids:
-                dangling.append({"source_id": eid, "ref_field": role, "target_id": str(v)})
-    return dangling
+def _candidate_unresolved_references(candidate: dict) -> list[dict]:
+    """Unresolved references in the candidate, via the *same* resolver as the base.
+
+    Using ``build_baseline_inventory`` (rather than a parallel raw-field walk)
+    guarantees base and candidate dangling checks share one schema / ID semantics,
+    so a reference that already dangled in the base is classified as *carried*, not
+    a brand-new error (#412 P1-7).
+    """
+    from .inventory import build_baseline_inventory
+    inv = build_baseline_inventory(candidate or {}, base_run_id="")
+    return list(inv.get("unresolved_references") or [])
 
 
 # ---------------------------------------------------------------------------
@@ -579,12 +562,18 @@ def apply_operations(
     dropped_edges = _apply_id_mapping(candidate, id_mapping)
 
     # Integrity: any NEW dangling reference (not pre-existing in base) is fatal.
-    base_keys = _base_unresolved_keys(base_inventory)
-    candidate_dangling = _candidate_dangling(candidate)
-    new_dangling = [
-        d for d in candidate_dangling
-        if (d["source_id"], d["ref_field"], d["target_id"]) not in base_keys
-    ]
+    # Base keys come from the same inventory resolver, so references that already
+    # dangled in the base are carried, never re-counted as new errors (#412 P1-7).
+    if base_inventory is not None:
+        base_keys = _base_unresolved_keys(base_inventory)
+    else:
+        from .inventory import build_baseline_inventory
+        base_keys = _base_unresolved_keys(
+            build_baseline_inventory(base_artifacts or {}, base_run_id="")
+        )
+    candidate_unresolved = _candidate_unresolved_references(candidate)
+    new_dangling = [d for d in candidate_unresolved if _ref_key(d) not in base_keys]
+    carried = [d for d in candidate_unresolved if _ref_key(d) in base_keys]
     if new_dangling:
         errors.append({"error": "new_unknown_references", "details": new_dangling})
 
@@ -596,10 +585,7 @@ def apply_operations(
         "operation_errors": errors,
         "protected_changes": protected_changes,
         "dropped_edges": dropped_edges,
-        "carried_unresolved_references": [
-            d for d in candidate_dangling
-            if (d["source_id"], d["ref_field"], d["target_id"]) in base_keys
-        ],
+        "carried_unresolved_references": carried,
         "invalid": invalid,
         "requires_confirmation": bool(protected_changes),
     }

--- a/backend/core/document_pipeline/revision/proposal.py
+++ b/backend/core/document_pipeline/revision/proposal.py
@@ -47,18 +47,21 @@ def _chunk_ids_from_locations(value: object) -> set[str]:
     return out
 
 
-def chunk_ids_for_audit_result(audit_result: dict | None) -> set[str]:
-    """Source chunk ids known-good for one audit result.
+def trusted_chunk_ids_for_audit_result(audit_result: dict | None) -> set[str]:
+    """Server-trusted source chunk ids for one audit result.
 
-    The chunks actually retrieved for a checkpoint (recorded in
-    ``source_locations`` / ``source_chunk_ids``) are valid *source* references,
-    living in the ``chunks.id`` space — NOT the EvidenceRegistry ``evidence_id``
-    space. They must never be validated as registry evidence (#412 P0-6).
+    Only the chunks the deterministic retrieval actually returned — recorded in
+    ``source_locations`` — are trusted as proof of existence (the ``chunks.id``
+    space). The LLM-returned ``source_chunk_ids`` are deliberately NOT used here:
+    an LLM's own output must never be the sole evidence that a chunk exists
+    (#414-5). They are validated against this trusted set instead.
     """
     audit_result = audit_result or {}
-    chunks = _chunk_ids_from_locations(audit_result.get("source_locations"))
-    chunks |= {str(c) for c in (audit_result.get("source_chunk_ids") or []) if c}
-    return chunks
+    return _chunk_ids_from_locations(audit_result.get("source_locations"))
+
+
+# Back-compat alias (older callers); now returns only the trusted retrieval set.
+chunk_ids_for_audit_result = trusted_chunk_ids_for_audit_result
 
 
 def _dedup(values: list[str]) -> list[str]:
@@ -107,15 +110,14 @@ def _resolve_evidence_refs(
     unknown_evidence: list[str] = []
     unknown_chunks: list[str] = []
 
+    # Every reference is validated against its own server-trusted index. Nothing
+    # is accepted on faith — an empty known-chunk set means a source_chunk_id
+    # cannot be proven to exist, so it is rejected (fail-closed), never accepted
+    # blindly (#414-5).
     for e in explicit_evidence:
         (evidence_refs if e in known_evidence_ids else unknown_evidence).append(e)
     for c in explicit_chunks:
-        # When no chunk index is available we cannot disprove the ref; accept it
-        # rather than mis-rejecting a valid chunk as unknown evidence.
-        if not known_chunk_ids or c in known_chunk_ids:
-            source_chunk_ids.append(c)
-        else:
-            unknown_chunks.append(c)
+        (source_chunk_ids if c in known_chunk_ids else unknown_chunks).append(c)
     for ref in mixed:
         if ref in known_evidence_ids:
             evidence_refs.append(ref)
@@ -243,8 +245,15 @@ def validate_proposed_operations(
     *,
     audit_results: list[dict] | None = None,
     checkpoints: list[dict] | None = None,
+    known_chunk_ids: set[str] | None = None,
 ) -> dict:
-    """Validate a batch of raw proposed operations (e.g. from the debug raw-JSON path)."""
+    """Validate a batch of raw proposed operations (e.g. from the debug raw-JSON path).
+
+    ``known_chunk_ids`` is the server-trusted source-chunk index (e.g. from the
+    ``chunks`` table); it is unioned with the chunk ids the deterministic audit
+    actually retrieved and with the checkpoints' source scope. The LLM's own
+    ``source_chunk_ids`` are never trusted as proof of existence (#414-5).
+    """
     accepted, rejected = [], []
     audit_by_checkpoint = {
         str(audit.get("checkpoint_id")): audit
@@ -256,15 +265,15 @@ def validate_proposed_operations(
         for checkpoint in (checkpoints or [])
         if isinstance(checkpoint, dict) and checkpoint.get("checkpoint_id")
     } | set(audit_by_checkpoint)
-    # Source-chunk id space (chunks.id), distinct from EvidenceRegistry ids. Built
-    # from every audit result's retrieved source + every checkpoint's source scope
-    # so legitimate chunk references survive validation (#412 P0-6).
-    known_chunk_ids: set[str] = set()
+    # Source-chunk id space (chunks.id), distinct from EvidenceRegistry ids and
+    # built only from trusted server data: the caller-provided chunk index, the
+    # chunks the deterministic retrieval returned, and the checkpoints' scope.
+    trusted_chunk_ids: set[str] = set(known_chunk_ids or set())
     for audit in audit_by_checkpoint.values():
-        known_chunk_ids |= chunk_ids_for_audit_result(audit)
+        trusted_chunk_ids |= trusted_chunk_ids_for_audit_result(audit)
     for checkpoint in (checkpoints or []):
         if isinstance(checkpoint, dict):
-            known_chunk_ids |= _chunk_ids_from_locations(checkpoint.get("source_scope"))
+            trusted_chunk_ids |= _chunk_ids_from_locations(checkpoint.get("source_scope"))
     seen_targets: set[tuple[str, str, str]] = set()
     for raw in raw_ops or []:
         raw_checkpoint_ids = [
@@ -279,7 +288,7 @@ def validate_proposed_operations(
             inventory,
             audit,
             known_checkpoint_ids=known_checkpoint_ids,
-            known_chunk_ids=known_chunk_ids,
+            known_chunk_ids=trusted_chunk_ids,
         )
         if op is not None:
             key = (op.get("operation") or "", op.get("target_type") or "", op.get("target_id") or "")
@@ -337,16 +346,23 @@ def propose_operations(
     inventory: dict,
     *,
     generate: Callable[[list[dict]], str] | None = None,
+    known_chunk_ids: set[str] | None = None,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> dict:
     """Generate validated revision operations from ``requires_revision`` audits.
 
     When ``generate`` is None (no LLM), no operations are proposed and each
     actionable finding is reported as a manual-review item — never auto-confirmed.
+    ``known_chunk_ids`` is the server-trusted source-chunk index used (together
+    with each audit's retrieved chunks) to validate ``source_chunk_ids`` (#414-5).
+    ``progress_callback(completed, total)`` reports per-target progress (#414-3).
     """
     inventory = inventory or {}
+    trusted_chunk_ids = set(known_chunk_ids or set())
     targets = [a for a in (audit_results or []) if a.get("requires_revision")]
+    total = len(targets)
     operations, rejected, manual_review = [], [], []
-    for audit in targets:
+    for index, audit in enumerate(targets, start=1):
         if generate is None:
             manual_review.append({
                 "checkpoint_id": audit.get("checkpoint_id"),
@@ -354,22 +370,28 @@ def propose_operations(
                 "target_id": audit.get("target_id"),
                 "reason": "no_llm_available_manual_operation_required",
             })
+            if progress_callback:
+                progress_callback(index, total)
             continue
         try:
             raw = _extract_json(generate(_proposal_messages(audit, inventory)))
         except Exception as exc:
             rejected.append({"checkpoint_id": audit.get("checkpoint_id"),
                              "reason": f"proposal_generation_failed:{exc}"})
+            if progress_callback:
+                progress_callback(index, total)
             continue
         op, reason = validate_proposed_operation(
             raw,
             inventory,
             audit,
             known_checkpoint_ids={str(audit.get("checkpoint_id"))},
-            known_chunk_ids=chunk_ids_for_audit_result(audit),
+            known_chunk_ids=trusted_chunk_ids | trusted_chunk_ids_for_audit_result(audit),
         )
         if op is not None:
             operations.append(op)
         else:
             rejected.append({"checkpoint_id": audit.get("checkpoint_id"), "reason": reason})
+        if progress_callback:
+            progress_callback(index, total)
     return {"operations": operations, "rejected": rejected, "manual_review": manual_review}

--- a/backend/core/document_pipeline/revision/proposal.py
+++ b/backend/core/document_pipeline/revision/proposal.py
@@ -34,12 +34,111 @@ def _known_evidence_ids(inventory: dict) -> set[str]:
     return set((inventory.get("entities", {}).get("evidence", {}) or {}).keys())
 
 
+def _chunk_ids_from_locations(value: object) -> set[str]:
+    """Collect chunk ids referenced by a list of source-location dicts."""
+    out: set[str] = set()
+    for loc in value or []:
+        if isinstance(loc, dict):
+            cid = loc.get("chunk_id")
+            if cid:
+                out.add(str(cid))
+        elif loc:
+            out.add(str(loc))
+    return out
+
+
+def chunk_ids_for_audit_result(audit_result: dict | None) -> set[str]:
+    """Source chunk ids known-good for one audit result.
+
+    The chunks actually retrieved for a checkpoint (recorded in
+    ``source_locations`` / ``source_chunk_ids``) are valid *source* references,
+    living in the ``chunks.id`` space — NOT the EvidenceRegistry ``evidence_id``
+    space. They must never be validated as registry evidence (#412 P0-6).
+    """
+    audit_result = audit_result or {}
+    chunks = _chunk_ids_from_locations(audit_result.get("source_locations"))
+    chunks |= {str(c) for c in (audit_result.get("source_chunk_ids") or []) if c}
+    return chunks
+
+
+def _dedup(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for v in values:
+        if v not in seen:
+            seen.add(v)
+            out.append(v)
+    return out
+
+
+def _resolve_evidence_refs(
+    raw_op: dict,
+    audit_result: dict,
+    *,
+    known_evidence_ids: set[str],
+    known_chunk_ids: set[str],
+) -> tuple[list[str], list[str], str]:
+    """Split + validate references into the registry-evidence and source-chunk spaces.
+
+    Returns ``(evidence_refs, source_chunk_ids, reason)``. ``reason`` is non-empty
+    only when a reference resolves to *neither* space (a genuinely unknown id);
+    valid chunk references are never reported as ``unknown_evidence`` (#412 P0-6).
+
+    Three input shapes are accepted so the LLM/audit may emit either typed fields
+    or the legacy mixed ``evidence_refs`` list:
+      * ``evidence_ids``      — explicit EvidenceRegistry ids (validated vs registry)
+      * ``source_chunk_ids``  — explicit ``chunks.id`` refs (validated vs chunk index)
+      * ``evidence_refs``     — legacy mixed list, routed by id space
+    """
+    explicit_evidence = [str(e) for e in (raw_op.get("evidence_ids") or []) if e]
+    explicit_chunks = [
+        str(c)
+        for c in (raw_op.get("source_chunk_ids") or audit_result.get("source_chunk_ids") or [])
+        if c
+    ]
+    mixed = [
+        str(e)
+        for e in (raw_op.get("evidence_refs") or audit_result.get("evidence_refs") or [])
+        if e
+    ]
+
+    evidence_refs: list[str] = []
+    source_chunk_ids: list[str] = []
+    unknown_evidence: list[str] = []
+    unknown_chunks: list[str] = []
+
+    for e in explicit_evidence:
+        (evidence_refs if e in known_evidence_ids else unknown_evidence).append(e)
+    for c in explicit_chunks:
+        # When no chunk index is available we cannot disprove the ref; accept it
+        # rather than mis-rejecting a valid chunk as unknown evidence.
+        if not known_chunk_ids or c in known_chunk_ids:
+            source_chunk_ids.append(c)
+        else:
+            unknown_chunks.append(c)
+    for ref in mixed:
+        if ref in known_evidence_ids:
+            evidence_refs.append(ref)
+        elif ref in known_chunk_ids:
+            source_chunk_ids.append(ref)
+        else:
+            unknown_evidence.append(ref)
+
+    reason = ""
+    if unknown_evidence:
+        reason = f"unknown_evidence:{','.join(_dedup(unknown_evidence))}"
+    elif unknown_chunks:
+        reason = f"unknown_source_chunk:{','.join(_dedup(unknown_chunks))}"
+    return _dedup(evidence_refs), _dedup(source_chunk_ids), reason
+
+
 def validate_proposed_operation(
     raw_op: dict,
     inventory: dict,
     audit_result: dict | None = None,
     *,
     known_checkpoint_ids: set[str] | None = None,
+    known_chunk_ids: set[str] | None = None,
 ) -> tuple:
     """Validate a single proposed operation server-side.
 
@@ -84,14 +183,18 @@ def validate_proposed_operation(
         ):
             return None, f"unknown_relation_target:{relation_target_type}:{relation_target_id}"
 
-    # Evidence refs must resolve (source-derived, from the audit result).
+    # References must resolve, but the registry-evidence and source-chunk ID
+    # spaces are validated separately (#412 P0-6). A valid chunk reference (in
+    # ``chunks.id``) is kept as ``source_chunk_ids`` and never rejected as
+    # unknown registry evidence.
     known_ev = _known_evidence_ids(inventory)
     audit_result = audit_result or {}
-    evidence_refs = [str(e) for e in (raw_op.get("evidence_refs")
-                                      or audit_result.get("evidence_refs") or []) if e]
-    unknown_evidence = [e for e in evidence_refs if e not in known_ev]
-    if unknown_evidence:
-        return None, f"unknown_evidence:{','.join(unknown_evidence)}"
+    known_chunks = set(known_chunk_ids or set()) | chunk_ids_for_audit_result(audit_result)
+    evidence_refs, source_chunk_ids, ref_reason = _resolve_evidence_refs(
+        raw_op, audit_result, known_evidence_ids=known_ev, known_chunk_ids=known_chunks
+    )
+    if ref_reason:
+        return None, ref_reason
 
     checkpoint_ids = [str(value) for value in (raw_op.get("checkpoint_ids") or []) if value]
     if audit_result.get("checkpoint_id") and audit_result["checkpoint_id"] not in checkpoint_ids:
@@ -110,7 +213,7 @@ def validate_proposed_operation(
     source_locations = (
         raw_op.get("source_locations") or audit_result.get("source_locations") or []
     )
-    if not evidence_refs and not source_locations:
+    if not evidence_refs and not source_chunk_ids and not source_locations:
         return None, "missing_source_or_evidence"
 
     op = make_operation(
@@ -123,6 +226,7 @@ def validate_proposed_operation(
             if audit_result.get("findings") else raw_op.get("reason", ""),
         checkpoint_ids=checkpoint_ids,
         evidence_refs=evidence_refs,
+        source_chunk_ids=source_chunk_ids,
         source_locations=source_locations,
         confidence=float(raw_op.get("confidence") or audit_result.get("confidence") or 0.0),
         operation_id=raw_op.get("operation_id") or "",
@@ -152,6 +256,15 @@ def validate_proposed_operations(
         for checkpoint in (checkpoints or [])
         if isinstance(checkpoint, dict) and checkpoint.get("checkpoint_id")
     } | set(audit_by_checkpoint)
+    # Source-chunk id space (chunks.id), distinct from EvidenceRegistry ids. Built
+    # from every audit result's retrieved source + every checkpoint's source scope
+    # so legitimate chunk references survive validation (#412 P0-6).
+    known_chunk_ids: set[str] = set()
+    for audit in audit_by_checkpoint.values():
+        known_chunk_ids |= chunk_ids_for_audit_result(audit)
+    for checkpoint in (checkpoints or []):
+        if isinstance(checkpoint, dict):
+            known_chunk_ids |= _chunk_ids_from_locations(checkpoint.get("source_scope"))
     seen_targets: set[tuple[str, str, str]] = set()
     for raw in raw_ops or []:
         raw_checkpoint_ids = [
@@ -166,6 +279,7 @@ def validate_proposed_operations(
             inventory,
             audit,
             known_checkpoint_ids=known_checkpoint_ids,
+            known_chunk_ids=known_chunk_ids,
         )
         if op is not None:
             key = (op.get("operation") or "", op.get("target_type") or "", op.get("target_id") or "")
@@ -188,8 +302,12 @@ def _proposal_messages(audit_result: dict, inventory: dict) -> list[dict]:
         "revision operationを1つ提案してください。operationは次から選ぶ: "
         + ", ".join(OPERATIONS) +
         "。出力は次のJSONのみ: {\"operation\":..,\"target_type\":..,\"target_id\":..,"
-        "\"after_json\":..,\"reason\":..,\"evidence_refs\":[..]}。"
-        "原文根拠(evidence_refs)を必ず付け、推測だけで確定しないこと。"
+        "\"after_json\":..,\"reason\":..,"
+        "\"evidence_ids\":[EvidenceRegistryのevidence_id],"
+        "\"source_chunk_ids\":[原文chunkのchunks.id]}。"
+        "evidence_ids（登録済みevidence）とsource_chunk_ids（原文chunk）はID空間が異なるため"
+        "必ず分けて出力すること。chunk IDをevidence_idとして出さない。"
+        "原文根拠を必ず付け、推測だけで確定しないこと。"
     )
     payload = {"audit": {
         "verdict": audit_result.get("verdict"),
@@ -197,6 +315,7 @@ def _proposal_messages(audit_result: dict, inventory: dict) -> list[dict]:
         "target_type": audit_result.get("target_type"),
         "target_id": audit_result.get("target_id"),
         "evidence_refs": audit_result.get("evidence_refs"),
+        "source_chunk_ids": sorted(chunk_ids_for_audit_result(audit_result)),
         "source_locations": audit_result.get("source_locations"),
     }, "entity": entity}
     return [
@@ -247,6 +366,7 @@ def propose_operations(
             inventory,
             audit,
             known_checkpoint_ids={str(audit.get("checkpoint_id"))},
+            known_chunk_ids=chunk_ids_for_audit_result(audit),
         )
         if op is not None:
             operations.append(op)

--- a/backend/tests/api/test_revisions_api.py
+++ b/backend/tests/api/test_revisions_api.py
@@ -203,6 +203,17 @@ def test_accept_success(app_client, monkeypatch):
     assert resp.json()["accepted"] is True
 
 
+def test_accept_partial_flag_forwarded(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    captured = {}
+    monkeypatch.setattr(revisions.coordinator, "accept_revision",
+                        lambda **k: captured.update(k) or {"active_run_id": "rev-1"})
+    resp = client.post("/api/admin/documents/doc-1/revisions/rev-1/accept",
+                       json={"comment": "ok", "accept_partial": True})
+    assert resp.status_code == 200
+    assert captured["accept_partial"] is True
+
+
 def test_accept_hard_error_returns_422(app_client, monkeypatch):
     client, revisions, _dep, _app = app_client
     from core.document_pipeline.revision.coordinator import AcceptBlockedError

--- a/backend/tests/api/test_revisions_api.py
+++ b/backend/tests/api/test_revisions_api.py
@@ -68,30 +68,72 @@ def test_create_revision_no_base_returns_409(app_client, monkeypatch):
     assert resp.status_code == 409
 
 
-def test_run_rejects_invalid_raw_operations_with_422(app_client, monkeypatch):
+def _pending_run(monkeypatch, revisions):
+    """Make the target revision look freshly created (startable)."""
+    monkeypatch.setattr(revisions.persistence, "get_analysis_run",
+                        lambda *, run_id: {"id": run_id, "run_type": "revision",
+                                           "document_id": "doc-1", "status": "pending",
+                                           "revision_status": "preparing",
+                                           "base_run_id": "base-1", "current_stage": None,
+                                           "stage_outputs": {"_artifacts": {}}})
+
+
+def test_run_returns_202_and_launches_worker(app_client, monkeypatch):
     client, revisions, _dep, _app = app_client
-    monkeypatch.setattr(
-        revisions.coordinator,
-        "audit_revision_run",
-        lambda **kwargs: {"verdict_counts": {}, "revision_targets": []},
-    )
+    _pending_run(monkeypatch, revisions)
+    launched = {}
+    monkeypatch.setattr(revisions, "create_background_task", lambda *a, **k: None)
+    monkeypatch.setattr(revisions, "update_background_task", lambda *a, **k: None)
+    monkeypatch.setattr(revisions, "_launch_revision_worker",
+                        lambda **kwargs: launched.update(kwargs))
+    resp = client.post("/api/admin/documents/doc-1/revisions/rev-1/run", json={})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["revision_run_id"] == "rev-1"
+    assert body["revision_status"] == "running"
+    assert body["task_id"]
+    # the long-running work was handed to the worker, not done in the request
+    assert launched["revision_id"] == "rev-1"
+
+
+def test_run_rejects_duplicate_in_progress_with_409(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    # default fixture run has status "running" -> a second /run is a duplicate
+    monkeypatch.setattr(revisions, "create_background_task",
+                        lambda *a, **k: pytest.fail("must not start a duplicate run"))
+    resp = client.post("/api/admin/documents/doc-1/revisions/rev-1/run", json={})
+    assert resp.status_code == 409
+
+
+def test_run_worker_records_invalid_raw_operations(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    _pending_run(monkeypatch, revisions)
+    tasks: dict = {}
+
+    def _update(task_id, status, result_data=None, error_message=None):
+        tasks[task_id] = {"status": status, "result_data": result_data,
+                          "error_message": error_message}
+    monkeypatch.setattr(revisions, "create_background_task", lambda *a, **k: None)
+    monkeypatch.setattr(revisions, "update_background_task", _update)
 
     def _invalid(**kwargs):
         raise revisions.coordinator.ProposalValidationError([
-            {"raw": kwargs["operations"][0], "reason": "missing_source_or_evidence"},
+            {"raw": (kwargs.get("operations") or [{}])[0], "reason": "missing_source_or_evidence"},
         ])
+    monkeypatch.setattr(revisions.coordinator, "run_revision_pipeline", _invalid)
+    # run the worker synchronously so we can inspect the recorded outcome
+    monkeypatch.setattr(revisions, "_launch_revision_worker",
+                        lambda **kwargs: revisions._revision_run_worker(**kwargs))
 
-    monkeypatch.setattr(revisions.coordinator, "assemble_candidate", _invalid)
     resp = client.post(
         "/api/admin/documents/doc-1/revisions/rev-1/run",
-        json={"operations": [{
-            "operation": "update_entity",
-            "target_type": "claim",
-            "target_id": "clm_1",
-        }]},
+        json={"operations": [{"operation": "update_entity", "target_type": "claim",
+                              "target_id": "clm_1"}]},
     )
-    assert resp.status_code == 422
-    assert resp.json()["detail"]["rejected_operations"][0]["reason"] == "missing_source_or_evidence"
+    assert resp.status_code == 202
+    failed = [t for t in tasks.values() if t["status"] == "failed"]
+    assert failed and failed[0]["result_data"]["rejected_operations"][0]["reason"] == \
+        "missing_source_or_evidence"
 
 
 def test_accept_success(app_client, monkeypatch):

--- a/backend/tests/api/test_revisions_api.py
+++ b/backend/tests/api/test_revisions_api.py
@@ -68,19 +68,17 @@ def test_create_revision_no_base_returns_409(app_client, monkeypatch):
     assert resp.status_code == 409
 
 
-def _pending_run(monkeypatch, revisions):
-    """Make the target revision look freshly created (startable)."""
-    monkeypatch.setattr(revisions.persistence, "get_analysis_run",
-                        lambda *, run_id: {"id": run_id, "run_type": "revision",
-                                           "document_id": "doc-1", "status": "pending",
-                                           "revision_status": "preparing",
-                                           "base_run_id": "base-1", "current_stage": None,
-                                           "stage_outputs": {"_artifacts": {}}})
+def _claimable(monkeypatch, revisions, ok=True):
+    """Stub the atomic DB run-claim (#414-1) as winner (ok) or loser (409)."""
+    monkeypatch.setattr(revisions.persistence, "claim_revision_run",
+                        lambda *, run_id, **k: ok)
+    monkeypatch.setattr(revisions.persistence, "release_revision_run",
+                        lambda *, run_id, **k: None)
 
 
 def test_run_returns_202_and_launches_worker(app_client, monkeypatch):
     client, revisions, _dep, _app = app_client
-    _pending_run(monkeypatch, revisions)
+    _claimable(monkeypatch, revisions, ok=True)
     launched = {}
     monkeypatch.setattr(revisions, "create_background_task", lambda *a, **k: None)
     monkeypatch.setattr(revisions, "update_background_task", lambda *a, **k: None)
@@ -96,18 +94,38 @@ def test_run_returns_202_and_launches_worker(app_client, monkeypatch):
     assert launched["revision_id"] == "rev-1"
 
 
-def test_run_rejects_duplicate_in_progress_with_409(app_client, monkeypatch):
+def test_run_rejects_duplicate_via_failed_atomic_claim_with_409(app_client, monkeypatch):
     client, revisions, _dep, _app = app_client
-    # default fixture run has status "running" -> a second /run is a duplicate
+    # The atomic claim lost the race -> 409, and no worker is started.
+    _claimable(monkeypatch, revisions, ok=False)
     monkeypatch.setattr(revisions, "create_background_task",
                         lambda *a, **k: pytest.fail("must not start a duplicate run"))
+    monkeypatch.setattr(revisions, "_launch_revision_worker",
+                        lambda **kwargs: pytest.fail("must not launch worker on 409"))
     resp = client.post("/api/admin/documents/doc-1/revisions/rev-1/run", json={})
     assert resp.status_code == 409
 
 
+def test_run_releases_claim_when_worker_launch_fails(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    _claimable(monkeypatch, revisions, ok=True)
+    released = {}
+    monkeypatch.setattr(revisions.persistence, "release_revision_run",
+                        lambda *, run_id, **k: released.update({"run_id": run_id}))
+    monkeypatch.setattr(revisions, "create_background_task", lambda *a, **k: None)
+    monkeypatch.setattr(revisions, "update_background_task", lambda *a, **k: None)
+
+    def _boom(**kwargs):
+        raise RuntimeError("thread pool exhausted")
+    monkeypatch.setattr(revisions, "_launch_revision_worker", _boom)
+    resp = client.post("/api/admin/documents/doc-1/revisions/rev-1/run", json={})
+    assert resp.status_code == 500
+    assert released.get("run_id") == "rev-1"  # claim released -> retryable
+
+
 def test_run_worker_records_invalid_raw_operations(app_client, monkeypatch):
     client, revisions, _dep, _app = app_client
-    _pending_run(monkeypatch, revisions)
+    _claimable(monkeypatch, revisions, ok=True)
     tasks: dict = {}
 
     def _update(task_id, status, result_data=None, error_message=None):
@@ -134,6 +152,45 @@ def test_run_worker_records_invalid_raw_operations(app_client, monkeypatch):
     failed = [t for t in tasks.values() if t["status"] == "failed"]
     assert failed and failed[0]["result_data"]["rejected_operations"][0]["reason"] == \
         "missing_source_or_evidence"
+
+
+def test_run_status_attaches_only_owning_task(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    # A task id from a *different* revision must not be attached; fall back to the
+    # latest task that belongs to this revision (#414-2 / #414-4).
+    monkeypatch.setattr(revisions, "get_background_task",
+                        lambda task_id: {"task_id": task_id,
+                                         "result_data": {"revision_run_id": "OTHER"}})
+    monkeypatch.setattr(revisions, "get_latest_revision_task",
+                        lambda rev: {"task_id": "own-task", "status": "processing",
+                                     "stage": "audit",
+                                     "result_data": {"revision_run_id": rev}})
+    resp = client.get("/api/admin/documents/doc-1/revisions/rev-1/run-status?task_id=foreign")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["task"]["task_id"] == "own-task"
+    assert body["task"]["result_data"]["revision_run_id"] == "rev-1"
+
+
+def test_detail_returns_restore_fields(app_client, monkeypatch):
+    client, revisions, _dep, _app = app_client
+    monkeypatch.setattr(revisions.persistence, "get_analysis_run",
+                        lambda *, run_id: {"id": run_id, "run_type": "revision",
+                                           "document_id": "doc-1", "status": "failed",
+                                           "revision_status": "proposed",
+                                           "current_stage": "candidate_assembly",
+                                           "error_message": "ProposalValidationError: 3",
+                                           "base_run_id": "base-1",
+                                           "stage_outputs": {"_artifacts": {}}})
+    monkeypatch.setattr(revisions.persistence, "get_revision_decisions", lambda *, run_id: [])
+    monkeypatch.setattr(revisions, "get_latest_revision_task",
+                        lambda rev: {"task_id": "t1", "status": "failed", "stage": "candidate_assembly"})
+    resp = client.get("/api/admin/documents/doc-1/revisions/rev-1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["current_stage"] == "candidate_assembly"
+    assert body["error_message"].startswith("ProposalValidationError")
+    assert body["latest_task"]["status"] == "failed"
 
 
 def test_accept_success(app_client, monkeypatch):

--- a/backend/tests/test_revision_audit.py
+++ b/backend/tests/test_revision_audit.py
@@ -201,3 +201,27 @@ def test_audit_revision_run_rejects_non_revision(monkeypatch):
     )
     with pytest.raises(ValueError):
         coordinator.audit_revision_run(run_id="init-1")
+
+
+# --- #414-3: audit progress callback ---------------------------------------
+
+def test_run_source_audit_reports_monotonic_progress():
+    checkpoints = [_cp(checkpoint_id=f"ckpt_{i}", trigger_reason="non_atomic_claim")
+                   for i in range(5)]
+    seen = []
+    out = run_source_audit(
+        checkpoints=checkpoints, chunk_index=_chunk_index(),
+        progress_callback=lambda done, total: seen.append((done, total)),
+    )
+    assert seen == [(1, 5), (2, 5), (3, 5), (4, 5), (5, 5)]
+    # monotonic non-decreasing completed counts, final == total
+    assert [d for d, _ in seen] == sorted(d for d, _ in seen)
+    assert seen[-1] == (5, 5)
+    assert len(out["audit_results"]) == 5
+
+
+def test_run_source_audit_progress_empty_is_safe():
+    seen = []
+    run_source_audit(checkpoints=[], chunk_index=[],
+                     progress_callback=lambda done, total: seen.append((done, total)))
+    assert seen == []

--- a/backend/tests/test_revision_decisions.py
+++ b/backend/tests/test_revision_decisions.py
@@ -192,6 +192,74 @@ def test_coordinator_accept_confirmed_protected_proceeds(monkeypatch):
     assert out["accepted"] is True
 
 
+# --- #415: partial adoption gating -----------------------------------------
+
+def _partial_run(candidate_status, candidate=None):
+    return _run_with_report(
+        {"candidate_status": candidate_status, "hard_error_count": 0,
+         "protected_change_count": 0,
+         "operation_summary": {"applied_count": 48, "excluded_invalid_count": 1,
+                               "excluded_dependency_count": 0}},
+        candidate=candidate or {
+            "candidate_artifacts": {"component_graph": {"nodes": []}},
+            "candidate_status": candidate_status,
+            "operation_summary": {"applied_count": 48, "excluded_invalid_count": 1,
+                                  "excluded_dependency_count": 0},
+            "excluded_operations": [{"operation_id": "op-49", "status": "excluded_invalid",
+                                     "reason": "target not found", "target_type": "equation",
+                                     "target_id": "eq_missing"}],
+        })
+
+
+def test_coordinator_blocks_accept_when_candidate_blocked(monkeypatch):
+    monkeypatch.setattr(coordinator.persistence, "get_analysis_run",
+                        lambda *, run_id: _partial_run("blocked"))
+    with pytest.raises(AcceptBlockedError):
+        coordinator.accept_revision(document_id="doc-1", run_id="rev-1")
+
+
+def test_coordinator_blocks_partial_accept_without_explicit_flag(monkeypatch):
+    monkeypatch.setattr(coordinator.persistence, "get_analysis_run",
+                        lambda *, run_id: _partial_run("partially_adoptable"))
+    with pytest.raises(AcceptBlockedError):
+        coordinator.accept_revision(document_id="doc-1", run_id="rev-1", accept_partial=False)
+
+
+def test_coordinator_partial_accept_records_excluded_in_decision(monkeypatch):
+    monkeypatch.setattr(coordinator.persistence, "get_analysis_run",
+                        lambda *, run_id: _partial_run("partially_adoptable"))
+    captured = {}
+    monkeypatch.setattr(coordinator.persistence, "accept_revision",
+                        lambda **k: captured.update(k) or {"accepted": True})
+    out = coordinator.accept_revision(document_id="doc-1", run_id="rev-1", accept_partial=True)
+    assert out["accepted"] is True
+    meta = captured["decision_metadata"]
+    assert meta["partial"] is True
+    assert meta["candidate_status"] == "partially_adoptable"
+    assert meta["excluded_operations"][0]["operation_id"] == "op-49"
+
+
+def test_revise_carries_parent_exclusions_into_checkpoints(monkeypatch):
+    parent = {"id": "rev-1", "run_type": "revision", "document_id": "doc-1",
+              "stage_outputs": {"_artifacts": {"candidate": {"excluded_operations": [
+                  {"operation_id": "op-49", "status": "excluded_invalid",
+                   "reason": "target not found", "target_type": "equation",
+                   "target_id": "eq_missing"}]}}}}
+    monkeypatch.setattr(coordinator.persistence, "get_analysis_run", lambda *, run_id: parent)
+    monkeypatch.setattr(coordinator.persistence, "resolve_artifact_run",
+                        lambda *, document_id, material_id=None: {
+                            "id": "active-1", "document_id": document_id,
+                            "stage_outputs": {"_artifacts": {}}})
+    monkeypatch.setattr(coordinator.persistence, "load_revision_projection_overlay",
+                        lambda *, document_id: {"claims": [], "components": [], "review_events": []})
+    monkeypatch.setattr(coordinator.persistence, "create_revision_run", lambda **k: "child-1")
+    monkeypatch.setattr(coordinator.persistence, "update_revision_status", lambda **k: None)
+    out = coordinator.revise_revision_run(document_id="doc-1", parent_run_id="rev-1", comment="")
+    carried = [c for c in out["audit_checkpoints"] if c.get("trigger_reason") == "prior_exclusion"]
+    assert carried and carried[0]["prior_exclusion"]["operation_id"] == "op-49"
+    assert carried[0]["target_id"] == "eq_missing"
+
+
 # --- coordinator.revise ----------------------------------------------------
 
 def test_revise_creates_child_with_parent_and_active_base(monkeypatch):

--- a/backend/tests/test_revision_diff_report.py
+++ b/backend/tests/test_revision_diff_report.py
@@ -87,6 +87,9 @@ def _report_for(ops, base=None):
         protected_changes=result["protected_changes"],
         requires_confirmation=result["requires_confirmation"],
         id_mapping=result["id_mapping"],
+        operation_candidate_status=result["candidate_status"],
+        operation_summary=result["operation_summary"],
+        excluded_operations=result["excluded_operations"],
     ), result
 
 
@@ -157,6 +160,40 @@ def test_resolved_vs_introduced_findings_classified():
     # acceptable requires zero hard errors
     if report["quality_after"]["hard_error_count"] == 0:
         assert report["summary"]["acceptable"] is True
+
+
+# --- #415: partial adoption in the report ----------------------------------
+
+def test_report_partially_adoptable_lists_excluded_operations():
+    report, result = _report_for([
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_MISSING", after_json={"text": "x"},
+                       operation_id="op-bad"),
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_1", after_json={"text": "kept"},
+                       operation_id="op-good"),
+    ])
+    # operation-level verdict is partially_adoptable (independent of the gate)
+    assert result["candidate_status"] == "partially_adoptable"
+    assert report["operation_summary"]["applied_count"] == 1
+    assert report["operation_summary"]["excluded_invalid_count"] == 1
+    assert report["excluded_operations"][0]["operation_id"] == "op-bad"
+    # report-level status downgrades to blocked only if the gate still has hard
+    # errors after exclusion; otherwise it stays partially_adoptable + acceptable.
+    if report["summary"]["hard_error_count"] == 0:
+        assert report["candidate_status"] == "partially_adoptable"
+        assert report["summary"]["acceptable"] is True
+    else:
+        assert report["candidate_status"] == "blocked"
+
+
+def test_report_blocked_when_all_ops_excluded():
+    report, _ = _report_for([
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_MISSING", after_json={"text": "x"}),
+    ])
+    assert report["candidate_status"] == "blocked"
+    assert report["summary"]["acceptable"] is False
 
 
 def test_candidate_has_hard_errors_helper():

--- a/backend/tests/test_revision_llm_audit_proposal.py
+++ b/backend/tests/test_revision_llm_audit_proposal.py
@@ -192,6 +192,98 @@ def test_valid_chunk_refs_do_not_cause_mass_rejection():
     assert out["operations"][0]["source_chunk_ids"] == ["chunk-0"]
 
 
+# --- #414-5: fail-closed typed reference validation ------------------------
+
+def _update(target_type="claim", target_id="clm_1", **extra):
+    base = {"operation": "update_entity", "target_type": target_type,
+            "target_id": target_id, "after_json": {"text": "x"},
+            "checkpoint_ids": ["ckpt_1"]}
+    base.update(extra)
+    return base
+
+
+def test_existing_registry_evidence_id_accepted():
+    op, reason = validate_proposed_operation(
+        _update(evidence_ids=["ev_1"]), _inventory(),
+        {"checkpoint_id": "ckpt_1"}, known_chunk_ids=set())
+    assert op is not None and reason == ""
+    assert op["evidence_refs"] == ["ev_1"] and op["source_chunk_ids"] == []
+
+
+def test_existing_source_chunk_id_accepted_from_trusted_index():
+    op, reason = validate_proposed_operation(
+        _update(source_chunk_ids=["c1"]), _inventory(),
+        {"checkpoint_id": "ckpt_1"}, known_chunk_ids={"c1"})
+    assert op is not None and reason == ""
+    assert op["source_chunk_ids"] == ["c1"] and op["evidence_refs"] == []
+
+
+def test_evidence_id_in_source_chunk_field_is_rejected():
+    op, reason = validate_proposed_operation(
+        _update(source_chunk_ids=["ev_1"]), _inventory(),
+        {"checkpoint_id": "ckpt_1"}, known_chunk_ids={"c1"})
+    assert op is None
+    assert reason == "unknown_source_chunk:ev_1"
+
+
+def test_nonexistent_source_chunk_is_rejected():
+    op, reason = validate_proposed_operation(
+        _update(source_chunk_ids=["c_GONE"]), _inventory(),
+        {"checkpoint_id": "ckpt_1"}, known_chunk_ids={"c1"})
+    assert op is None
+    assert reason == "unknown_source_chunk:c_GONE"
+
+
+def test_source_chunk_not_accepted_when_chunk_index_unavailable():
+    # No trusted chunk index at all -> a source_chunk_id cannot be proven; reject
+    # rather than fail-open (#414-5).
+    op, reason = validate_proposed_operation(
+        _update(source_chunk_ids=["c1"]), _inventory(),
+        {"checkpoint_id": "ckpt_1"}, known_chunk_ids=set())
+    assert op is None
+    assert reason == "unknown_source_chunk:c1"
+
+
+def test_llm_source_chunk_ids_alone_are_not_self_certifying():
+    # audit_result carries LLM-claimed source_chunk_ids but NO retrieved
+    # source_locations -> the claim is not trusted, so it is rejected.
+    audit = {"checkpoint_id": "ckpt_1", "source_chunk_ids": ["c_hallucinated"]}
+    op, reason = validate_proposed_operation(
+        _update(), _inventory(), audit, known_chunk_ids=set())
+    assert op is None
+    assert reason == "unknown_source_chunk:c_hallucinated"
+
+
+def test_retrieved_source_locations_make_chunk_trusted():
+    # Same chunk id, but now backed by a real retrieval (source_locations).
+    audit = {"checkpoint_id": "ckpt_1", "source_chunk_ids": ["c1"],
+             "source_locations": [{"chunk_id": "c1"}]}
+    op, reason = validate_proposed_operation(
+        _update(), _inventory(), audit, known_chunk_ids=set())
+    assert op is not None and reason == ""
+    assert op["source_chunk_ids"] == ["c1"]
+
+
+# --- #414-3: proposal progress callback ------------------------------------
+
+def test_propose_operations_reports_progress_over_targets():
+    audit_results = [
+        {"checkpoint_id": f"c{i}", "target_type": "claim", "target_id": "clm_1",
+         "requires_revision": True, "source_locations": [{"chunk_id": "c1"}]}
+        for i in range(4)
+    ]
+    seen = []
+
+    def fake_generate(messages):
+        return json.dumps({"operation": "update_entity", "target_type": "claim",
+                           "target_id": "clm_1", "after_json": {"text": "x"},
+                           "source_chunk_ids": ["c1"]})
+    propose_operations(audit_results, _inventory(), generate=fake_generate,
+                       known_chunk_ids={"c1"},
+                       progress_callback=lambda done, total: seen.append((done, total)))
+    assert seen == [(1, 4), (2, 4), (3, 4), (4, 4)]
+
+
 def test_propose_operations_uses_generate_and_validates():
     audit_results = [{"checkpoint_id": "ckpt_1", "target_type": "claim", "target_id": "clm_1",
                       "verdict": "incorrect", "requires_revision": True,

--- a/backend/tests/test_revision_llm_audit_proposal.py
+++ b/backend/tests/test_revision_llm_audit_proposal.py
@@ -130,6 +130,68 @@ def test_validate_rejects_unknown_evidence_instead_of_dropping_it():
     assert reason == "unknown_evidence:ev_GONE"
 
 
+# --- #412 P0-6: source-chunk vs EvidenceRegistry ID spaces -----------------
+
+def test_chunk_reference_is_not_rejected_as_unknown_evidence():
+    # The LLM cited the retrieved chunk id in the (legacy mixed) evidence_refs.
+    # It must be routed to source_chunk_ids, NOT rejected as unknown evidence.
+    audit = {"checkpoint_id": "ckpt_1", "evidence_refs": ["c1"],
+             "source_locations": [{"chunk_id": "c1"}]}
+    op, reason = validate_proposed_operation(
+        {"operation": "update_entity", "target_type": "claim", "target_id": "clm_1",
+         "after_json": {"text": "fixed"}}, _inventory(), audit)
+    assert op is not None and reason == ""
+    assert op["source_chunk_ids"] == ["c1"]
+    assert op["evidence_refs"] == []
+
+
+def test_typed_evidence_and_chunk_fields_validated_against_their_own_space():
+    op, reason = validate_proposed_operation(
+        {"operation": "update_entity", "target_type": "claim", "target_id": "clm_1",
+         "after_json": {"text": "x"}, "evidence_ids": ["ev_1"],
+         "source_chunk_ids": ["c1"], "checkpoint_ids": ["ckpt_1"]},
+        _inventory(),
+        {"checkpoint_id": "ckpt_1", "source_locations": [{"chunk_id": "c1"}]})
+    assert op is not None and reason == ""
+    assert op["evidence_refs"] == ["ev_1"]
+    assert op["source_chunk_ids"] == ["c1"]
+
+
+def test_chunk_uuid_not_accepted_as_registry_evidence_id():
+    # A chunk id placed in the *evidence* field is unknown registry evidence.
+    op, reason = validate_proposed_operation(
+        {"operation": "update_entity", "target_type": "claim", "target_id": "clm_1",
+         "after_json": {"text": "x"}, "evidence_ids": ["c1"], "checkpoint_ids": ["ckpt_1"]},
+        _inventory(),
+        {"checkpoint_id": "ckpt_1", "source_locations": [{"chunk_id": "c1"}]})
+    assert op is None
+    assert reason == "unknown_evidence:c1"
+
+
+def test_valid_chunk_refs_do_not_cause_mass_rejection():
+    # Mirrors the real-data failure: 58/59 proposals were rejected only because
+    # valid chunk refs were validated against the EvidenceRegistry ID space.
+    audit_results = [
+        {"checkpoint_id": f"ckpt_{i}", "target_type": "claim", "target_id": "clm_1",
+         "evidence_refs": [f"chunk-{i}"], "source_locations": [{"chunk_id": f"chunk-{i}"}]}
+        for i in range(20)
+    ]
+    raw_ops = [
+        {"operation": "update_entity", "target_type": "claim", "target_id": "clm_1",
+         "after_json": {"text": f"fix {i}"}, "checkpoint_ids": [f"ckpt_{i}"]}
+        for i in range(20)
+    ]
+    out = validate_proposed_operations(
+        raw_ops, _inventory(), audit_results=audit_results,
+        checkpoints=[{"checkpoint_id": f"ckpt_{i}"} for i in range(20)],
+    )
+    # all but the duplicate-target collisions accepted; none rejected for evidence
+    rejected_reasons = {r["reason"] for r in out["rejected"]}
+    assert "unknown_evidence" not in " ".join(rejected_reasons)
+    assert out["operations"], "valid chunk-backed proposals must not be mass-rejected"
+    assert out["operations"][0]["source_chunk_ids"] == ["chunk-0"]
+
+
 def test_propose_operations_uses_generate_and_validates():
     audit_results = [{"checkpoint_id": "ckpt_1", "target_type": "claim", "target_id": "clm_1",
                       "verdict": "incorrect", "requires_revision": True,

--- a/backend/tests/test_revision_operations.py
+++ b/backend/tests/test_revision_operations.py
@@ -204,25 +204,28 @@ def test_add_and_remove_relation():
 
 # --- safety: invalid candidate ---------------------------------------------
 
-def test_new_unknown_reference_marks_candidate_invalid():
+def test_new_unknown_reference_excludes_op_and_blocks_when_alone():
+    # #415: the op that introduces an unknown reference is excluded. As the only
+    # op, the candidate has nothing adoptable -> blocked.
     base = _base_artifacts()
     res = apply_operations(base, [
         make_operation(operation="add_relation", target_type="claim", target_id="clm_2",
                        relation_target_type="evidence", relation_target_id="ev_DOESNOTEXIST"),
     ])
+    assert res["candidate_status"] == "blocked"
     assert res["invalid"] is True
-    assert any(e.get("error") == "new_unknown_references" for e in res["operation_errors"])
+    assert res["excluded_operations"][0]["status"] == "excluded_invalid"
 
 
-def test_failed_operation_marks_invalid_without_partial_active():
+def test_failed_operation_is_excluded_not_applied():
     base = _base_artifacts()
     res = apply_operations(base, [
         make_operation(operation="update_entity", target_type="claim",
                        target_id="clm_MISSING", after_json={"text": "x"}),
     ])
+    assert res["candidate_status"] == "blocked"
     assert res["invalid"] is True
-    failed = [o for o in res["applied_operations"] if o["validation_result"]["status"] == "failed"]
-    assert failed
+    assert res["excluded_operations"][0]["target_id"] == "clm_MISSING"
 
 
 def test_pre_existing_unresolved_ref_does_not_invalidate():
@@ -275,15 +278,103 @@ def test_preexisting_member_dangling_is_carried_not_new():
                for d in res["carried_unresolved_references"])
 
 
-def test_operation_introduced_member_dangling_is_still_new_error():
+def test_operation_introduced_member_dangling_is_excluded(_=None):
+    # #415: the offending op (edge → ghost_node) is excluded, not the whole
+    # candidate. With it the only op, nothing remains -> blocked.
     base = _base_artifacts()
     res = apply_operations(base, [
         make_operation(operation="add_relation", target_type="graph_edge",
                        after_json={"edge_id": "edge_new", "source": "cmp_1",
                                    "target": "ghost_node", "edge_type": "REQUIRES"}),
     ])
+    assert res["candidate_status"] == "blocked"
     assert res["invalid"] is True
-    assert any(e.get("error") == "new_unknown_references" for e in res["operation_errors"])
+    assert any(x["status"] == "excluded_invalid" for x in res["excluded_operations"])
+
+
+# --- #415: partial adoption -------------------------------------------------
+
+def test_full_adoption_when_all_ops_valid():
+    base = _base_artifacts()
+    res = apply_operations(base, [
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_1", after_json={"text": "A1"}),
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_2", after_json={"text": "C1"}),
+    ])
+    assert res["candidate_status"] == "adoptable"
+    assert res["operation_summary"]["applied_count"] == 2
+    assert res["excluded_operations"] == []
+
+
+def test_partial_adoption_keeps_independent_valid_ops():
+    base = _base_artifacts()
+    res = apply_operations(base, [
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_MISSING", after_json={"text": "x"},
+                       operation_id="op-bad"),
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_1", after_json={"text": "kept"},
+                       operation_id="op-good"),
+    ])
+    assert res["candidate_status"] == "partially_adoptable"
+    assert res["operation_summary"]["applied_count"] == 1
+    assert res["operation_summary"]["excluded_invalid_count"] == 1
+    # the independent valid change survived
+    claims = _claims(res)
+    assert claims["clm_1"]["text"] == "kept"
+    assert [x["operation_id"] for x in res["excluded_operations"]] == ["op-bad"]
+
+
+def test_dependency_excluded_when_producer_is_excluded():
+    base = _base_artifacts()
+    res = apply_operations(base, [
+        # A: invalid split (target missing) — would have produced clm_x
+        make_operation(operation="split_entity", target_type="claim",
+                       target_id="clm_GONE", operation_id="op-A",
+                       after_json=[{"claim_id": "clm_x", "text": "x", "is_atomic": True}]),
+        # B: depends on clm_x, which only exists if A succeeds
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_x", after_json={"text": "y"}, operation_id="op-B"),
+        # C: independent valid change
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_2", after_json={"text": "kept"}, operation_id="op-C"),
+    ])
+    assert res["candidate_status"] == "partially_adoptable"
+    by_id = {x["operation_id"]: x for x in res["excluded_operations"]}
+    assert by_id["op-A"]["status"] == "excluded_invalid"
+    assert by_id["op-B"]["status"] == "excluded_dependency"
+    assert res["operation_summary"]["applied_count"] == 1
+    assert _claims(res)["clm_2"]["text"] == "kept"
+
+
+def test_blocked_when_no_ops_survive_exclusion():
+    base = _base_artifacts()
+    res = apply_operations(base, [
+        make_operation(operation="update_entity", target_type="claim",
+                       target_id="clm_MISSING", after_json={"text": "x"}),
+    ])
+    assert res["candidate_status"] == "blocked"
+    assert res["invalid"] is True
+
+
+def test_pre_excluded_ops_propagate_dependency_exclusion():
+    base = _base_artifacts()
+    # op A pre-rejected upstream (e.g. typed-evidence validation #414); it would
+    # have added eq_new, so the relation op that consumes eq_new is a dependency.
+    res = apply_operations(
+        base,
+        [make_operation(operation="add_relation", target_type="claim",
+                        target_id="clm_2", relation_target_type="equation",
+                        relation_target_id="eq_new", operation_id="op-rel")],
+        pre_excluded=[{"op": {"operation": "add_entity", "target_type": "equation",
+                              "operation_id": "op-add",
+                              "after_json": {"equation_id": "eq_new", "label": "(9)"}},
+                       "reason": "unknown_evidence:ev_x"}],
+    )
+    statuses = {x["operation_id"]: x["status"] for x in res["excluded_operations"]}
+    assert statuses["op-add"] == "excluded_invalid"
+    assert statuses["op-rel"] == "excluded_dependency"
 
 
 # --- protected target ------------------------------------------------------
@@ -358,7 +449,10 @@ def test_assemble_candidate_persists_without_touching_projections(monkeypatch):
     assert arts["candidate"]["candidate_artifacts"]["claim_object_builder"]["claims"][0]["text"] == "patched"
 
 
-def test_assemble_candidate_rejects_invalid_operation_before_persist(monkeypatch):
+def test_assemble_candidate_excludes_invalid_operation_without_raising(monkeypatch):
+    # #415: an invalid operation no longer aborts the whole assembly. It is
+    # excluded and the candidate is persisted (blocked here, since it is the only
+    # op), so the report can show *why* it was excluded.
     inventory = build_baseline_inventory(_base_artifacts(), base_run_id="base-1")
     run = {"id": "rev-1", "run_type": "revision", "base_run_id": "base-1",
            "document_id": "doc-1",
@@ -373,19 +467,19 @@ def test_assemble_candidate_rejects_invalid_operation_before_persist(monkeypatch
         "get_analysis_run",
         lambda *, run_id: run if run_id == "rev-1" else base,
     )
-    monkeypatch.setattr(
-        coordinator.persistence,
-        "update_revision_status",
-        lambda **kwargs: pytest.fail("invalid operations must not create a candidate"),
-    )
+    captured = {}
+    monkeypatch.setattr(coordinator.persistence, "update_revision_status",
+                        lambda **k: captured.update(k))
 
-    with pytest.raises(coordinator.ProposalValidationError):
-        coordinator.assemble_candidate(run_id="rev-1", operations=[
-            make_operation(
-                operation="update_entity",
-                target_type="claim",
-                target_id="clm_1",
-                after_json={"text": "patched"},
-                checkpoint_ids=["ckpt_1"],
-            ),
-        ])
+    out = coordinator.assemble_candidate(run_id="rev-1", operations=[
+        make_operation(
+            operation="update_entity", target_type="claim", target_id="clm_1",
+            after_json={"text": "patched"}, checkpoint_ids=["ckpt_1"],
+            # no evidence/source -> pre-validation rejects -> excluded_invalid
+        ),
+    ])
+    assert out["candidate_status"] == "blocked"
+    cand = captured["stage_outputs"]["_artifacts"]["candidate"]
+    assert cand["candidate_status"] == "blocked"
+    assert cand["excluded_operations"][0]["status"] == "excluded_invalid"
+    assert cand["excluded_operations"][0]["reason"] == "missing_source_or_evidence"

--- a/backend/tests/test_revision_operations.py
+++ b/backend/tests/test_revision_operations.py
@@ -240,6 +240,52 @@ def test_pre_existing_unresolved_ref_does_not_invalidate():
     assert any(d["target_id"] == "eq_missing" for d in res["carried_unresolved_references"])
 
 
+# --- #412 P1-7: shared resolver for base vs candidate dangling --------------
+
+def test_graph_member_and_step_refs_resolve_via_shared_resolver():
+    base = _base_artifacts()
+    # Main node aggregates a detail node and references a derivation step. Under
+    # the old raw-field check these looked like dangling component/derivation refs.
+    base["component_graph"]["nodes"].append(
+        {"node_id": "main_1", "label": "Stage", "graph_layer": "main",
+         "member_component_ids": ["eq_op_1"], "linked_derivation_ids": ["step_1"]})
+    base["component_graph"]["nodes"].append(
+        {"node_id": "eq_op_1", "label": "detail", "graph_layer": "equation_detail"})
+    base["derivation_chain"]["chains"][0]["steps"][0]["step_id"] = "step_1"
+    # Remove an unrelated, unreferenced evidence record (the "equation deletion"
+    # style case): the pre-existing member/step refs must not become new danglers.
+    res = apply_operations(base, [
+        make_operation(operation="remove_entity", target_type="evidence", target_id="ev_2"),
+    ])
+    assert not any(e.get("error") == "new_unknown_references"
+                   for e in res["operation_errors"]), res["operation_errors"]
+    assert res["invalid"] is False
+
+
+def test_preexisting_member_dangling_is_carried_not_new():
+    base = _base_artifacts()
+    base["component_graph"]["nodes"].append(
+        {"node_id": "main_1", "graph_layer": "main",
+         "member_component_ids": ["ghost_node"]})
+    res = apply_operations(base, [
+        make_operation(operation="remove_entity", target_type="evidence", target_id="ev_2"),
+    ])
+    assert res["invalid"] is False, res["operation_errors"]
+    assert any(d["target_id"] == "ghost_node"
+               for d in res["carried_unresolved_references"])
+
+
+def test_operation_introduced_member_dangling_is_still_new_error():
+    base = _base_artifacts()
+    res = apply_operations(base, [
+        make_operation(operation="add_relation", target_type="graph_edge",
+                       after_json={"edge_id": "edge_new", "source": "cmp_1",
+                                   "target": "ghost_node", "edge_type": "REQUIRES"}),
+    ])
+    assert res["invalid"] is True
+    assert any(e.get("error") == "new_unknown_references" for e in res["operation_errors"])
+
+
 # --- protected target ------------------------------------------------------
 
 def test_protected_target_flagged_not_auto_adoptable():

--- a/backend/tests/test_revision_pg_integration.py
+++ b/backend/tests/test_revision_pg_integration.py
@@ -166,6 +166,110 @@ def test_stale_base_accept_conflicts(pg):
                                     candidate_artifacts={})
 
 
+def _seed_revision(pg, *, with_checkpoints=False):
+    persistence = pg["persistence"]
+    doc_id, base_id = _seed_document(pg, {"_artifacts": {}})
+    rev = persistence.create_revision_run(document_id=doc_id, base_run_id=base_id)
+    if with_checkpoints:
+        persistence.update_revision_status(
+            run_id=rev, revision_status="preparing",
+            stage_outputs={"_artifacts": {
+                "baseline_inventory": {"entities": {}, "unresolved_references": []},
+                "audit_checkpoints": [
+                    {"checkpoint_id": "ckpt_1", "target_type": "claim", "target_id": "clm_1",
+                     "trigger_reason": "non_atomic_claim", "source_scope": [], "status": "planned"},
+                    {"checkpoint_id": "ckpt_2", "target_type": "claim", "target_id": "clm_1",
+                     "trigger_reason": "low_confidence", "source_scope": [], "status": "planned"},
+                ],
+            }})
+    return doc_id, base_id, rev
+
+
+# --- #414-1: atomic run-claim exclusion (real concurrency) -----------------
+
+def test_concurrent_run_claim_is_exclusive(pg):
+    import concurrent.futures
+    persistence = pg["persistence"]
+    _doc, _base, rev = _seed_revision(pg)
+
+    workers = 8
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+        results = list(ex.map(lambda _i: persistence.claim_revision_run(run_id=rev),
+                              range(workers)))
+    # Exactly one POST wins the claim; the rest must get 409.
+    assert sum(1 for r in results if r) == 1
+    # A further claim while running fails too.
+    assert persistence.claim_revision_run(run_id=rev) is False
+    # Releasing (task/worker launch failure path) makes it re-claimable.
+    persistence.release_revision_run(run_id=rev, error_message="launch failed")
+    run = persistence.get_analysis_run(run_id=rev)
+    assert run["status"] == "failed"
+    assert persistence.claim_revision_run(run_id=rev) is True
+
+
+def test_different_revisions_claim_independently(pg):
+    persistence = pg["persistence"]
+    _d1, _b1, rev1 = _seed_revision(pg)
+    _d2, _b2, rev2 = _seed_revision(pg)
+    assert persistence.claim_revision_run(run_id=rev1) is True
+    assert persistence.claim_revision_run(run_id=rev2) is True  # independent runs
+
+
+# --- #414-3: status transitions persisted to real DB -----------------------
+
+def test_run_pipeline_persists_status_transitions(pg):
+    persistence = pg["persistence"]
+    from core.document_pipeline.revision import coordinator
+    _doc, _base, rev = _seed_revision(pg, with_checkpoints=True)
+    assert persistence.claim_revision_run(run_id=rev) is True  # endpoint claim
+    coordinator.run_revision_pipeline(run_id=rev)
+    run = persistence.get_analysis_run(run_id=rev)
+    assert run["status"] == "completed"
+    assert run["current_stage"] == "completed"
+    assert run["revision_status"] == "proposed"
+    assert run["started_at"] is not None
+    assert run["completed_at"] is not None
+
+
+# --- #414-2: revision task stage not overwritten by the initial run --------
+
+def test_revision_task_stage_not_overwritten_by_initial_run(pg, monkeypatch):
+    Session, text = pg["Session"], pg["text"]
+    try:
+        import api.services as services
+    except Exception:  # pragma: no cover
+        pytest.skip("api.services unavailable")
+    monkeypatch.setattr(services, "_pg_session", lambda: Session())
+
+    doc_id, base_id, rev = _seed_revision(pg)
+    task_id = "rt_" + uuid.uuid4().hex[:9]   # unique so reruns don't collide
+    s = Session()
+    try:
+        try:
+            s.execute(text("SELECT 1 FROM background_tasks LIMIT 1"))
+        except Exception:
+            pytest.skip("background_tasks table not present")
+        s.execute(text("UPDATE document_analysis_runs SET current_stage='document_pipeline' "
+                       "WHERE id=CAST(:r AS uuid)"), {"r": base_id})
+        s.execute(text("UPDATE document_analysis_runs SET current_stage='audit' "
+                       "WHERE id=CAST(:r AS uuid)"), {"r": rev})
+        s.execute(text("""INSERT INTO background_tasks (id, task_type, status, result_data)
+                          VALUES (:id, 'revision_pipeline', 'processing', CAST(:rd AS jsonb))"""),
+                  {"id": task_id, "rd": _json({
+                      "document_id": doc_id, "revision_run_id": rev,
+                      "stage": "audit", "total_count": 2, "completed_count": 1})})
+        s.commit()
+    finally:
+        s.close()
+
+    task = services.get_background_task(task_id)
+    # NOT overwritten by the initial run's 'document_pipeline' current_stage.
+    assert task["result_data"]["stage"] == "audit"
+    assert task["result_data"]["completed_count"] == 1
+    latest = services.get_latest_revision_task(rev)
+    assert latest and latest["task_id"] == task_id and latest["stage"] == "audit"
+
+
 def test_reject_leaves_active_unchanged(pg):
     persistence = pg["persistence"]
     text, Session = pg["text"], pg["Session"]

--- a/backend/tests/test_revision_pg_integration.py
+++ b/backend/tests/test_revision_pg_integration.py
@@ -270,6 +270,65 @@ def test_revision_task_stage_not_overwritten_by_initial_run(pg, monkeypatch):
     assert latest and latest["task_id"] == task_id and latest["stage"] == "audit"
 
 
+def test_partial_accept_rebuilds_projection_and_records_excluded(pg):
+    """#415: partial adoption — blocked without the flag, then single-transaction
+    accept of the reduced op set with the excluded operations in the audit trail."""
+    persistence = pg["persistence"]
+    text, Session = pg["text"], pg["Session"]
+    from core.document_pipeline.revision import coordinator
+
+    doc_id, base_id = _seed_document(pg, {"_artifacts": {}})
+    rev = persistence.create_revision_run(document_id=doc_id, base_run_id=base_id)
+    candidate_artifacts = _artifacts()["_artifacts"]
+    excluded = [{"operation_id": "op-49", "status": "excluded_invalid",
+                 "reason": "target not found", "target_type": "equation",
+                 "target_id": "eq_missing"}]
+    persistence.update_revision_status(run_id=rev, revision_status="proposed",
+        stage_outputs={"_artifacts": {
+            "candidate": {
+                "candidate_artifacts": candidate_artifacts,
+                "candidate_status": "partially_adoptable",
+                "operation_summary": {"applied_count": 1, "excluded_invalid_count": 1,
+                                      "excluded_dependency_count": 0},
+                "excluded_operations": excluded,
+            },
+            "revision_operations": [
+                {"operation_id": "op-1", "operation_status": "applied"},
+                {"operation_id": "op-49", "operation_status": "excluded_invalid"},
+            ],
+            "diff_report": {"summary": {
+                "candidate_status": "partially_adoptable", "acceptable": True,
+                "hard_error_count": 0, "protected_change_count": 0},
+                "operation_summary": {"applied_count": 1, "excluded_invalid_count": 1}},
+        }})
+
+    # Explicit partial confirmation is required.
+    with pytest.raises(coordinator.AcceptBlockedError):
+        coordinator.accept_revision(document_id=doc_id, run_id=rev)
+
+    out = coordinator.accept_revision(document_id=doc_id, run_id=rev, accept_partial=True)
+    assert out["accepted"] is True
+
+    s = Session()
+    try:
+        active = s.execute(text("SELECT active_analysis_run_id::text FROM documents "
+                                "WHERE id=CAST(:d AS uuid)"), {"d": doc_id}).fetchone()[0]
+        assert active == rev   # active switched only on success
+        claims = s.execute(text("SELECT count(*) FROM theory_claims WHERE document_id=:d"),
+                           {"d": doc_id}).fetchone()[0]
+        assert claims == 1     # projection rebuilt from the reduced candidate
+    finally:
+        s.close()
+
+    decisions = persistence.get_revision_decisions(run_id=rev)
+    accept = [d for d in decisions if (d.get("metadata") or {}).get("decision") == "accept"]
+    assert accept, "accept decision recorded"
+    meta = accept[0]["metadata"]
+    assert meta["partial"] is True
+    assert meta["candidate_status"] == "partially_adoptable"
+    assert meta["excluded_operations"][0]["operation_id"] == "op-49"
+
+
 def test_reject_leaves_active_unchanged(pg):
     persistence = pg["persistence"]
     text, Session = pg["text"], pg["Session"]

--- a/backend/tests/test_revision_pipeline_status.py
+++ b/backend/tests/test_revision_pipeline_status.py
@@ -58,14 +58,35 @@ def test_pipeline_status_transitions_through_each_stage(monkeypatch, caplog):
     assert ("running", "audit") in stages
     assert (None, "proposal") in stages
     assert (None, "candidate_assembly") in stages
+    # #414-3: validation is an explicit stage, not skipped from assembly to report
+    assert (None, "validation") in stages
     assert (None, "report") in stages
     assert ("completed", "completed") in stages
+    # canonical stage order preserved
+    seen_order = [cs for _, cs in stages if cs in coordinator.REVISION_STAGES]
+    assert seen_order == ["audit", "proposal", "candidate_assembly",
+                          "validation", "report", "completed"]
     assert out["revision_status"] == "proposed"
     # #412 P1-5: stage boundary logs are present and run-scoped
     assert "revision_started" in caplog.text
     assert "revision_audit_completed" in caplog.text
     assert "revision_completed" in caplog.text
     assert "run_id=rev-1" in caplog.text
+
+
+def test_pipeline_reports_stage_progress_counts(monkeypatch):
+    _patch_stages(monkeypatch)
+    # Sub-stage functions are patched out, so assert the pipeline itself forwards
+    # a (stage, done, total) callback at each stage boundary (#414-3).
+    progress = []
+    coordinator.run_revision_pipeline(
+        run_id="rev-1",
+        progress_callback=lambda stage, done, total: progress.append((stage, done, total)),
+    )
+    stages_seen = {p[0] for p in progress}
+    assert "audit" in stages_seen
+    assert "validation" in stages_seen
+    assert ("completed", 1, 1) in progress
 
 
 def test_pipeline_failure_marks_failed_with_stage_and_error(monkeypatch):

--- a/backend/tests/test_revision_pipeline_status.py
+++ b/backend/tests/test_revision_pipeline_status.py
@@ -1,0 +1,144 @@
+"""#412: revision run status transitions, structured logging, report sections."""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from core.document_pipeline.revision import coordinator  # noqa: E402
+from core.document_pipeline.revision.diff import (  # noqa: E402
+    build_stage_summary,
+    summarize_rejections,
+)
+
+
+def _run():
+    return {"id": "rev-1", "run_type": "revision", "document_id": "doc-1",
+            "stage_outputs": {"_artifacts": {
+                "audit_checkpoints": [{"checkpoint_id": "c1"}, {"checkpoint_id": "c2"}]}}}
+
+
+def _patch_stages(monkeypatch, *, audit=None, proposals=None, candidate=None, report=None):
+    monkeypatch.setattr(coordinator.persistence, "get_analysis_run", lambda *, run_id: _run())
+    updates: list[dict] = []
+    monkeypatch.setattr(coordinator.persistence, "update_revision_status",
+                        lambda **k: updates.append(k))
+    monkeypatch.setattr(coordinator, "audit_revision_run",
+                        lambda **k: audit or {"revision_targets": [{}], "review_items": [{}, {}],
+                                              "verdict_counts": {}})
+    monkeypatch.setattr(coordinator, "generate_proposals",
+                        lambda **k: proposals or {"operations": [{"operation": "update_entity"}],
+                                                  "rejected": [], "manual_review": []})
+    monkeypatch.setattr(coordinator, "assemble_candidate",
+                        lambda **k: candidate or {"invalid": False, "applied_operations": [{}],
+                                                  "operation_errors": []})
+    monkeypatch.setattr(coordinator, "revalidate_and_report",
+                        lambda **k: report or {"report": {
+                            "recommendation": "accept",
+                            "summary": {"outcome": "changes_proposed",
+                                        "entity_change_count": 1, "candidate_invalid": False},
+                            "stage_summary": {}}})
+    return updates
+
+
+# --- #412 P1-3: status transitions -----------------------------------------
+
+def test_pipeline_status_transitions_through_each_stage(monkeypatch, caplog):
+    updates = _patch_stages(monkeypatch)
+    caplog.set_level(logging.INFO)
+    out = coordinator.run_revision_pipeline(run_id="rev-1")
+    stages = [(u.get("status"), u.get("current_stage")) for u in updates]
+    assert ("running", "audit") in stages
+    assert (None, "proposal") in stages
+    assert (None, "candidate_assembly") in stages
+    assert (None, "report") in stages
+    assert ("completed", "completed") in stages
+    assert out["revision_status"] == "proposed"
+    # #412 P1-5: stage boundary logs are present and run-scoped
+    assert "revision_started" in caplog.text
+    assert "revision_audit_completed" in caplog.text
+    assert "revision_completed" in caplog.text
+    assert "run_id=rev-1" in caplog.text
+
+
+def test_pipeline_failure_marks_failed_with_stage_and_error(monkeypatch):
+    updates = _patch_stages(monkeypatch)
+
+    def _boom(**k):
+        raise RuntimeError("downstream blew up")
+    monkeypatch.setattr(coordinator, "audit_revision_run", _boom)
+
+    with pytest.raises(RuntimeError):
+        coordinator.run_revision_pipeline(run_id="rev-1")
+    failed = [u for u in updates if u.get("status") == "failed"]
+    assert failed
+    assert failed[0]["current_stage"] == "audit"
+    assert "downstream blew up" in failed[0]["error_message"]
+
+
+def test_pipeline_proposal_validation_failure_marks_candidate_assembly(monkeypatch):
+    updates = _patch_stages(monkeypatch)
+
+    def _invalid(**k):
+        raise coordinator.ProposalValidationError([{"raw": {}, "reason": "missing_checkpoint"}])
+    monkeypatch.setattr(coordinator, "assemble_candidate", _invalid)
+
+    with pytest.raises(coordinator.ProposalValidationError):
+        coordinator.run_revision_pipeline(run_id="rev-1", operations=[{"operation": "update_entity"}])
+    failed = [u for u in updates if u.get("status") == "failed"]
+    assert failed and failed[0]["current_stage"] == "candidate_assembly"
+
+
+def test_safe_error_is_bounded_and_single_line():
+    msg = coordinator._safe_error("X", RuntimeError("a" * 500 + "\nsecret line"))
+    assert msg.startswith("X: ")
+    assert "\n" not in msg
+    assert len(msg) <= 210
+
+
+# --- #412 P1-8: report stage sections --------------------------------------
+
+def test_stage_summary_distinguishes_no_targets_from_failed_proposals():
+    no_targets = build_stage_summary(
+        audit_summary={"revision_target_count": 0, "checkpoints_total": 199,
+                       "manual_review_count": 0},
+        proposal_summary={}, candidate_invalid=False,
+        new_unknown_reference_count=0, applied_change_count=0,
+    )
+    assert no_targets["outcome"] == "no_audit_targets"
+
+    # 59 targets, 58 rejected, 0 adopted -> "proposals failed", not "nothing to do"
+    failed = build_stage_summary(
+        audit_summary={"revision_target_count": 59, "checkpoints_total": 199,
+                       "manual_review_count": 138},
+        proposal_summary={"accepted_count": 0, "rejected_count": 58},
+        candidate_invalid=False, new_unknown_reference_count=0, applied_change_count=0,
+    )
+    assert failed["outcome"] == "proposals_failed"
+    assert failed["audit"]["manual_review_count"] == 138
+    assert failed["candidate_generation"]["rejected_count"] == 58
+
+    invalid = build_stage_summary(
+        audit_summary={"revision_target_count": 59},
+        proposal_summary={"accepted_count": 1, "rejected_count": 58},
+        candidate_invalid=True, new_unknown_reference_count=2, applied_change_count=1,
+    )
+    assert invalid["outcome"] == "candidate_invalid"
+    assert invalid["candidate_evaluation"]["new_unknown_reference_count"] == 2
+
+
+def test_summarize_rejections_groups_by_leading_code():
+    out = summarize_rejections([
+        {"reason": "unknown_evidence:a"},
+        {"reason": "unknown_evidence:b"},
+        {"reason": "missing_checkpoint"},
+    ])
+    assert out[0] == {"reason": "unknown_evidence", "count": 2}
+    assert {"reason": "missing_checkpoint", "count": 1} in out

--- a/backend/tests/test_revision_projection_rebuild.py
+++ b/backend/tests/test_revision_projection_rebuild.py
@@ -139,6 +139,57 @@ def test_revision_graph_rejects_unknown_component_endpoint():
         )
 
 
+def test_revision_graph_preserves_graph_native_operation_nodes():
+    graph = persistence._remap_revision_graph(
+        {
+            "nodes": [
+                {
+                    "component_id": "theory_op_0001",
+                    "component_type": "TheoryOperationNode",
+                    "graph_layer": "main",
+                    "representative_component_id": "cmp_1",
+                },
+                {
+                    "component_id": "eq_op_0001",
+                    "component_type": "EquationOperationNode",
+                    "graph_layer": "equation_detail",
+                },
+                {"component_id": "cmp_1", "label": "Stored component"},
+            ],
+            "edges": [
+                {"source": "theory_op_0001", "target": "eq_op_0001"},
+                {"source": "eq_op_0001", "target": "cmp_1"},
+            ],
+        },
+        {"cmp_1": "db-comp-1"},
+        {},
+    )
+    by_agent = {
+        n.get("agent_component_id") or n.get("component_id"): n
+        for n in graph["nodes"]
+    }
+    assert by_agent["theory_op_0001"]["component_id"] == "theory_op_0001"
+    assert by_agent["eq_op_0001"]["component_id"] == "eq_op_0001"
+    assert by_agent["cmp_1"]["component_id"] == "db-comp-1"
+    assert graph["edges"][0]["source"] == "theory_op_0001"
+    assert graph["edges"][0]["target"] == "eq_op_0001"
+    assert graph["edges"][1]["target"] == "db-comp-1"
+
+
+def test_revision_graph_still_rejects_unresolved_ordinary_component_node():
+    with pytest.raises(ValueError, match="unknown component id"):
+        persistence._remap_revision_graph(
+            {
+                "nodes": [
+                    {"component_id": "cmp_missing", "label": "Missing component"},
+                ],
+                "edges": [],
+            },
+            {},
+            {},
+        )
+
+
 # --- full accept transaction ----------------------------------------------
 
 def _candidate():

--- a/backend/tests/test_revision_ui.py
+++ b/backend/tests/test_revision_ui.py
@@ -109,3 +109,27 @@ def test_stop_polling_prevents_duplicate_timers(admin_js):
     assert "stopPolling" in admin_js
     # close() and openDetail() both stop polling before (re)rendering
     assert "function stopPolling()" in admin_js
+
+
+# --- #415: partial adoption UI --------------------------------------------
+
+def test_partial_adoption_rendered(admin_js):
+    assert "excludedOpsHtml" in admin_js
+    assert "candidate_status" in admin_js
+    assert "operation_summary" in admin_js
+    assert "excluded_operations" in admin_js
+    # the three candidate states are surfaced
+    assert "partially_adoptable" in admin_js
+    assert "blocked" in admin_js
+
+
+def test_partial_accept_button_and_flag(admin_js):
+    # a distinct, explicit partial-accept action + accept_partial flag (#415)
+    assert "問題のある変更を除外して採用" in admin_js
+    assert "accept_partial" in admin_js
+
+
+def test_excluded_operations_show_reason(admin_js):
+    assert "除外される変更" in admin_js
+    assert "excluded_invalid" in admin_js
+    assert "excluded_dependency" in admin_js

--- a/backend/tests/test_revision_ui.py
+++ b/backend/tests/test_revision_ui.py
@@ -73,3 +73,39 @@ def test_styles_added():
     css = STYLES.read_text(encoding="utf-8")
     assert ".eg-rev-overlay" in css
     assert ".eg-rev-badge-protected" in css
+
+
+# --- #414: async polling / reload-restore / progress wiring ----------------
+
+def test_async_run_uses_poll_loop_not_inline_report(admin_js):
+    # /run is fire-and-poll: a 202 launches polling, not an inline report fetch.
+    assert "pollRunStatus" in admin_js
+    assert "run-status" in admin_js
+    assert "202" not in admin_js or "pollRunStatus" in admin_js
+
+
+def test_run_status_409_surfaced_and_failure_vs_timeout_distinguished(admin_js):
+    # duplicate run rejected (409), and timeout is NOT shown as a failure (#414-1/-4).
+    assert "既に実行中" in admin_js
+    assert "接続が切れたため状態を確認中" in admin_js  # timeout/network -> keep checking
+    assert "renderRunFailure" in admin_js              # server failure -> explicit fail
+
+
+def test_reload_restores_running_failed_completed(admin_js):
+    assert "restoreRunState" in admin_js
+    assert "latest_task" in admin_js
+    # running -> resume polling the same task; failed -> show stage + error
+    assert "pollRunStatus()" in admin_js
+    assert "renderRunFailure(" in admin_js
+
+
+def test_progress_shows_completed_over_total(admin_js):
+    # recommended "27 / 199" style count, from the worker's completed/total (#414-3).
+    assert "completed_count" in admin_js
+    assert "total_count" in admin_js
+
+
+def test_stop_polling_prevents_duplicate_timers(admin_js):
+    assert "stopPolling" in admin_js
+    # close() and openDetail() both stop polling before (re)rendering
+    assert "function stopPolling()" in admin_js

--- a/backend/tests/test_revision_ui.py
+++ b/backend/tests/test_revision_ui.py
@@ -46,7 +46,17 @@ def test_decision_actions_present(admin_js):
 
 def test_accept_handles_conflict_and_block(admin_js):
     assert "409" in admin_js  # optimistic-concurrency conflict surfaced
-    assert "422" in admin_js  # hard-error / protected block surfaced
+    # Every non-2xx response, including hard-error/protected blocks (422) and
+    # projection validation failures (400/500), goes through one error path.
+    assert "decisionResponse" in admin_js
+
+
+def test_decision_actions_reject_all_non_success_responses(admin_js):
+    assert "function decisionResponse(r, fallback)" in admin_js
+    assert "if (r.ok) return r.json()" in admin_js
+    assert 'decisionResponse(r, "採用できません")' in admin_js
+    assert 'decisionResponse(r, "却下に失敗しました。")' in admin_js
+    assert 'decisionResponse(r, "再修正の作成に失敗しました。")' in admin_js
 
 
 def test_protected_change_warning_and_confirm(admin_js):

--- a/frontend/public/css/styles.css
+++ b/frontend/public/css/styles.css
@@ -4237,6 +4237,13 @@ body {
 .eg-rev-comment { flex: 1 1 200px; padding: 5px 8px; border: 1px solid rgba(0,0,0,0.2); border-radius: 5px; }
 .eg-rev-ops-text { width: 100%; min-height: 70px; font-family: monospace; font-size: 12px; margin-top: 6px; }
 .eg-rev-warn { background: #fdecea; color: #b71c1c; padding: 8px 10px; border-radius: 6px; margin: 8px 0; font-size: 13px; }
+.eg-rev-info { background: #e8f0fe; color: #174ea6; padding: 8px 10px; border-radius: 6px; margin: 8px 0; font-size: 13px; }
+.eg-rev-done { background: #e6f4ea; color: #1e7e34; padding: 8px 10px; border-radius: 6px; margin: 8px 0; font-size: 13px; font-weight: 600; }
+.eg-rev-progress { margin: 6px 0; }
+.eg-rev-stages { border: 1px solid rgba(0,0,0,0.12); border-radius: 6px; padding: 8px 12px; margin: 8px 0; background: #fafafa; }
+.eg-rev-stages h5 { margin: 8px 0 2px; }
+.eg-rev-stagelist { margin: 0 0 4px; padding-left: 18px; font-size: 13px; }
+.eg-rev-outcome { font-size: 13px; font-weight: 600; margin: 2px 0 6px; }
 .eg-rev-rec { font-size: 13px; margin: 6px 0; }
 .eg-rev-filter { display: flex; gap: 6px; margin: 8px 0; }
 .eg-rev-filter-btn { padding: 3px 10px; border: 1px solid rgba(0,0,0,0.2); border-radius: 14px; background: #fff; cursor: pointer; font-size: 12px; }

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -9179,13 +9179,21 @@
                               accept_partial: acceptPartial });
     }
 
+    function decisionResponse(r, fallback) {
+      if (r.ok) return r.json();
+      return r.json()
+        .catch(function () { return {}; })
+        .then(function (j) {
+          throw new Error(j.detail || fallback || ("server " + r.status));
+        });
+    }
+
     function acceptRevision() {
       apiFetch(docPath() + "/" + encodeURIComponent(current.revisionId) + "/accept",
                { method: "POST", body: decisionBody() })
         .then(function (r) {
           if (r.status === 409) throw new Error("競合: 採用版が更新されています。最新の差分で再確認してください。");
-          if (r.status === 422) return r.json().then(function (j) { throw new Error(j.detail || "採用できません"); });
-          return r.json();
+          return decisionResponse(r, "採用できません");
         })
         .then(function () { alert("採用しました。採用版を切り替えました。"); loadList(); openDetail(current.revisionId); })
         .catch(function (e) { alert(e.message || "採用に失敗しました。"); });
@@ -9194,17 +9202,17 @@
     function rejectRevision() {
       apiFetch(docPath() + "/" + encodeURIComponent(current.revisionId) + "/reject",
                { method: "POST", body: decisionBody() })
-        .then(function (r) { return r.json(); })
+        .then(function (r) { return decisionResponse(r, "却下に失敗しました。"); })
         .then(function () { alert("却下しました。採用版は変更されません。"); loadList(); openDetail(current.revisionId); })
-        .catch(function () { alert("却下に失敗しました。"); });
+        .catch(function (e) { alert(e.message || "却下に失敗しました。"); });
     }
 
     function reviseRevision() {
       apiFetch(docPath() + "/" + encodeURIComponent(current.revisionId) + "/revise",
                { method: "POST", body: decisionBody() })
-        .then(function (r) { return r.json(); })
+        .then(function (r) { return decisionResponse(r, "再修正の作成に失敗しました。"); })
         .then(function (data) { loadList(); if (data.revision_run_id) openDetail(data.revision_run_id); })
-        .catch(function () { alert("再修正の作成に失敗しました。"); });
+        .catch(function (e) { alert(e.message || "再修正の作成に失敗しました。"); });
     }
 
     return { open: open };

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -8848,14 +8848,30 @@
         .then(function (detail) {
           renderDetail(detail);
           if (detail.has_report) loadReport();
-          // Resume polling after a reload while a worker is still running (#412 P1-4).
-          if (String(detail.status || "").toLowerCase() === "running") {
-            current.taskId = null;
-            setRunning(true, STAGE_LABELS[detail.current_stage] || "処理中…");
-            pollRunStatus();
-          }
+          restoreRunState(detail);   // #414-4: restore running/failed/completed on reload
         })
         .catch(function () { alert("詳細の取得に失敗しました。"); });
+    }
+
+    // Restore the run's UI state after a modal reopen / browser reload (#414-4):
+    // running -> resume polling the same task; failed -> show stage + error;
+    // completed -> the report (loaded above) already shows the outcome.
+    function restoreRunState(detail) {
+      var status = String(detail.status || "").toLowerCase();
+      var task = detail.latest_task || null;
+      current.taskId = (task && task.task_id) || null;
+      if (status === "running") {
+        setRunning(true, STAGE_LABELS[detail.current_stage] || "処理中…");
+        renderRunProgress({ current_stage: detail.current_stage, task: task });
+        pollRunStatus();
+      } else if (status === "failed") {
+        setRunning(false);
+        renderRunFailure({
+          current_stage: detail.current_stage,
+          error_message: detail.error_message,
+          task: task
+        });
+      }
     }
 
     function decisionsHtml(decisions) {
@@ -8912,8 +8928,15 @@
       var rd = (st.task && st.task.result_data) || {};
       var stageKey = rd.stage || st.current_stage || "queued";
       var label = STAGE_LABELS[stageKey] || stageKey;
-      var prog = (typeof rd.progress === "number" && rd.progress > 0) ? (" " + rd.progress + "%") : "";
-      setProgress('<div class="eg-rev-info">' + escHtml(label) + escHtml(prog) + ' …</div>');
+      // Prefer the real "completed / total" count (e.g. 27 / 199) over a bare %
+      // when the worker has published per-checkpoint progress (#414-3).
+      var detail = "";
+      if (typeof rd.total_count === "number" && rd.total_count > 0) {
+        detail = " " + (rd.completed_count || 0) + " / " + rd.total_count;
+      } else if (typeof rd.progress === "number" && rd.progress > 0) {
+        detail = " " + rd.progress + "%";
+      }
+      setProgress('<div class="eg-rev-info">' + escHtml(label) + escHtml(detail) + ' …</div>');
     }
 
     function renderRunFailure(st) {

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -9095,18 +9095,63 @@
         '</div>';
     }
 
+    var EXCLUDE_LABELS = {
+      excluded_invalid: "不正な操作", excluded_dependency: "依存により除外",
+      requires_confirmation: "要承認"
+    };
+
+    // #415: per-operation outcome — adoptable / partially_adoptable / blocked.
+    function excludedOpsHtml(report) {
+      var status = report.candidate_status || (report.summary || {}).candidate_status || "adoptable";
+      var os = report.operation_summary || {};
+      var excluded = report.excluded_operations || [];
+      if (status === "adoptable" && !excluded.length) {
+        return '<div class="eg-rev-outcome">すべての変更を採用できます（' +
+          (os.applied_count || 0) + ' 件）。</div>';
+      }
+      var head;
+      if (status === "partially_adoptable") {
+        head = '<div class="eg-rev-outcome">問題のある変更を除外すれば採用できます。</div>';
+      } else if (status === "blocked") {
+        head = '<div class="eg-rev-warn">除外後も hard error または未解決参照が残るため採用できません（blocked）。</div>';
+      } else {
+        head = "";
+      }
+      var counts = '<ul class="eg-rev-stagelist">' +
+        '<li>採用可能な変更: ' + (os.applied_count || 0) + '</li>' +
+        '<li>除外（不正）: ' + (os.excluded_invalid_count || 0) + '</li>' +
+        '<li>除外（依存）: ' + (os.excluded_dependency_count || 0) + '</li>' +
+        '<li>除外後の hard error: ' + ((report.summary || {}).hard_error_count || 0) + '</li></ul>';
+      var rows = excluded.map(function (x) {
+        return '<li class="eg-rev-change"><span class="eg-rev-ctype">' +
+          escHtml(EXCLUDE_LABELS[x.status] || x.status) + '</span> ' +
+          '<code>' + escHtml(x.target_type || "") + ':' + escHtml(x.target_id || "") + '</code>' +
+          (x.operation_id ? ' <span class="eg-rev-trace">(' + escHtml(x.operation_id) + ')</span>' : '') +
+          '<div class="eg-rev-reason">理由: ' + escHtml(x.reason || "") + '</div></li>';
+      }).join("");
+      return '<div class="eg-rev-stages">' + head + counts +
+        (rows ? '<h5>除外される変更</h5><ul class="eg-rev-changes">' + rows + '</ul>' : '') + '</div>';
+    }
+
     function renderReport() {
       var rep = el("eg-rev-report"); if (!rep || !current.report) return;
       var report = current.report;
       var s = report.summary || {};
+      var status = report.candidate_status || s.candidate_status || (s.acceptable ? "adoptable" : "blocked");
+      var partial = status === "partially_adoptable";
       var acc = el("eg-rev-accept");
-      if (acc) acc.disabled = !s.acceptable;
+      if (acc) {
+        acc.disabled = !s.acceptable;
+        // #415: partial adoption needs an explicit, differently-labelled action.
+        acc.textContent = partial ? "問題のある変更を除外して採用" : "採用";
+      }
       var warn = "";
-      if (!s.acceptable) warn = '<div class="eg-rev-warn">hard error または invalid のため採用できません。</div>';
+      if (status === "blocked") warn = '<div class="eg-rev-warn">候補は blocked です。具体的な hard error と除外対象を確認してください。</div>';
       else if (s.protected_change_count > 0) warn = '<div class="eg-rev-warn">教師承認/手動編集済み項目への変更が ' + s.protected_change_count + ' 件あります。採用には明示承認が必要です。</div>';
       var html = warn +
         '<div class="eg-rev-rec">推奨: <strong>' + escHtml(report.recommendation) + '</strong>' +
           '（参考情報。自動採用には使われません）</div>' +
+        excludedOpsHtml(report) +
         stageSummaryHtml(report) +
         '<h5>品質指標 (before / after)</h5>' + metricsTable(report.quality_before, report.quality_after) +
         '<h5>解消: ' + (s.resolved_issue_count || 0) + ' / 新規: ' + (s.introduced_issue_count || 0) +
@@ -9125,7 +9170,13 @@
     function decisionBody() {
       var comment = (el("eg-rev-comment") && el("eg-rev-comment").value) || "";
       var confirm = !!(el("eg-rev-confirm-protected") && el("eg-rev-confirm-protected").checked);
-      return JSON.stringify({ comment: comment, confirm_protected: confirm });
+      // Adopt the reduced operation set only when the candidate is partial; the
+      // differently-labelled button is the user's explicit partial-accept action.
+      var s = (current.report && current.report.summary) || {};
+      var status = (current.report && current.report.candidate_status) || s.candidate_status || "";
+      var acceptPartial = status === "partially_adoptable";
+      return JSON.stringify({ comment: comment, confirm_protected: confirm,
+                              accept_partial: acceptPartial });
     }
 
     function acceptRevision() {

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -8740,8 +8740,22 @@
   var EGRevisions = (function () {
     var current = { documentId: null, revisionId: null, report: null, filter: "all" };
 
+    var STAGE_LABELS = {
+      queued: "待機中", audit: "原論文を監査中", proposal: "修正候補を生成中",
+      candidate_assembly: "候補を組み立て中", validation: "候補を検証中",
+      report: "差分レポートを作成中", completed: "完了 — 採否を確認してください",
+      failed: "失敗"
+    };
+    var OUTCOME_LABELS = {
+      no_audit_targets: "監査の結果、修正対象は見つかりませんでした。",
+      proposals_failed: "修正対象はありましたが、採用可能な修正候補を生成できませんでした（改善案の生成に失敗）。",
+      candidate_invalid: "修正候補を生成しましたが、検証に通らず採用できません。",
+      changes_proposed: "修正候補を生成しました。採否を確認してください。"
+    };
+
     function el(id) { return document.getElementById(id); }
-    function close() { var m = el("eg-rev-modal"); if (m) m.remove(); }
+    function stopPolling() { if (current.pollTimer) { clearTimeout(current.pollTimer); current.pollTimer = null; } }
+    function close() { stopPolling(); var m = el("eg-rev-modal"); if (m) m.remove(); }
     function docPath() { return "/admin/documents/" + encodeURIComponent(current.documentId) + "/revisions"; }
 
     function open(documentId) {
@@ -8826,11 +8840,21 @@
     }
 
     function openDetail(revId) {
+      stopPolling();
       current.revisionId = revId;
       current.report = null;
       apiFetch(docPath() + "/" + encodeURIComponent(revId))
         .then(function (r) { return r.json(); })
-        .then(function (detail) { renderDetail(detail); if (detail.has_report) loadReport(); })
+        .then(function (detail) {
+          renderDetail(detail);
+          if (detail.has_report) loadReport();
+          // Resume polling after a reload while a worker is still running (#412 P1-4).
+          if (String(detail.status || "").toLowerCase() === "running") {
+            current.taskId = null;
+            setRunning(true, STAGE_LABELS[detail.current_stage] || "処理中…");
+            pollRunStatus();
+          }
+        })
         .catch(function () { alert("詳細の取得に失敗しました。"); });
     }
 
@@ -8862,6 +8886,7 @@
         '<label class="eg-rev-confirm"><input type="checkbox" id="eg-rev-confirm-protected"> 保護項目の変更を明示承認</label>' +
         '<input id="eg-rev-comment" class="eg-rev-comment" placeholder="決定コメント">' +
         '</div>';
+      html += '<div class="eg-rev-progress" id="eg-rev-progress"></div>';
       html += '<div class="eg-rev-report" id="eg-rev-report"></div>';
       html += decisionsHtml(detail.decisions);
       d.innerHTML = html;
@@ -8871,19 +8896,98 @@
       el("eg-rev-revise").addEventListener("click", reviseRevision);
     }
 
+    function setProgress(html) { var p = el("eg-rev-progress"); if (p) p.innerHTML = html || ""; }
+
+    function setRunning(on, label) {
+      current.running = !!on;
+      var btn = el("eg-rev-run");
+      if (btn) { btn.disabled = !!on; btn.textContent = on ? (label || "処理中…") : "監査＋候補生成"; }
+      // Prevent accept/revise while a worker is active (#412 P1-4: avoid double run).
+      ["eg-rev-accept", "eg-rev-reject", "eg-rev-revise"].forEach(function (id) {
+        var b = el(id); if (b && on) b.disabled = true;
+      });
+    }
+
+    function renderRunProgress(st) {
+      var rd = (st.task && st.task.result_data) || {};
+      var stageKey = rd.stage || st.current_stage || "queued";
+      var label = STAGE_LABELS[stageKey] || stageKey;
+      var prog = (typeof rd.progress === "number" && rd.progress > 0) ? (" " + rd.progress + "%") : "";
+      setProgress('<div class="eg-rev-info">' + escHtml(label) + escHtml(prog) + ' …</div>');
+    }
+
+    function renderRunFailure(st) {
+      var stage = STAGE_LABELS[st.current_stage] || st.current_stage || "";
+      var msg = st.error_message || "サーバーエラー";
+      var rd = (st.task && st.task.result_data) || {};
+      var extra = "";
+      if (rd.rejected_operations && rd.rejected_operations.length) {
+        extra = '<div>修正候補が検証で却下されました（' + rd.rejected_operations.length + ' 件）。</div>';
+      }
+      setProgress('<div class="eg-rev-warn">処理に失敗しました（' + escHtml(stage) + '）: ' +
+        escHtml(msg) + extra + '</div>');
+    }
+
+    function pollRunStatus() {
+      if (!current.revisionId) return;
+      var url = docPath() + "/" + encodeURIComponent(current.revisionId) + "/run-status" +
+        (current.taskId ? ("?task_id=" + encodeURIComponent(current.taskId)) : "");
+      apiFetch(url)
+        .then(function (r) { if (!r.ok) throw new Error("status " + r.status); return r.json(); })
+        .then(function (st) {
+          current.pollFails = 0;
+          var status = String(st.status || "").toLowerCase();
+          if (status === "completed") {
+            setRunning(false);
+            setProgress('<div class="eg-rev-done">' + escHtml(STAGE_LABELS.completed) + '</div>');
+            openDetail(current.revisionId);   // reload detail + report
+            return;
+          }
+          if (status === "failed") {
+            setRunning(false);
+            renderRunFailure(st);
+            return;
+          }
+          renderRunProgress(st);
+          current.pollTimer = setTimeout(pollRunStatus, 3000);
+        })
+        .catch(function () {
+          // Network/timeout is NOT a processing failure — keep checking (#412 P1-4).
+          current.pollFails = (current.pollFails || 0) + 1;
+          setProgress('<div class="eg-rev-info">接続が切れたため状態を確認中…（再試行 ' +
+            current.pollFails + '）</div>');
+          current.pollTimer = setTimeout(pollRunStatus, 5000);
+        });
+    }
+
     function runRevision() {
-      var btn = el("eg-rev-run"); if (btn) { btn.disabled = true; btn.textContent = "処理中…"; }
       var body = {};
       var opsEl = el("eg-rev-ops");
       if (opsEl && opsEl.value.trim()) {
         try { body.operations = JSON.parse(opsEl.value); }
-        catch (e) { alert("operations の JSON が不正です。"); if (btn) { btn.disabled = false; btn.textContent = "監査＋候補生成"; } return; }
+        catch (e) { alert("operations の JSON が不正です。"); return; }
       }
+      stopPolling();
+      current.taskId = null;
+      setRunning(true, STAGE_LABELS.audit + " …");
+      setProgress('<div class="eg-rev-info">' + escHtml(STAGE_LABELS.queued) + ' …</div>');
       apiFetch(docPath() + "/" + encodeURIComponent(current.revisionId) + "/run",
                { method: "POST", body: JSON.stringify(body) })
-        .then(function (r) { return r.json(); })
-        .then(function () { openDetail(current.revisionId); })
-        .catch(function () { alert("処理に失敗しました。"); if (btn) { btn.disabled = false; btn.textContent = "監査＋候補生成"; } });
+        .then(function (r) {
+          if (r.status === 409) { setRunning(false); setProgress('<div class="eg-rev-warn">この改善runは既に実行中です。</div>'); return null; }
+          if (!r.ok) { return r.text().then(function (t) { throw new Error("server " + r.status + ": " + t); }); }
+          return r.json();
+        })
+        .then(function (data) {
+          if (!data) return;
+          current.taskId = data.task_id || null;
+          pollRunStatus();   // 202 accepted → poll task/revision status
+        })
+        .catch(function (e) {
+          // Could not even start the run → a real failure, not a timeout.
+          setRunning(false);
+          setProgress('<div class="eg-rev-warn">開始に失敗しました: ' + escHtml(String(e.message || e)) + '</div>');
+        });
     }
 
     function loadReport() {
@@ -8938,9 +9042,34 @@
           (c.reason ? '<div class="eg-rev-reason">理由: ' + escHtml(c.reason) + '</div>' : '') +
           (c.checkpoint_ids && c.checkpoint_ids.length ? '<div class="eg-rev-trace">checkpoint: ' + escHtml(c.checkpoint_ids.join(", ")) + '</div>' : '') +
           (c.evidence_refs && c.evidence_refs.length ? '<div class="eg-rev-trace">evidence: ' + escHtml(c.evidence_refs.join(", ")) + '</div>' : '') +
+          (c.source_chunk_ids && c.source_chunk_ids.length ? '<div class="eg-rev-trace">source chunk: ' + escHtml(c.source_chunk_ids.join(", ")) + '</div>' : '') +
           (src ? '<div class="eg-rev-trace">原文: ' + src + '</div>' : '') +
           '</li>';
       }).join("") + '</ul>';
+    }
+
+    function stageSummaryHtml(report) {
+      var ss = report.stage_summary; if (!ss) return "";
+      var a = ss.audit || {}, g = ss.candidate_generation || {}, e = ss.candidate_evaluation || {};
+      var outcomeMsg = OUTCOME_LABELS[ss.outcome] || "";
+      var reasons = (g.rejection_reasons || []).map(function (r) {
+        return '<li>' + escHtml(r.reason) + ': ' + (r.count || 0) + '</li>';
+      }).join("");
+      return '<div class="eg-rev-stages">' +
+        (outcomeMsg ? '<div class="eg-rev-outcome">' + escHtml(outcomeMsg) + '</div>' : '') +
+        '<h5>監査結果</h5><ul class="eg-rev-stagelist">' +
+          '<li>チェック: ' + (a.checkpoints_total || 0) + '</li>' +
+          '<li>修正対象: ' + (a.revision_target_count || 0) + '</li>' +
+          '<li>人手確認: ' + (a.manual_review_count || 0) + '</li></ul>' +
+        '<h5>候補生成</h5><ul class="eg-rev-stagelist">' +
+          '<li>採用可能な提案: ' + (g.accepted_count || 0) + '</li>' +
+          '<li>拒否された提案: ' + (g.rejected_count || 0) + '</li>' +
+          (reasons ? '<li>主な拒否理由:<ul>' + reasons + '</ul></li>' : '') + '</ul>' +
+        '<h5>候補評価</h5><ul class="eg-rev-stagelist">' +
+          '<li>適用変更: ' + (e.applied_change_count || 0) + '</li>' +
+          '<li>candidate invalid: <strong>' + (e.candidate_invalid ? "true" : "false") + '</strong></li>' +
+          '<li>新規未解決参照: ' + (e.new_unknown_reference_count || 0) + '</li></ul>' +
+        '</div>';
     }
 
     function renderReport() {
@@ -8955,6 +9084,7 @@
       var html = warn +
         '<div class="eg-rev-rec">推奨: <strong>' + escHtml(report.recommendation) + '</strong>' +
           '（参考情報。自動採用には使われません）</div>' +
+        stageSummaryHtml(report) +
         '<h5>品質指標 (before / after)</h5>' + metricsTable(report.quality_before, report.quality_after) +
         '<h5>解消: ' + (s.resolved_issue_count || 0) + ' / 新規: ' + (s.introduced_issue_count || 0) +
           ' / 変更: ' + (s.entity_change_count || 0) + '</h5>' +


### PR DESCRIPTION
## Summary

Refactors the revision pipeline to run asynchronously in a background worker, eliminating blocking HTTP requests and enabling structured progress tracking. The `/run` endpoint now returns 202 immediately with a task ID, while the actual audit→proposal→assembly→validation→report pipeline executes off-thread. Adds stage-aware status transitions, structured logging, and enhanced report sections to distinguish "no improvements found" from "improvements proposed but not adoptable."

## Key Changes

### Backend: Async Pipeline Execution
- **`coordinator.py`**: New `run_revision_pipeline()` function orchestrates the full pipeline end-to-end with stage transitions (STAGE_AUDIT → STAGE_PROPOSAL → STAGE_CANDIDATE_ASSEMBLY → STAGE_REPORT → STAGE_COMPLETED). Drives generic run state (`status` / `current_stage` / `completed_at`) and emits structured stage logs (#412 P1-3, P1-5).
- **`coordinator.py`**: Added `_safe_error()` helper to produce bounded, structural error summaries for persistence/logs (never includes provider response bodies, full source text, or secrets).
- **`revisions.py`**: New `_revision_run_worker()` background worker function that runs the pipeline and records results/failures on a background task. `_launch_revision_worker()` spawns the worker thread.
- **`revisions.py`**: `/run` endpoint now returns 202 + task ID immediately, rejecting duplicate in-progress runs with 409. Long-running work no longer blocks the request.

### Backend: Reference Space Separation (#412 P0-6)
- **`proposal.py`**: New `_resolve_evidence_refs()` function separates EvidenceRegistry IDs from source chunk IDs (distinct ID spaces). Chunk references are routed to `source_chunk_ids` and never rejected as unknown registry evidence.
- **`proposal.py`**: Added `chunk_ids_for_audit_result()` to extract valid chunk IDs from audit results' `source_locations` / `source_chunk_ids`.
- **`proposal.py`**: `validate_proposed_operation()` now accepts `known_chunk_ids` parameter and validates references against both spaces separately.
- **`operations.py`**: `make_operation()` now includes `source_chunk_ids` field (separate from `evidence_refs`).
- **`audit.py`**: Empty audit result template now includes `source_chunk_ids` field with comment clarifying the distinct ID space.

### Backend: Report Enhancements (#412 P1-8)
- **`diff.py`**: New `summarize_rejections()` function aggregates rejected-proposal reasons by code.
- **`diff.py`**: New `build_stage_summary()` function creates three-stage rollup (audit / candidate generation / candidate evaluation) distinguishing "no improvement found" from "improvements proposed but not adoptable."
- **`coordinator.py`**: `revalidate_and_report()` now computes `audit_summary`, `proposal_summary`, and `new_unknown_reference_count` and passes them to `build_diff_report()`.

### Backend: Inventory & Graph Resolution (#412 P1-7)
- **`inventory.py`**: Derivation chain indexing now tracks `step_ids` alongside equation IDs, allowing refs to point at either.
- **`inventory.py`**: Graph node indexing now includes `member_component_ids` (references to aggregated detail nodes), enabling shared resolver for base vs candidate dangling checks.
- **`operations.py`**: Refactored dangling reference detection to use a shared resolver that validates both pre-existing and new references against the same schema-defined ID spaces.

### Backend: Persistence & Status
- **`persistence.py`**: `update_revision_status()` now accepts `current_stage` parameter to track pipeline progress.
- **`services.py`**: Background task service integration for tracking async work.

### Frontend: Async Progress UI
- **`admin.js`**: New `STAGE_LABELS` and `OUTCOME_LABELS` maps for localized stage/outcome display.
- **`admin.js`**: New `pollRunStatus()` function polls `/run-status` endpoint every

https://claude.ai/code/session_0146ZdEDPwbBjkmjTcxo5sed