### PR TITLE
Fix split-recommendation schema canonicalization & equation completeness

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -594,6 +594,7 @@ def _build_document_completeness_reports(
             structure,
             document_id=doc_id,
             evidence_artifact=artifacts.get("evidence_registry"),
+            equations_artifact=artifacts.get("equation_semantics"),
         ))
     return out
 

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -1161,12 +1161,17 @@ def build_document_completeness(
     *,
     document_id: str,
     evidence_artifact: Any = None,
+    equations_artifact: Any = None,
 ) -> dict:
-    """Deterministic document-completeness report (issue #366).
+    """Deterministic document-completeness report (issue #366 / #420).
 
     Thin wrapper over ``core.document_pipeline.completeness`` so the export route
     and the pipeline gate share one implementation. Imported lazily so importing
     this module never hard-depends on the (sometimes stubbed) ``core`` package.
+
+    ``equations_artifact`` (equation_semantics) is passed through so equation
+    artifact coverage reflects the real EquationRecords (#420); without it a TeX
+    document with math would be reported as permanently incomplete.
     """
     analyze_document_completeness = _load_completeness_analyzer()
 
@@ -1174,6 +1179,7 @@ def build_document_completeness(
         _coerce_dict(structure_artifact),
         _coerce_dict(evidence_artifact) if evidence_artifact is not None else None,
         document_id=document_id,
+        equations=_coerce_dict(equations_artifact) if equations_artifact is not None else None,
     )
 
 

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -1483,13 +1483,21 @@ def _classify_operation_family(operation_text: str) -> dict:
 def _graph_node_is_component(node: dict, known_component_ids: set[str]) -> bool:
     if not isinstance(node, dict):
         return False
-    layer = str(node.get("graph_layer") or "main")
     comp_type = str(node.get("component_type") or "")
     node_id = str(node.get("component_id") or node.get("node_id") or node.get("id") or "")
-    if known_component_ids and node_id in known_component_ids:
-        return True
+    # Operation-level nodes (EquationOperationNode) are never components.
     if comp_type in _OPERATION_NODE_TYPES:
         return False
+    # Issue #418: when the real component-id registry is supplied, membership is
+    # mandatory — a node is a component_graph node ONLY if its id is an actual
+    # component. This stops aggregate theory nodes (graph_layer=main but not a
+    # real component) from being misclassified as components and leaking into
+    # component_graph.json with a non-component id.
+    if known_component_ids:
+        return node_id in known_component_ids
+    # No registry available (legacy / standalone graph): fall back to the layer
+    # heuristic so the split still works without the components artifact.
+    layer = str(node.get("graph_layer") or "main")
     return layer in _COMPONENT_GRAPH_LAYERS
 
 

--- a/backend/core/document_pipeline/completeness.py
+++ b/backend/core/document_pipeline/completeness.py
@@ -72,6 +72,14 @@ _MATH_ENV_BASE = {
 _TEX_BEGIN_RE = re.compile(r"\\begin\s*\{([A-Za-z*]+)\}")
 _TEX_END_RE = re.compile(r"\\end\s*\{([A-Za-z*]+)\}")
 
+# A symbolic TeX equation label: ``\label{eq:foo}`` / ``\label{some_label}``.
+# TeX equations are labelled symbolically (not by a numeric (N.k) sequence), so
+# label coverage must be reported separately from numeric continuity (#416).
+_TEX_LABEL_RE = re.compile(r"\\label\s*\{([^}]+)\}")
+# Unnumbered display math delimiters: ``\[ ... \]`` and ``$$ ... $$``.
+_TEX_BRACKET_DISPLAY_RE = re.compile(r"\\\[")
+_TEX_DOLLAR_DISPLAY_RE = re.compile(r"(?<!\\)\$\$")
+
 # A parsed equation label token: "(3.36)" / "3.36" / "(12)".
 _EQ_LABEL_RE = re.compile(r"^\(?\s*(?:(\d+)\.)?(\d+)\s*\)?$")
 
@@ -173,12 +181,138 @@ def detect_unclosed_math_environments(tex_source: Any) -> list[str]:
     return sorted(unmatched)
 
 
+def tex_equation_inventory(tex_source: Any) -> dict:
+    """Inventory TeX math environments and symbolic labels (#416).
+
+    Returns ``{"display_math_blocks": int, "labels": [str], "label_count": int}``.
+    ``display_math_blocks`` counts numbered/unnumbered display environments and
+    ``\\[ \\]`` / ``$$`` delimiters; ``labels`` are the symbolic ``\\label{...}``
+    targets that occur inside math environments (TeX labels are symbolic, not the
+    numeric ``(N.k)`` scheme handled by the label-continuity check).
+    """
+    text = str(tex_source or "")
+    if not text:
+        return {"display_math_blocks": 0, "labels": [], "label_count": 0}
+    text = re.sub(r"(?m)(?<!\\)%.*$", "", text)
+
+    # Collect math-environment spans so labels can be attributed to math.
+    begins = [(m.start(), m.end(), m.group(1)) for m in _TEX_BEGIN_RE.finditer(text)]
+    ends = {m.group(1): [] for m in _TEX_END_RE.finditer(text)}
+    for m in _TEX_END_RE.finditer(text):
+        ends.setdefault(m.group(1), []).append(m.start())
+
+    display_math_blocks = 0
+    math_spans: list[tuple[int, int]] = []
+    used_end: dict[str, set[int]] = {}
+    for start, body_start, env in begins:
+        if not _is_math_env(env):
+            continue
+        display_math_blocks += 1
+        end_starts = ends.get(env) or []
+        chosen = None
+        for e in sorted(end_starts):
+            if e > body_start and e not in used_end.get(env, set()):
+                chosen = e
+                break
+        if chosen is not None:
+            used_end.setdefault(env, set()).add(chosen)
+            math_spans.append((body_start, chosen))
+    display_math_blocks += len(_TEX_BRACKET_DISPLAY_RE.findall(text))
+    # ``$$`` delimiters come in pairs; each pair is one display block.
+    display_math_blocks += len(_TEX_DOLLAR_DISPLAY_RE.findall(text)) // 2
+
+    labels: list[str] = []
+    for m in _TEX_LABEL_RE.finditer(text):
+        pos = m.start()
+        in_math = any(s <= pos <= e for s, e in math_spans)
+        label = m.group(1).strip()
+        # Heuristic: a label is an equation label if it sits inside a math
+        # environment or uses a conventional ``eq``-style prefix.
+        if in_math or re.match(r"(?i)^(eq|eqn|equation)[:.]", label):
+            labels.append(label)
+    labels = sorted(dict.fromkeys(labels))
+    return {
+        "display_math_blocks": display_math_blocks,
+        "labels": labels,
+        "label_count": len(labels),
+    }
+
+
+def _equation_artifact_counts(equations: Any) -> dict:
+    """Count candidates / records and accepted-candidate resolution (#416)."""
+    eq = equations if isinstance(equations, dict) else {}
+    records = [r for r in (eq.get("equations") or eq.get("records") or []) if isinstance(r, dict)]
+    candidates = [c for c in (eq.get("equation_candidates") or []) if isinstance(c, dict)]
+    record_ids = {str(r.get("equation_id") or r.get("id") or "") for r in records}
+    accepted_like = [
+        c for c in candidates
+        if str(c.get("acceptance_status") or "") in ("accepted", "provisional")
+    ]
+    resolved = sum(
+        1 for c in accepted_like
+        if str(c.get("accepted_equation_id") or "") in record_ids
+        and str(c.get("accepted_equation_id") or "")
+    )
+    return {
+        "candidate_count": len(candidates),
+        "accepted_candidate_count": len(accepted_like),
+        "resolved_candidate_count": resolved,
+        "record_count": len(records),
+    }
+
+
+def analyze_equation_artifact_coverage(
+    structure: Any,
+    equations: Any,
+    *,
+    tex_source: Any = None,
+    pages_total: Any = None,
+) -> dict:
+    """Compare TeX math blocks / labels / candidates / records (#416).
+
+    Produces a coverage report (counts + symbolic labels) and a list of
+    ``review_reasons`` for artifact-level equation gaps that page-based ingest
+    reachability cannot see — in particular TeX inputs where ``pages=0`` would
+    otherwise let a missing equation registry pass silently.
+    """
+    structure = structure if isinstance(structure, dict) else {}
+    tex = tex_equation_inventory(tex_source)
+    counts = _equation_artifact_counts(equations)
+
+    review_reasons: list[str] = []
+    # A large silent shrink from accepted/provisional candidates to final records.
+    accepted = counts["accepted_candidate_count"]
+    resolved = counts["resolved_candidate_count"]
+    if accepted and resolved < accepted:
+        review_reasons.append("accepted_candidate_not_in_registry")
+
+    # pages=0 (or unknown) TeX documents: page reachability is meaningless, so a
+    # TeX file with display math but no final equation records is the #416 silent
+    # pass. Use artifact coverage as the completeness signal instead.
+    no_pages = not (isinstance(pages_total, int) and pages_total > 0)
+    if no_pages and tex["display_math_blocks"] > 0 and counts["record_count"] == 0:
+        review_reasons.append("tex_display_math_without_equation_records")
+
+    return {
+        "tex_display_math_blocks": tex["display_math_blocks"],
+        "tex_equation_labels": tex["labels"],
+        "tex_equation_label_count": tex["label_count"],
+        "equation_candidate_count": counts["candidate_count"],
+        "accepted_candidate_count": counts["accepted_candidate_count"],
+        "resolved_candidate_count": counts["resolved_candidate_count"],
+        "equation_record_count": counts["record_count"],
+        "review_reasons": review_reasons,
+        "complete": not review_reasons,
+    }
+
+
 def analyze_document_completeness(
     structure: Any,
     evidence: Any = None,
     *,
     document_id: str,
     tex_source: Any = None,
+    equations: Any = None,
 ) -> dict:
     """Return a JSON-serialisable document-completeness report (issues #366 / #371 / #373).
 
@@ -423,6 +557,14 @@ def analyze_document_completeness(
         and tail_confidence >= _TAIL_TRUNCATION_CONFIDENCE_THRESHOLD
     )
 
+    # --- equation artifact coverage (issue #416) ----------------------------
+    # TeX math-block / label / candidate / record coverage. This is the
+    # completeness signal that page reachability cannot provide for TeX inputs
+    # where ``pages=0`` and the parser reports EOF.
+    equation_coverage = analyze_equation_artifact_coverage(
+        structure, equations, tex_source=tex_source, pages_total=pages_total
+    )
+
     review_reasons: list[str] = []
     if equation_has_gaps:
         review_reasons.append("equation_label_discontinuity")
@@ -432,6 +574,8 @@ def analyze_document_completeness(
         review_reasons.append("ingest_incomplete")
     if tail_truncation_suspected:
         review_reasons.append("tail_truncation_suspected")
+    if not equation_coverage.get("complete", True):
+        review_reasons.append("equation_artifact_coverage_incomplete")
 
     return {
         "document_id": document_id,
@@ -474,4 +618,5 @@ def analyze_document_completeness(
             "distribution_ratio": evidence_distribution_ratio,
             "sparse": evidence_sparse,
         },
+        "equation_artifact_coverage": equation_coverage,
     }

--- a/backend/core/document_pipeline/completeness.py
+++ b/backend/core/document_pipeline/completeness.py
@@ -261,22 +261,49 @@ def _equation_artifact_counts(equations: Any) -> dict:
     }
 
 
+def _coerce_tex_inventory(inventory: Any) -> dict:
+    """Normalize a precomputed TeX inventory dict to the canonical shape (#420)."""
+    inv = inventory if isinstance(inventory, dict) else {}
+    labels = [str(v) for v in (inv.get("labels") or []) if str(v)]
+    blocks = inv.get("display_math_blocks")
+    try:
+        blocks = int(blocks)
+    except (TypeError, ValueError):
+        blocks = 0
+    count = inv.get("label_count")
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        count = len(labels)
+    return {"display_math_blocks": blocks, "labels": labels, "label_count": count}
+
+
 def analyze_equation_artifact_coverage(
     structure: Any,
     equations: Any,
     *,
     tex_source: Any = None,
     pages_total: Any = None,
+    tex_inventory: Any = None,
 ) -> dict:
-    """Compare TeX math blocks / labels / candidates / records (#416).
+    """Compare TeX math blocks / labels / candidates / records (#416 / #420).
 
     Produces a coverage report (counts + symbolic labels) and a list of
     ``review_reasons`` for artifact-level equation gaps that page-based ingest
     reachability cannot see — in particular TeX inputs where ``pages=0`` would
     otherwise let a missing equation registry pass silently.
+
+    The TeX inventory is taken from ``tex_source`` when given; otherwise the
+    precomputed ``tex_inventory`` (persisted on the metadata at ingest, #420) is
+    used so coverage works even when the raw source is not re-stored.
     """
     structure = structure if isinstance(structure, dict) else {}
-    tex = tex_equation_inventory(tex_source)
+    if tex_source:
+        tex = tex_equation_inventory(tex_source)
+    elif tex_inventory is not None:
+        tex = _coerce_tex_inventory(tex_inventory)
+    else:
+        tex = tex_equation_inventory(None)
     counts = _equation_artifact_counts(equations)
 
     review_reasons: list[str] = []
@@ -341,6 +368,11 @@ def analyze_document_completeness(
         tex_source = metadata.get("tex_source") or metadata.get("source_tex")
     if tex_source is None:
         tex_source = structure.get("tex_source") or structure.get("source_tex")
+    # Precomputed TeX equation inventory persisted at ingest (#420): used when the
+    # raw source is not carried on the structure (the normal TeX-archive case).
+    tex_inventory = (
+        metadata.get("tex_equation_inventory") if isinstance(metadata, dict) else None
+    )
     parser_pages_processed = None
     parser_reached_eof = None
     if isinstance(metadata, dict):
@@ -562,7 +594,11 @@ def analyze_document_completeness(
     # completeness signal that page reachability cannot provide for TeX inputs
     # where ``pages=0`` and the parser reports EOF.
     equation_coverage = analyze_equation_artifact_coverage(
-        structure, equations, tex_source=tex_source, pages_total=pages_total
+        structure,
+        equations,
+        tex_source=tex_source,
+        pages_total=pages_total,
+        tex_inventory=tex_inventory,
     )
 
     review_reasons: list[str] = []

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -38,6 +38,10 @@ class ValidationEntry:
     artifact: str
     path: str | None = None
     source_stage: str | None = None
+    # Issue #418: the concrete entity a finding is about, stored directly so the
+    # revision inventory can resolve it without parsing the JSON ``path``.
+    target_type: str | None = None
+    target_id: str | None = None
 
 
 @dataclass
@@ -648,7 +652,10 @@ class ExportValidationGate:
         document_id = str(structure.get("document_id") or "")
 
         # Prefer the report the orchestrator already computed at the stage exit;
-        # only recompute if it is absent (e.g. legacy / partial runs).
+        # only recompute if it is absent (e.g. legacy / partial runs). The
+        # orchestrator runs before equation_semantics, so equation-artifact
+        # coverage (#416) is computed/refreshed here where all artifacts exist.
+        equations = artifacts.get("equation_semantics")
         report = artifacts.get("document_completeness")
         if not isinstance(report, dict) or not report:
             analyze_document_completeness = _load_completeness_analyzer()
@@ -658,6 +665,11 @@ class ExportValidationGate:
                 structure,
                 evidence if isinstance(evidence, dict) else None,
                 document_id=document_id,
+                equations=equations if isinstance(equations, dict) else None,
+            )
+        else:
+            report = self._refresh_equation_artifact_coverage(
+                report, structure, equations, document_id=document_id
             )
 
         result = _empty_document_completeness()
@@ -718,7 +730,72 @@ class ExportValidationGate:
                 path="$.completeness.tail_truncation",
                 source_stage="export_validation",
             ))
+        coverage = report.get("equation_artifact_coverage") or {}
+        if not coverage.get("complete", True):
+            warnings.append(ValidationEntry(
+                code="DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE",
+                message=(
+                    f"document {document_id!r} equation artifact coverage is "
+                    f"incomplete: TeX display math blocks "
+                    f"{coverage.get('tex_display_math_blocks')}, candidates "
+                    f"{coverage.get('equation_candidate_count')}, records "
+                    f"{coverage.get('equation_record_count')}; reasons "
+                    f"{coverage.get('review_reasons')}"
+                ),
+                artifact="equation_semantics",
+                path="$.completeness.equation_artifact_coverage",
+                source_stage="export_validation",
+            ))
         return result
+
+    @staticmethod
+    def _refresh_equation_artifact_coverage(
+        report: dict,
+        structure: dict,
+        equations: Any,
+        *,
+        document_id: str,
+    ) -> dict:
+        """Recompute equation-artifact coverage on a precomputed report (#416).
+
+        The orchestrator computes ``document_completeness`` before
+        equation_semantics runs, so its coverage block is empty/stale. Here, where
+        the equation artifacts exist, the coverage is recomputed and folded back
+        into ``complete`` / ``review_reasons`` without disturbing the other checks.
+        """
+        if not isinstance(report, dict):
+            return report
+        try:
+            from .completeness import analyze_equation_artifact_coverage
+        except Exception:  # pragma: no cover - import resilience
+            try:
+                from core.document_pipeline.completeness import (
+                    analyze_equation_artifact_coverage,
+                )
+            except Exception:
+                return report
+        metadata = structure.get("metadata") if isinstance(structure, dict) else {}
+        pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
+        tex_source = None
+        if isinstance(metadata, dict):
+            tex_source = metadata.get("tex_source") or metadata.get("source_tex")
+        if tex_source is None and isinstance(structure, dict):
+            tex_source = structure.get("tex_source") or structure.get("source_tex")
+        coverage = analyze_equation_artifact_coverage(
+            structure,
+            equations if isinstance(equations, dict) else None,
+            tex_source=tex_source,
+            pages_total=pages_total,
+        )
+        report = dict(report)
+        report["equation_artifact_coverage"] = coverage
+        if not coverage.get("complete", True):
+            reasons = list(report.get("review_reasons") or [])
+            if "equation_artifact_coverage_incomplete" not in reasons:
+                reasons.append("equation_artifact_coverage_incomplete")
+            report["review_reasons"] = reasons
+            report["complete"] = False
+        return report
 
     def _aggregate_artifact_issues(
         self,
@@ -1484,19 +1561,24 @@ class ExportValidationGate:
         errors: list,
         warnings: list,
     ) -> None:
-        """Verify CourseMapping topics reference real component IDs."""
-        known_component_ids: set[str] = {
-            c.component_id
-            for c in (getattr(component_result, "components", []) or [])
+        """Verify CourseMapping topics reference real component IDs (#418)."""
+        components = list(getattr(component_result, "components", []) or [])
+        known_component_ids: set[str] = {c.component_id for c in components}
+        # Per-component derivation links, used to verify topic→derivation relevance.
+        component_derivations: dict[str, set[str]] = {
+            c.component_id: {str(d) for d in (getattr(c, "linked_derivation_ids", []) or [])}
+            for c in components
         }
+
+        def _topic_attr(topic, name):
+            if isinstance(topic, dict):
+                return topic.get(name) or []
+            return getattr(topic, name, []) or []
+
         topics = getattr(course_mapping, "topics", []) or []
         if isinstance(topics, list):
             for idx, topic in enumerate(topics):
-                linked = []
-                if isinstance(topic, dict):
-                    linked = topic.get("linked_component_ids") or []
-                else:
-                    linked = getattr(topic, "linked_component_ids", []) or []
+                linked = _topic_attr(topic, "linked_component_ids")
                 for comp_id in linked:
                     if known_component_ids and comp_id not in known_component_ids:
                         errors.append(ValidationEntry(
@@ -1505,7 +1587,28 @@ class ExportValidationGate:
                             artifact="course_mapping",
                             path=f"$.topics[{idx}].linked_component_ids",
                             source_stage="export_validation",
-                    ))
+                            target_type="component",
+                            target_id=str(comp_id),
+                        ))
+                # Issue #418: a topic may only link derivations that belong to one
+                # of its linked components; an unrelated derivation link is flagged.
+                relevant_derivations: set[str] = set()
+                for comp_id in linked:
+                    relevant_derivations |= component_derivations.get(comp_id, set())
+                for der_id in _topic_attr(topic, "linked_derivation_ids"):
+                    if str(der_id) not in relevant_derivations:
+                        warnings.append(ValidationEntry(
+                            code="COURSE_TOPIC_UNRELATED_DERIVATION",
+                            message=(
+                                f"course topic [{idx}] links derivation {der_id!r} that is "
+                                "not connected to any of the topic's components"
+                            ),
+                            artifact="course_mapping",
+                            path=f"$.topics[{idx}].linked_derivation_ids",
+                            source_stage="export_validation",
+                            target_type="derivation",
+                            target_id=str(der_id),
+                        ))
 
     @staticmethod
     def _component_equation_refs(component, refs: dict) -> list[str]:
@@ -1929,12 +2032,15 @@ class ExportValidationGate:
             return
 
         node_ids: set[str] = set()
+        for node in nodes:
+            if isinstance(node, dict):
+                nid = str(node.get("component_id") or node.get("node_id") or node.get("id") or "")
+                if nid:
+                    node_ids.add(nid)
         for idx, node in enumerate(nodes):
             if not isinstance(node, dict):
                 continue
-            comp_id = str(node.get("component_id") or "")
-            if comp_id:
-                node_ids.add(comp_id)
+            comp_id = str(node.get("component_id") or node.get("node_id") or node.get("id") or "")
             if not str(node.get("label") or "").strip():
                 errors.append(ValidationEntry(
                     code="COMPONENT_GRAPH_NODE_MISSING_LABEL",
@@ -1942,7 +2048,41 @@ class ExportValidationGate:
                     artifact="component_graph",
                     path=f"$.nodes[{idx}].label",
                     source_stage="export_validation",
+                    target_type="graph_node",
+                    target_id=comp_id or None,
                 ))
+            # Issue #418: a detail / operation node must point at an existing
+            # parent node in the same graph (parent_component_id integrity).
+            parent_id = str(node.get("parent_component_id") or "")
+            if parent_id and parent_id not in node_ids:
+                errors.append(ValidationEntry(
+                    code="COMPONENT_GRAPH_PARENT_COMPONENT_INVALID",
+                    message=(
+                        f"component graph node {comp_id or idx!r} parent_component_id "
+                        f"{parent_id!r} does not resolve to a graph node"
+                    ),
+                    artifact="component_graph",
+                    path=f"$.nodes[{idx}].parent_component_id",
+                    source_stage="export_validation",
+                    target_type="graph_node",
+                    target_id=comp_id or None,
+                ))
+            # Issue #418: a main node aggregates other nodes via member_component_ids;
+            # each member must resolve to an existing graph node.
+            for member_id in node.get("member_component_ids") or []:
+                if str(member_id) and str(member_id) not in node_ids:
+                    errors.append(ValidationEntry(
+                        code="COMPONENT_GRAPH_MEMBER_COMPONENT_INVALID",
+                        message=(
+                            f"component graph node {comp_id or idx!r} member_component_id "
+                            f"{member_id!r} does not resolve to a graph node"
+                        ),
+                        artifact="component_graph",
+                        path=f"$.nodes[{idx}].member_component_ids",
+                        source_stage="export_validation",
+                        target_type="graph_node",
+                        target_id=comp_id or None,
+                    ))
             if not str(node.get("component_type") or "").strip():
                 warnings.append(ValidationEntry(
                     code="COMPONENT_GRAPH_NODE_MISSING_COMPONENT_TYPE",

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -777,8 +777,12 @@ class ExportValidationGate:
         metadata = structure.get("metadata") if isinstance(structure, dict) else {}
         pages_total = metadata.get("pages") if isinstance(metadata, dict) else None
         tex_source = None
+        tex_inventory = None
         if isinstance(metadata, dict):
             tex_source = metadata.get("tex_source") or metadata.get("source_tex")
+            # Issue #420: prefer the inventory persisted at ingest when the raw
+            # source is not carried on the structure.
+            tex_inventory = metadata.get("tex_equation_inventory")
         if tex_source is None and isinstance(structure, dict):
             tex_source = structure.get("tex_source") or structure.get("source_tex")
         coverage = analyze_equation_artifact_coverage(
@@ -786,6 +790,7 @@ class ExportValidationGate:
             equations if isinstance(equations, dict) else None,
             tex_source=tex_source,
             pages_total=pages_total,
+            tex_inventory=tex_inventory,
         )
         report = dict(report)
         report["equation_artifact_coverage"] = coverage

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -794,12 +794,20 @@ class ExportValidationGate:
         )
         report = dict(report)
         report["equation_artifact_coverage"] = coverage
+        # Reconcile bidirectionally (#420): the orchestrator computes the report
+        # before equation_semantics, so its coverage is stale (record_count=0 →
+        # equation_artifact_coverage_incomplete). When the refreshed coverage is
+        # now complete, the stale reason must be REMOVED and ``complete``
+        # recomputed from the remaining reasons — otherwise a normal TeX document
+        # stays permanently incomplete. Other failure reasons are preserved.
+        reasons = [
+            r for r in (report.get("review_reasons") or [])
+            if r != "equation_artifact_coverage_incomplete"
+        ]
         if not coverage.get("complete", True):
-            reasons = list(report.get("review_reasons") or [])
-            if "equation_artifact_coverage_incomplete" not in reasons:
-                reasons.append("equation_artifact_coverage_incomplete")
-            report["review_reasons"] = reasons
-            report["complete"] = False
+            reasons.append("equation_artifact_coverage_incomplete")
+        report["review_reasons"] = reasons
+        report["complete"] = not reasons
         return report
 
     def _aggregate_artifact_issues(

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -574,30 +574,17 @@ def run_document_pipeline(
         # signal flows downstream (and a truncated document never silently
         # reaches publish-ready).
         try:
-            from .completeness import analyze_document_completeness
-
-            completeness_report = analyze_document_completeness(
-                _to_plain_data(structure),
-                _to_plain_data(evidence),
+            # equation_semantics (stage 8) runs before this point, so the real
+            # EquationRecords are available and MUST be passed so equation artifact
+            # coverage reflects them (#420) — otherwise the saved artifact is
+            # permanently incomplete for any TeX document with math.
+            _record_document_completeness(
+                structure=structure,
+                evidence=evidence,
+                equations=equations,
                 document_id=document_id,
+                save_artifact=save_artifact,
             )
-            save_artifact("document_completeness", completeness_report)
-            if not completeness_report.get("complete", True):
-                reasons = completeness_report.get("review_reasons") or []
-                logger.warning(
-                    "document %s ingest looks incomplete: %s", document_id, reasons,
-                )
-                # equation_artifact_coverage is evaluated before equation_semantics
-                # has run, so its EquationRecord count is always 0 here (#420). Do
-                # not propagate that (provisional) reason onto document_structure —
-                # it would persist as a stale warning even after the gate refreshes
-                # coverage with the real records. The ExportValidationGate is the
-                # authoritative coverage check.
-                propagated = [
-                    r for r in reasons if r != "equation_artifact_coverage_incomplete"
-                ]
-                _propagate_completeness_to_structure(structure, propagated)
-                save_artifact("document_structure", structure)
         except Exception:
             logger.exception(
                 "document_completeness check failed (non-fatal): document=%s", document_id
@@ -1344,6 +1331,41 @@ def _to_plain_data(value: Any) -> Any:
     if isinstance(value, dict):
         return {k: _to_plain_data(v) for k, v in value.items()}
     return value
+
+
+def _record_document_completeness(
+    *,
+    structure: Any,
+    evidence: Any,
+    equations: Any,
+    document_id: str,
+    save_artifact,
+) -> dict:
+    """Compute, persist, and propagate document completeness (#366 / #420).
+
+    Runs at the DocumentStructure / equation_semantics / EvidenceRegistry exit.
+    The equation_semantics result is passed through so equation artifact coverage
+    reflects the real EquationRecords; without it the saved ``document_completeness``
+    artifact would be permanently incomplete for any TeX document with math.
+    Returns the report. Best-effort propagation onto ``structure``.
+    """
+    from .completeness import analyze_document_completeness
+
+    report = analyze_document_completeness(
+        _to_plain_data(structure),
+        _to_plain_data(evidence),
+        document_id=document_id,
+        equations=_to_plain_data(equations),
+    )
+    save_artifact("document_completeness", report)
+    if not report.get("complete", True):
+        reasons = report.get("review_reasons") or []
+        logger.warning(
+            "document %s ingest looks incomplete: %s", document_id, reasons,
+        )
+        _propagate_completeness_to_structure(structure, reasons)
+        save_artifact("document_structure", structure)
+    return report
 
 
 def _propagate_completeness_to_structure(structure: Any, review_reasons: list) -> None:

--- a/backend/core/document_pipeline/orchestrator.py
+++ b/backend/core/document_pipeline/orchestrator.py
@@ -587,7 +587,16 @@ def run_document_pipeline(
                 logger.warning(
                     "document %s ingest looks incomplete: %s", document_id, reasons,
                 )
-                _propagate_completeness_to_structure(structure, reasons)
+                # equation_artifact_coverage is evaluated before equation_semantics
+                # has run, so its EquationRecord count is always 0 here (#420). Do
+                # not propagate that (provisional) reason onto document_structure —
+                # it would persist as a stale warning even after the gate refreshes
+                # coverage with the real records. The ExportValidationGate is the
+                # authoritative coverage check.
+                propagated = [
+                    r for r in reasons if r != "equation_artifact_coverage_incomplete"
+                ]
+                _propagate_completeness_to_structure(structure, propagated)
                 save_artifact("document_structure", structure)
         except Exception:
             logger.exception(

--- a/backend/core/document_pipeline/revision/checkpoints.py
+++ b/backend/core/document_pipeline/revision/checkpoints.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
+from episteme_graph.agents.component_assembly.split_recommendation import (
+    split_is_required as _split_is_required,
+)
+
 # Confidence below which an entity is considered low-confidence and worth a
 # source re-check.
 LOW_CONFIDENCE_THRESHOLD = 0.5
@@ -84,7 +88,11 @@ def _from_existing_issues(inventory: dict) -> list[dict]:
     out: list[dict] = []
     for issue in inventory.get("existing_issues", []):
         target_id = issue.get("target_id") or issue.get("artifact") or "document"
-        target_type = _infer_target_type(issue.get("artifact"), target_id)
+        # Issue #418: prefer the explicit target_type recorded on the issue; fall
+        # back to artifact/id heuristics only when it is absent (legacy issues).
+        target_type = issue.get("target_type") or _infer_target_type(
+            issue.get("artifact"), target_id
+        )
         code = issue.get("code") or "issue"
         out.append(_make_checkpoint(
             target_type=target_type,
@@ -200,7 +208,10 @@ def _from_components(inventory: dict) -> list[dict]:
     out: list[dict] = []
     for cid, comp in (inventory.get("entities", {}).get("components", {}) or {}).items():
         split = comp.get("split_recommendation") or {}
-        if split.get("split_required") or split.get("should_split"):
+        # Canonical key is ``required`` (#417). Read through the shared helper so
+        # legacy ``split_required`` / ``should_split`` shapes are still honored
+        # and a ``required: true`` component is never silently skipped.
+        if _split_is_required(split):
             out.append(_make_checkpoint(
                 target_type="component", target_id=cid,
                 question="component が単一責務・適切な粒度か（分割推奨あり）。input/output が claim/equation と整合するか確認する",

--- a/backend/core/document_pipeline/revision/diff.py
+++ b/backend/core/document_pipeline/revision/diff.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from episteme_graph.agents.component_assembly.split_recommendation import (
+    split_is_required,
+)
+
 from .inventory import build_baseline_inventory
 from .validation import gate_error_count
 
@@ -63,8 +67,7 @@ def compute_quality_metrics(artifacts: dict, *, gate_result: dict | None = None)
 
     granularity_violations = sum(
         1 for c in components.values()
-        if (c.get("split_recommendation") or {}).get("split_required")
-        or (c.get("split_recommendation") or {}).get("should_split")
+        if split_is_required(c.get("split_recommendation"))
     )
 
     return {

--- a/backend/core/document_pipeline/revision/inventory.py
+++ b/backend/core/document_pipeline/revision/inventory.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 import copy
 from typing import Any
 
+from episteme_graph.agents.component_assembly.split_recommendation import (
+    normalize_split_recommendation as _normalize_split_recommendation,
+)
+
 ARTIFACTS_KEY = "_artifacts"
 
 # Entity buckets used throughout the revision subsystem.
@@ -232,7 +236,12 @@ def _index_components(artifacts: dict) -> dict[str, dict]:
             "label": r.get("label") or r.get("name") or "",
             "responsibility_type": r.get("responsibility_type") or "",
             "review_status": r.get("review_status") or "teacher_review_required",
-            "split_recommendation": _as_dict(r.get("split_recommendation")),
+            # Canonical ``required`` schema (#417): normalize on the way in so the
+            # checkpoint planner and any other reader see a single shape even if
+            # the producing run used a legacy split-recommendation key.
+            "split_recommendation": _normalize_split_recommendation(
+                r.get("split_recommendation")
+            ),
             "component_quality": _as_dict(r.get("component_quality")),
             "confidence": float(r.get("confidence") or 0.0),
             "claim_ids": _str_list(r.get("linked_claim_ids")),
@@ -463,6 +472,9 @@ def _collect_existing_issues(artifacts: dict) -> list[dict]:
                 "message": entry.get("message") or "",
                 "artifact": entry.get("artifact") or "",
                 "path": entry.get("path") or "",
+                # Issue #418: prefer the explicit target_type/target_id the gate
+                # now records, falling back to JSON-path parsing for legacy entries.
+                "target_type": entry.get("target_type") or "",
                 "target_id": entry.get("target_id") or _target_from_path(entry.get("path")),
             })
     # Per-artifact validation_issues.
@@ -482,6 +494,7 @@ def _collect_existing_issues(artifacts: dict) -> list[dict]:
                 "message": vi.get("message") or vi.get("reason") or "",
                 "artifact": stage,
                 "path": vi.get("path") or "",
+                "target_type": vi.get("target_type") or "",
                 "target_id": vi.get("target_id") or vi.get("id") or "",
             })
     return issues

--- a/backend/core/document_pipeline/tex_archive.py
+++ b/backend/core/document_pipeline/tex_archive.py
@@ -101,6 +101,11 @@ def build_structure_from_tex_archive(
     unclosed_math_environments = _detect_unclosed_math_environments(
         source.expanded_tex
     )
+    # Issue #420: compute the TeX equation inventory at ingest from the expanded
+    # source and persist it on the metadata (display math counts + symbolic
+    # labels), so downstream completeness / coverage can detect TeX math without
+    # re-storing the large source.
+    tex_equation_inventory = _compute_tex_equation_inventory(source.expanded_tex)
     source_bytes = len(source.expanded_tex.encode("utf-8"))
     authors = list(author_result.authors or source.authors)
     author_extraction = author_result.to_metadata()
@@ -121,6 +126,7 @@ def build_structure_from_tex_archive(
         source_bytes_processed=source_bytes,
         unclosed_math_environments=unclosed_math_environments,
         author_extraction=author_extraction,
+        tex_equation_inventory=tex_equation_inventory,
     )
     result = DocumentStructureResult(
         document_id=document_id,
@@ -698,6 +704,27 @@ def _split_authors(authors_raw: str) -> list[str]:
         return []
     parts = re.split(r"\s+(?:and|AND)\s+|\\\\|;", authors_raw)
     return [part.strip() for part in parts if part.strip()]
+
+
+def _compute_tex_equation_inventory(tex: str) -> dict:
+    """Compute the canonical TeX equation inventory at ingest (issue #420).
+
+    Delegates to ``completeness.tex_equation_inventory`` so ingest and the
+    completeness / coverage checks share one definition of display-math counting
+    and symbolic-label extraction. Resilient: any failure yields an empty
+    inventory rather than breaking ingestion.
+    """
+    try:
+        from .completeness import tex_equation_inventory
+    except Exception:  # pragma: no cover - import resilience
+        try:
+            from core.document_pipeline.completeness import tex_equation_inventory
+        except Exception:
+            return {"display_math_blocks": 0, "labels": [], "label_count": 0}
+    try:
+        return tex_equation_inventory(tex)
+    except Exception:  # pragma: no cover - defensive
+        return {"display_math_blocks": 0, "labels": [], "label_count": 0}
 
 
 def _detect_unclosed_math_environments(tex: str) -> list[str]:

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -857,3 +857,113 @@ class TestPipelineGateCompleteness:
         res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
         assert res["document_completeness"]["all_documents_complete"] is False
         assert "DOCUMENT_TERMINAL_SECTION_MISSING" in {w["code"] for w in res["warnings"]}
+
+
+# ---------------------------------------------------------------------------
+# Issue #416: TeX equation-artifact coverage / pages=0 silent pass
+# ---------------------------------------------------------------------------
+
+class TestEquationArtifactCoverage:
+    def test_tex_equation_inventory_counts_blocks_and_symbolic_labels(self):
+        mod = _import_completeness_mod()
+        tex = r"""
+        \begin{equation}\label{eq:energy} E = mc^2 \end{equation}
+        \begin{align}\label{eq:force} F = ma \end{align}
+        \[ a^2 + b^2 = c^2 \]
+        """
+        inv = mod.tex_equation_inventory(tex)
+        assert inv["display_math_blocks"] == 3
+        assert "eq:energy" in inv["labels"]
+        assert "eq:force" in inv["labels"]
+        assert inv["label_count"] == 2
+
+    def test_pages_zero_tex_with_math_but_no_records_is_incomplete(self):
+        # The #416 silent pass: pages=0 + parser_reached_eof=true would let a TeX
+        # document with display math but no equation registry pass. Artifact
+        # coverage must catch it.
+        mod = _import_completeness_mod()
+        structure = {
+            "document_id": "doc_tex",
+            "metadata": {"pages": 0, "parser_reached_eof": True,
+                         "tex_source": r"\begin{equation}\label{eq:a} x=1 \end{equation}"},
+            "blocks": [],
+            "sections": [],
+        }
+        report = mod.analyze_document_completeness(
+            structure, None, document_id="doc_tex",
+            equations={"equations": [], "equation_candidates": []},
+        )
+        cov = report["equation_artifact_coverage"]
+        assert cov["tex_display_math_blocks"] == 1
+        assert cov["complete"] is False
+        assert "tex_display_math_without_equation_records" in cov["review_reasons"]
+        assert "equation_artifact_coverage_incomplete" in report["review_reasons"]
+        assert report["complete"] is False
+
+    def test_accepted_candidate_not_in_registry_is_coverage_gap(self):
+        mod = _import_completeness_mod()
+        equations = {
+            "equations": [{"equation_id": "eq_1"}],
+            "equation_candidates": [
+                {"candidate_id": "c1", "acceptance_status": "accepted",
+                 "accepted_equation_id": "eq_1"},
+                {"candidate_id": "c2", "acceptance_status": "accepted",
+                 "accepted_equation_id": "eq_missing"},
+            ],
+        }
+        cov = mod.analyze_equation_artifact_coverage(
+            {}, equations, tex_source=None, pages_total=10
+        )
+        assert cov["complete"] is False
+        assert "accepted_candidate_not_in_registry" in cov["review_reasons"]
+
+    def test_complete_tex_coverage_passes(self):
+        mod = _import_completeness_mod()
+        equations = {
+            "equations": [{"equation_id": "eq_1"}],
+            "equation_candidates": [
+                {"candidate_id": "c1", "acceptance_status": "accepted",
+                 "accepted_equation_id": "eq_1"},
+            ],
+        }
+        cov = mod.analyze_equation_artifact_coverage(
+            {}, equations,
+            tex_source=r"\begin{equation} x=1 \end{equation}",
+            pages_total=0,
+        )
+        assert cov["complete"] is True
+        assert cov["review_reasons"] == []
+
+    def test_gate_refreshes_coverage_from_equation_artifacts(self):
+        # A precomputed (stale, pre-equation_semantics) completeness report gets
+        # its equation coverage refreshed at the gate where artifacts exist.
+        mod = _import_gate()
+        precomputed = {
+            "document_id": "doc_ref",
+            "complete": True,
+            "review_reasons": [],
+            "equation_label_continuity": {"missing_labels": [], "has_gaps": False},
+            "terminal_section": {"present": True, "missing": False, "matched_titles": []},
+            "ingest_coverage": {"sufficient": True, "reached_document_end": True,
+                                "pages_total": 0, "last_ingested_page": None,
+                                "structure_page_coverage_ratio": None,
+                                "trailing_uningested_page_ranges": []},
+            "evidence_page_distribution": {"pages": [], "distribution_ratio": None,
+                                           "sparse": False},
+            "equation_artifact_coverage": {},
+        }
+        artifacts = {
+            "document_structure": {
+                "document_id": "doc_ref",
+                "metadata": {"pages": 0, "parser_reached_eof": True,
+                             "tex_source": r"\begin{equation} x=1 \end{equation}"},
+                "blocks": [],
+                "sections": [],
+            },
+            "document_completeness": precomputed,
+            "equation_semantics": {"equations": [], "equation_candidates": []},
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        codes = {w["code"] for w in res["warnings"]}
+        assert "DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE" in codes
+        assert res["document_completeness"]["all_documents_complete"] is False

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -967,3 +967,50 @@ class TestEquationArtifactCoverage:
         codes = {w["code"] for w in res["warnings"]}
         assert "DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE" in codes
         assert res["document_completeness"]["all_documents_complete"] is False
+
+    def test_gate_refresh_uses_precomputed_inventory_without_tex_source(self):
+        # AC #420(5,6): the gate refresh detects TeX math from the persisted
+        # inventory alone — no raw tex_source on the structure.
+        mod = _import_gate()
+        precomputed = {
+            "document_id": "doc_inv",
+            "complete": True,
+            "review_reasons": [],
+            "equation_label_continuity": {"missing_labels": [], "has_gaps": False},
+            "terminal_section": {"present": True, "missing": False, "matched_titles": []},
+            "ingest_coverage": {"sufficient": True, "reached_document_end": True,
+                                "pages_total": 0, "last_ingested_page": None,
+                                "structure_page_coverage_ratio": None,
+                                "trailing_uningested_page_ranges": []},
+            "evidence_page_distribution": {"pages": [], "distribution_ratio": None,
+                                           "sparse": False},
+            "equation_artifact_coverage": {},
+        }
+        artifacts = {
+            "document_structure": {
+                "document_id": "doc_inv",
+                "metadata": {
+                    "pages": 0,
+                    "parser_reached_eof": True,
+                    # No tex_source — only the inventory persisted at ingest.
+                    "tex_equation_inventory": {
+                        "display_math_blocks": 5,
+                        "labels": ["eq:a", "eq:b"],
+                        "label_count": 2,
+                    },
+                },
+                "blocks": [],
+                "sections": [],
+            },
+            "document_completeness": precomputed,
+            "equation_semantics": {"equations": [], "equation_candidates": []},
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        doc = res["document_completeness"]["documents"][0]
+        cov = doc["equation_artifact_coverage"]
+        assert cov["tex_display_math_blocks"] == 5
+        assert cov["tex_equation_labels"] == ["eq:a", "eq:b"]
+        assert cov["complete"] is False
+        assert "DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE" in {
+            w["code"] for w in res["warnings"]
+        }

--- a/backend/tests/test_document_completeness.py
+++ b/backend/tests/test_document_completeness.py
@@ -1014,3 +1014,108 @@ class TestEquationArtifactCoverage:
         assert "DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE" in {
             w["code"] for w in res["warnings"]
         }
+
+    def test_gate_clears_stale_coverage_reason_when_records_present(self):
+        # Regression for #420 P1: the orchestrator's precomputed report ran before
+        # equation_semantics (record_count=0 → equation_artifact_coverage_incomplete
+        # + complete=false). Once real EquationRecords exist, the gate must REMOVE
+        # the stale reason and restore complete=true — not leave the document
+        # permanently incomplete.
+        mod = _import_gate()
+        precomputed = {
+            "document_id": "doc_stale",
+            "complete": False,
+            "review_reasons": ["equation_artifact_coverage_incomplete"],
+            "equation_label_continuity": {"missing_labels": [], "has_gaps": False},
+            "terminal_section": {"present": True, "missing": False, "matched_titles": []},
+            "ingest_coverage": {"sufficient": True, "reached_document_end": True,
+                                "pages_total": 0, "last_ingested_page": None,
+                                "structure_page_coverage_ratio": None,
+                                "trailing_uningested_page_ranges": []},
+            "evidence_page_distribution": {"pages": [], "distribution_ratio": None,
+                                           "sparse": False},
+            "equation_artifact_coverage": {
+                "tex_display_math_blocks": 3, "equation_record_count": 0,
+                "complete": False,
+                "review_reasons": ["tex_display_math_without_equation_records"],
+            },
+        }
+        artifacts = {
+            "document_structure": {
+                "document_id": "doc_stale",
+                "metadata": {
+                    "pages": 0, "parser_reached_eof": True,
+                    "tex_equation_inventory": {
+                        "display_math_blocks": 3, "labels": ["eq:a"], "label_count": 1,
+                    },
+                },
+                "blocks": [],
+                "sections": [],
+            },
+            "document_completeness": precomputed,
+            # Real EquationRecords now exist and cover the math.
+            "equation_semantics": {
+                "equations": [{"equation_id": "eq_1"}],
+                "equation_candidates": [
+                    {"candidate_id": "c1", "acceptance_status": "accepted",
+                     "accepted_equation_id": "eq_1"},
+                ],
+            },
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        doc = res["document_completeness"]["documents"][0]
+        assert doc["equation_artifact_coverage"]["complete"] is True
+        assert "equation_artifact_coverage_incomplete" not in doc["review_reasons"]
+        assert doc["complete"] is True
+        assert res["document_completeness"]["all_documents_complete"] is True
+        assert "DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE" not in {
+            w["code"] for w in res["warnings"]
+        }
+
+    def test_gate_preserves_other_reasons_when_coverage_clears(self):
+        # Clearing the coverage reason must not resurrect completeness when an
+        # unrelated failure (terminal section missing) is still present.
+        mod = _import_gate()
+        precomputed = {
+            "document_id": "doc_mixed",
+            "complete": False,
+            "review_reasons": [
+                "terminal_section_missing",
+                "equation_artifact_coverage_incomplete",
+            ],
+            "equation_label_continuity": {"missing_labels": [], "has_gaps": False},
+            "terminal_section": {"present": False, "missing": True, "matched_titles": []},
+            "ingest_coverage": {"sufficient": True, "reached_document_end": True,
+                                "pages_total": 0, "last_ingested_page": None,
+                                "structure_page_coverage_ratio": None,
+                                "trailing_uningested_page_ranges": []},
+            "evidence_page_distribution": {"pages": [], "distribution_ratio": None,
+                                           "sparse": False},
+            "equation_artifact_coverage": {},
+        }
+        artifacts = {
+            "document_structure": {
+                "document_id": "doc_mixed",
+                "metadata": {
+                    "pages": 0, "parser_reached_eof": True,
+                    "tex_equation_inventory": {
+                        "display_math_blocks": 3, "labels": ["eq:a"], "label_count": 1,
+                    },
+                },
+                "blocks": [],
+                "sections": [],
+            },
+            "document_completeness": precomputed,
+            "equation_semantics": {
+                "equations": [{"equation_id": "eq_1"}],
+                "equation_candidates": [
+                    {"candidate_id": "c1", "acceptance_status": "accepted",
+                     "accepted_equation_id": "eq_1"},
+                ],
+            },
+        }
+        res = mod.ExportValidationGate().run(artifacts=artifacts).to_dict()
+        doc = res["document_completeness"]["documents"][0]
+        assert "equation_artifact_coverage_incomplete" not in doc["review_reasons"]
+        assert "terminal_section_missing" in doc["review_reasons"]
+        assert doc["complete"] is False

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -403,6 +403,39 @@ def test_completeness_passes_when_records_cover_tex_math():
     assert cov["complete"] is True
 
 
+def test_build_document_completeness_passes_equations_to_coverage():
+    # Regression for #420 P1: the export-route wrapper must forward the
+    # equation_semantics artifact so a normal TeX document with records is not
+    # reported as permanently incomplete.
+    import sys as _sys
+    from pathlib import Path as _Path
+    _api = _Path(__file__).resolve().parents[1] / "api"
+    if str(_api) not in _sys.path:
+        _sys.path.insert(0, str(_api))
+    from routes import export_artifacts as ea
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-route", source_file="paper.tar.gz"
+    )
+    struct_dict = structure.to_dict()
+    equations = {
+        "equations": [{"equation_id": "eq_1"}],
+        "equation_candidates": [
+            {"candidate_id": "c1", "acceptance_status": "accepted",
+             "accepted_equation_id": "eq_1"},
+        ],
+    }
+    # Without equations → incomplete; with equations → complete.
+    without = ea.build_document_completeness(struct_dict, document_id="doc-route")
+    assert without["equation_artifact_coverage"]["complete"] is False
+    with_eq = ea.build_document_completeness(
+        struct_dict, document_id="doc-route", equations_artifact=equations
+    )
+    assert with_eq["equation_artifact_coverage"]["complete"] is True
+    assert "equation_artifact_coverage_incomplete" not in with_eq["review_reasons"]
+
+
 def test_tex_archive_wraps_alignment_equations_for_rendering():
     from core.document_pipeline.tex_archive import build_structure_from_tex_archive
 

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -314,6 +314,95 @@ def test_tex_archive_records_unclosed_math_environment_for_completeness():
     assert "equation_environment_cut_at_boundary" in report["tail_truncation"]["signals"]
 
 
+def _tex_archive_with_math() -> bytes:
+    return _make_tex_archive({
+        "main.tex": r"""
+            \documentclass{article}
+            \begin{document}
+            \section{Results}
+            \begin{equation}\label{eq:energy} E = mc^2 \end{equation}
+            \begin{align}\label{eq:force} F = ma \end{align}
+            \[ a^2 + b^2 = c^2 \]
+            \end{document}
+        """,
+    })
+
+
+def test_tex_archive_ingest_stores_equation_inventory():
+    # AC #420(1,2): ingest persists display-math counts and symbolic labels.
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-inv", source_file="paper.tar.gz"
+    )
+    inv = structure.metadata.tex_equation_inventory
+    assert inv is not None
+    assert inv["display_math_blocks"] == 3
+    assert "eq:energy" in inv["labels"]
+    assert "eq:force" in inv["labels"]
+    assert inv["label_count"] == 2
+
+
+def test_tex_equation_inventory_survives_serialization_roundtrip():
+    # AC #420(3): inventory persists through to_dict / from_dict.
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+    from episteme_graph.agents.document_structure.schema import DocumentStructureResult
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-rt", source_file="paper.tar.gz"
+    )
+    restored = DocumentStructureResult.from_dict(structure.to_dict())
+    assert restored.metadata.tex_equation_inventory == structure.metadata.tex_equation_inventory
+    assert restored.metadata.tex_equation_inventory["display_math_blocks"] == 3
+
+
+def test_completeness_uses_precomputed_inventory_without_tex_source():
+    # AC #420(4,6): a TeX doc (pages=0) with display math but no EquationRecords is
+    # incomplete, detected from the persisted inventory alone (no tex_source).
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+    from core.document_pipeline.completeness import analyze_document_completeness
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-cov", source_file="paper.tar.gz"
+    )
+    struct_dict = structure.to_dict()
+    # The structure carries no raw tex_source — only the precomputed inventory.
+    assert "tex_source" not in (struct_dict.get("metadata") or {})
+    report = analyze_document_completeness(
+        struct_dict,
+        document_id=structure.document_id,
+        equations={"equations": [], "equation_candidates": []},
+    )
+    cov = report["equation_artifact_coverage"]
+    assert cov["tex_display_math_blocks"] == 3
+    assert cov["complete"] is False
+    assert "tex_display_math_without_equation_records" in cov["review_reasons"]
+    assert report["complete"] is False
+
+
+def test_completeness_passes_when_records_cover_tex_math():
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+    from core.document_pipeline.completeness import analyze_document_completeness
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-cov2", source_file="paper.tar.gz"
+    )
+    report = analyze_document_completeness(
+        structure.to_dict(),
+        document_id=structure.document_id,
+        equations={
+            "equations": [{"equation_id": "eq_1"}],
+            "equation_candidates": [
+                {"candidate_id": "c1", "acceptance_status": "accepted",
+                 "accepted_equation_id": "eq_1"},
+            ],
+        },
+    )
+    cov = report["equation_artifact_coverage"]
+    assert cov["tex_display_math_blocks"] == 3
+    assert cov["complete"] is True
+
+
 def test_tex_archive_wraps_alignment_equations_for_rendering():
     from core.document_pipeline.tex_archive import build_structure_from_tex_archive
 

--- a/backend/tests/test_document_pipeline.py
+++ b/backend/tests/test_document_pipeline.py
@@ -403,6 +403,75 @@ def test_completeness_passes_when_records_cover_tex_math():
     assert cov["complete"] is True
 
 
+class _FakeEquations:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def to_dict(self):
+        return self._payload
+
+
+def test_orchestrator_records_completeness_with_equation_records():
+    # Regression for #420 P1: the orchestrator runs equation_semantics (stage 8)
+    # before this completeness call, so it must pass the real EquationRecords —
+    # the persisted document_completeness artifact must NOT be stale-incomplete
+    # for a normal TeX document with math.
+    from core.document_pipeline.orchestrator import _record_document_completeness
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-orch", source_file="paper.tar.gz"
+    )
+    equations = _FakeEquations({
+        "equations": [{"equation_id": "eq_1"}],
+        "equation_candidates": [
+            {"candidate_id": "c1", "acceptance_status": "accepted",
+             "accepted_equation_id": "eq_1"},
+        ],
+    })
+    saved: dict = {}
+    report = _record_document_completeness(
+        structure=structure,
+        evidence=None,
+        equations=equations,
+        document_id="doc-orch",
+        save_artifact=lambda name, value: saved.__setitem__(name, value),
+    )
+    cov = saved["document_completeness"]["equation_artifact_coverage"]
+    assert cov["equation_record_count"] == 1
+    assert cov["tex_display_math_blocks"] == 3
+    assert cov["complete"] is True
+    assert report["complete"] is True
+    # A complete document leaves structure untouched (no stale propagation).
+    assert not any(
+        getattr(i, "rule_id", "").startswith("document_completeness_equation")
+        for i in structure.validation_issues
+    )
+
+
+def test_orchestrator_completeness_incomplete_when_records_missing():
+    # The genuine missing-records case still reports incomplete and propagates.
+    from core.document_pipeline.orchestrator import _record_document_completeness
+    from core.document_pipeline.tex_archive import build_structure_from_tex_archive
+
+    structure = build_structure_from_tex_archive(
+        _tex_archive_with_math(), document_id="doc-orch2", source_file="paper.tar.gz"
+    )
+    saved: dict = {}
+    report = _record_document_completeness(
+        structure=structure,
+        evidence=None,
+        equations=_FakeEquations({"equations": [], "equation_candidates": []}),
+        document_id="doc-orch2",
+        save_artifact=lambda name, value: saved.__setitem__(name, value),
+    )
+    assert report["equation_artifact_coverage"]["complete"] is False
+    assert any(
+        getattr(i, "rule_id", "") == "document_completeness_equation_artifact_coverage_incomplete"
+        for i in structure.validation_issues
+    )
+
+
 def test_build_document_completeness_passes_equations_to_coverage():
     # Regression for #420 P1: the export-route wrapper must forward the
     # equation_semantics artifact so a normal TeX document with records is not

--- a/backend/tests/test_revision_inventory.py
+++ b/backend/tests/test_revision_inventory.py
@@ -162,6 +162,58 @@ def test_checkpoints_include_deterministic_signals():
     assert any(t.startswith("validation:") for t in triggers)
 
 
+def test_canonical_required_key_drives_component_checkpoint():
+    # Regression for #417: a component carrying the canonical ``required: true``
+    # split-recommendation key (the schema the granularity analyzer actually
+    # emits) must still produce a component_granularity checkpoint. Previously the
+    # planner only read ``split_required`` / ``should_split`` and silently skipped
+    # ``required: true`` components.
+    artifacts = {
+        "component_assembly": {
+            "components": [
+                {
+                    "component_id": "cmp_canon",
+                    "label": "Canonical split component",
+                    "linked_claim_ids": ["clm_x"],
+                    "split_recommendation": {
+                        "required": True,
+                        "reasons": ["responsibility type has more than one primary value"],
+                        "suggested_components": [],
+                    },
+                },
+            ],
+        },
+    }
+    inv = build_baseline_inventory(artifacts, base_run_id="base-canon")
+    # Inventory normalizes the stored recommendation to the canonical key.
+    stored = inv["entities"]["components"]["cmp_canon"]["split_recommendation"]
+    assert stored["required"] is True
+    assert "split_required" not in stored
+    triggers = {
+        (c["target_id"], c["trigger_reason"]) for c in plan_checkpoints(inv)
+    }
+    assert ("cmp_canon", "component_granularity") in triggers
+
+
+def test_legacy_split_keys_still_drive_component_checkpoint():
+    # Migration compatibility (#417): legacy keys are still honored.
+    for legacy_key in ("split_required", "should_split"):
+        artifacts = {
+            "component_assembly": {
+                "components": [
+                    {
+                        "component_id": "cmp_legacy",
+                        "label": "Legacy split component",
+                        "split_recommendation": {legacy_key: True},
+                    },
+                ],
+            },
+        }
+        inv = build_baseline_inventory(artifacts, base_run_id="base-legacy")
+        triggers = {c["trigger_reason"] for c in plan_checkpoints(inv)}
+        assert "component_granularity" in triggers, legacy_key
+
+
 def test_checkpoint_ids_are_stable_hashes():
     inv = build_baseline_inventory(_sample_artifacts(), base_run_id="base-1")
     cps = plan_checkpoints(inv)

--- a/src/episteme_graph/agents/component_assembly/component_refiner.py
+++ b/src/episteme_graph/agents/component_assembly/component_refiner.py
@@ -39,6 +39,10 @@ from .schema import (
     ComponentAssemblyResult,
     ComponentRecord,
 )
+from .split_recommendation import (
+    normalize_split_recommendation,
+    split_is_required,
+)
 
 # Component types that live on the main derivation path and are therefore
 # candidates for theory-operation refinement.
@@ -253,9 +257,7 @@ class ComponentRefiner:
             records.append({
                 "original_component_id": original_id,
                 "refinement_status": refinement_status,
-                "split_required": bool(
-                    (parent.split_recommendation or {}).get("required")
-                ),
+                "split_required": split_is_required(parent.split_recommendation),
                 "split_into": list(child_ids),
                 "split_reason": list(
                     trace.get("split_reasons")
@@ -295,11 +297,28 @@ class ComponentRefiner:
             remap=remap,
         )
 
+        # A component whose split was required (#417) must be accounted for: it is
+        # either split, failed, or explicitly review_required. Anything left as a
+        # silent "unchanged" while still flagged ``required: true`` is a contract
+        # violation and is surfaced so it cannot reach publish unprocessed.
+        processed = (
+            set(split_components)
+            | set(failed_refinements)
+            | set(review_required_refinements)
+        )
+        unprocessed_split_required = [
+            original_id
+            for original_id in original_order
+            if split_is_required(originals[original_id].split_recommendation)
+            and original_id not in processed
+        ]
+
         refinement_validation = {
             "split_components": split_components,
             "unchanged_components": unchanged_components,
             "failed_refinements": failed_refinements,
             "review_required_refinements": _ordered_unique(review_required_refinements),
+            "unprocessed_split_required": unprocessed_split_required,
             "unassigned_links": unassigned_links,
             "dangling_component_refs": graph_updates["unresolved_edges"],
             "teaching_granularity_warnings": teaching_warnings,
@@ -355,7 +374,7 @@ class ComponentRefiner:
     ) -> list[ComponentRecord]:
         claim_index = claim_index or {}
         split = component.split_recommendation if isinstance(component.split_recommendation, dict) else {}
-        if split.get("required"):
+        if split_is_required(split):
             report.oversized_components.append({
                 "component_id": component.component_id,
                 "label": component.label,
@@ -462,7 +481,7 @@ class ComponentRefiner:
         deterministic split is possible, the component is kept unchanged but the
         refinement is flagged ``review_required`` rather than silently accepted.
         """
-        if not (split or {}).get("required"):
+        if not split_is_required(split):
             return
         trace = self._traces.setdefault(component.component_id, {})
         trace["could_not_split"] = True
@@ -488,7 +507,7 @@ class ComponentRefiner:
         be assigned confidently is recorded as an unassigned link instead of being
         dropped.
         """
-        if not split.get("required"):
+        if not split_is_required(split):
             return []
         suggested = [s for s in (split.get("suggested_components") or []) if isinstance(s, dict)]
         # Distinct primary responsibilities are required to justify a split.
@@ -1088,7 +1107,7 @@ def _support_role_for_responsibility(responsibility_type: str) -> str:
 
 
 def _no_split_recommendation() -> dict:
-    return {"required": False, "suggested_components": []}
+    return normalize_split_recommendation({"required": False, "suggested_components": []})
 
 
 def _secondary_operations(steps: list, primary: str) -> list[str]:

--- a/src/episteme_graph/agents/component_assembly/granularity_analyzer.py
+++ b/src/episteme_graph/agents/component_assembly/granularity_analyzer.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from ..theory_operations import classify_operation
 from .responsibility import canonical_responsibility_type, canonical_responsibility_types
 from .schema import ComponentAssemblyResult, ComponentRecord
+from .split_recommendation import normalize_split_recommendation
 
 
 THRESHOLDS = {
@@ -53,9 +54,13 @@ class ComponentGranularityAnalyzer:
         derivations=None,
     ) -> ComponentAssemblyResult:
         derivation_index = _component_derivation_step_index(derivations)
+        equation_step_index = _equation_derivation_step_index(derivations)
         quality_entries: list[dict] = []
         for component in result.components:
-            quality = self._analyze_component(component, derivation_index.get(component.component_id, []))
+            steps = _derivation_steps_for_component(
+                component, derivation_index, equation_step_index
+            )
+            quality = self._analyze_component(component, steps)
             _apply_quality(component, quality)
             quality_entries.append(quality.to_dict())
 
@@ -99,11 +104,13 @@ class ComponentGranularityAnalyzer:
 
 def _apply_quality(component: ComponentRecord, quality: ComponentQuality) -> None:
     component.component_quality = quality.to_dict()
-    component.split_recommendation = {
+    # Canonical split-recommendation schema (#417): always emit the ``required``
+    # key through the shared normalizer so every downstream stage reads it.
+    component.split_recommendation = normalize_split_recommendation({
         "required": quality.split_required,
         "reasons": list(quality.split_reasons),
         "suggested_components": list(quality.suggested_split),
-    }
+    })
     if component.responsibility_type:
         component.responsibility_type = canonical_responsibility_type(component.responsibility_type)
 
@@ -216,14 +223,60 @@ def _detected_responsibilities(component: ComponentRecord) -> set[str]:
 
 
 def _suggested_split(component: ComponentRecord, responsibilities: set[str]) -> list[dict]:
+    """Build suggested children with *distinct* candidate links (#417).
+
+    Each suggested child must carry its own candidate equations/claims/derivations
+    rather than a duplicate of the parent's full link set, so the downstream
+    refiner has identifying information to redistribute by responsibility. The
+    parent's links are partitioned deterministically across the suggested
+    children (round-robin by sorted responsibility order); the ComponentRefiner
+    later performs the role-aware reassignment using equation roles.
+    """
+    ordered = sorted(responsibilities)
+    if not ordered:
+        return []
+    equation_partition = _partition(_component_equation_refs(component), len(ordered))
+    claim_partition = _partition(_component_claim_refs(component), len(ordered))
+    derivation_partition = _partition(
+        list(component.linked_derivation_ids or []), len(ordered)
+    )
+    evidence_partition = _partition(
+        _ordered_unique(
+            list(component.linked_evidence_ids or [])
+            + list((component.evidence_refs or {}).get("evidence_ids") or [])
+        ),
+        len(ordered),
+    )
     return [
         {
             "name": responsibility.replace("_", " ").title(),
             "responsibility_type": responsibility,
-            "linked_equation_ids": _component_equation_refs(component),
+            "linked_equation_ids": equation_partition[idx],
+            "candidate_claim_ids": claim_partition[idx],
+            "candidate_derivation_ids": derivation_partition[idx],
+            "candidate_evidence_ids": evidence_partition[idx],
         }
-        for responsibility in sorted(responsibilities)
+        for idx, responsibility in enumerate(ordered)
     ]
+
+
+def _partition(values: list[str], buckets: int) -> list[list[str]]:
+    """Split ``values`` into ``buckets`` disjoint lists, deterministically.
+
+    No value appears in more than one bucket, so suggested children never share
+    an identical link set (#417).
+    """
+    out: list[list[str]] = [[] for _ in range(max(buckets, 1))]
+    for i, value in enumerate(values):
+        out[i % len(out)].append(value)
+    return out
+
+
+def _component_claim_refs(component: ComponentRecord) -> list[str]:
+    return _ordered_unique(
+        list((component.evidence_refs or {}).get("claim_ids") or [])
+        + list(component.linked_claim_ids or [])
+    )
 
 
 def _component_derivation_step_index(derivations) -> dict[str, list]:
@@ -233,6 +286,55 @@ def _component_derivation_step_index(derivations) -> dict[str, list]:
         for comp_id in getattr(chain, "linked_component_ids", []) or []:
             index.setdefault(str(comp_id), []).extend(steps)
     return index
+
+
+def _equation_derivation_step_index(derivations) -> dict[str, list]:
+    """Index derivation steps by the equation ids they touch (#417).
+
+    When a derivation chain has no ``linked_component_ids`` it is invisible to the
+    component→step index, which left ``derivation_step_count`` at 0 and hid the
+    derivation structure from the granularity plan. Indexing steps by their
+    input/output equations lets a component recover its steps through equation
+    overlap instead.
+    """
+    index: dict[str, list] = {}
+    for chain in list(getattr(derivations, "chains", []) or []):
+        for step in list(getattr(chain, "steps", []) or []):
+            for eid in _step_equation_ids(step):
+                index.setdefault(str(eid), []).append(step)
+    return index
+
+
+def _step_equation_ids(step) -> list[str]:
+    ids: list[str] = []
+    for field_name in ("input_equation_ids", "output_equation_ids", "inputs", "outputs"):
+        value = getattr(step, field_name, None)
+        if value is None and isinstance(step, dict):
+            value = step.get(field_name)
+        for item in value or []:
+            if item:
+                ids.append(str(item))
+    return ids
+
+
+def _derivation_steps_for_component(
+    component: ComponentRecord,
+    derivation_index: dict[str, list],
+    equation_step_index: dict[str, list],
+) -> list:
+    """Collect a component's derivation steps via explicit link or eq overlap (#417)."""
+    steps = list(derivation_index.get(component.component_id, []))
+    if steps:
+        return steps
+    seen: list[int] = []
+    overlap_steps: list = []
+    for eid in _component_equation_refs(component):
+        for step in equation_step_index.get(eid, []):
+            marker = id(step)
+            if marker not in seen:
+                seen.append(marker)
+                overlap_steps.append(step)
+    return overlap_steps
 
 
 def _component_equation_refs(component: ComponentRecord) -> list[str]:

--- a/src/episteme_graph/agents/component_assembly/split_recommendation.py
+++ b/src/episteme_graph/agents/component_assembly/split_recommendation.py
@@ -1,0 +1,73 @@
+"""Canonical split-recommendation schema and normalization (issue #417).
+
+The component granularity analyzer, ComponentRefiner, and the revision
+checkpoint planner all exchange a *split recommendation*: the structured signal
+that says "this component bundles more than one reusable theory unit and should
+be decomposed".
+
+Historically these stages disagreed on the key name. The granularity analyzer
+emits::
+
+    {"required": true, "reasons": [...], "suggested_components": [...]}
+
+while the revision checkpoint planner only read ``split_required`` /
+``should_split``. As a result a component with ``required: true`` was never
+turned into a revision checkpoint and the split silently went unprocessed.
+
+This module is the single source of truth for the schema. The canonical key is
+``required``. ``normalize_split_recommendation`` accepts any of the legacy keys
+(``required`` / ``split_required`` / ``should_split``) during the migration
+period and always returns the canonical shape so every downstream stage reads
+the same thing.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Canonical key. All stages must read split state through this module so the
+# canonical key stays authoritative even while legacy keys are still produced.
+CANONICAL_SPLIT_KEY = "required"
+
+# Legacy keys accepted on input during the migration period (#417).
+_LEGACY_REQUIRED_KEYS = ("required", "split_required", "should_split")
+
+
+def _as_dict(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def split_is_required(recommendation: Any) -> bool:
+    """Return whether a (possibly legacy-shaped) recommendation requests a split.
+
+    Reads ``required`` first, then the legacy ``split_required`` / ``should_split``
+    aliases, so callers never miss a split signal because of a key mismatch.
+    """
+    rec = _as_dict(recommendation)
+    return any(bool(rec.get(key)) for key in _LEGACY_REQUIRED_KEYS)
+
+
+def normalize_split_recommendation(recommendation: Any) -> dict:
+    """Normalize any split recommendation to the canonical ``required`` schema.
+
+    Output shape::
+
+        {"required": bool, "reasons": list[str], "suggested_components": list[dict]}
+
+    Unknown extra keys are preserved (so richer producers keep their metadata),
+    but the canonical fields are always present and authoritative.
+    """
+    rec = dict(_as_dict(recommendation))
+    required = split_is_required(rec)
+    reasons = [str(r) for r in _as_list(rec.get("reasons")) if str(r)]
+    suggested = [s for s in _as_list(rec.get("suggested_components")) if isinstance(s, dict)]
+    # Drop the legacy alias keys so only the canonical key remains authoritative.
+    for legacy in ("split_required", "should_split"):
+        rec.pop(legacy, None)
+    rec[CANONICAL_SPLIT_KEY] = required
+    rec["reasons"] = reasons
+    rec["suggested_components"] = suggested
+    return rec

--- a/src/episteme_graph/agents/course_mapping/agent.py
+++ b/src/episteme_graph/agents/course_mapping/agent.py
@@ -181,6 +181,12 @@ class CourseMappingAgent:
         if not objectives:
             objectives.append("このコンポーネントが扱う主題を説明できる")
 
+        # Issue #418: link only derivations that belong to this topic's component
+        # (relevance by component linkage), never an indiscriminate全link.
+        linked_derivation_ids = [
+            str(d) for d in (_attr(component, "linked_derivation_ids") or []) if d
+        ]
+
         # Blackbox policy: derived from component_type
         blackbox_policy = self._default_blackbox_policy(comp_type, component)
 
@@ -191,6 +197,7 @@ class CourseMappingAgent:
             title=label or (comp_id or "Topic"),
             description=summary or label or "",
             linked_component_ids=[comp_id] if comp_id else [],
+            linked_derivation_ids=linked_derivation_ids,
             learning_objectives=objectives,
             prerequisite_concepts=prerequisite_concepts,
             introduced_concepts=introduced_concepts,

--- a/src/episteme_graph/agents/course_mapping/schema.py
+++ b/src/episteme_graph/agents/course_mapping/schema.py
@@ -10,6 +10,9 @@ class CourseTopicMapping:
     title: str
     description: str
     linked_component_ids: list[str] = field(default_factory=list)
+    # Issue #418: only derivations relevant to the topic's components are linked,
+    # determined from the linked components (not attached indiscriminately).
+    linked_derivation_ids: list[str] = field(default_factory=list)
     learning_objectives: list[str] = field(default_factory=list)
     prerequisite_concepts: list[str] = field(default_factory=list)
     introduced_concepts: list[str] = field(default_factory=list)

--- a/src/episteme_graph/agents/document_structure/schema.py
+++ b/src/episteme_graph/agents/document_structure/schema.py
@@ -86,6 +86,12 @@ class DocumentMetadata:
     # authors came from (grobid_tei / tex_author / pdf_front_matter / none),
     # with confidence + needs_review. None for legacy artifacts.
     author_extraction: dict | None = None
+    # TeX equation inventory (issue #420): a deterministic count of display math
+    # blocks + symbolic labels computed from the expanded TeX at ingest time, so
+    # completeness / coverage can detect TeX math without re-storing the (large)
+    # source. Shape: {"display_math_blocks": int, "labels": [str], "label_count": int}.
+    # None for non-TeX or legacy artifacts.
+    tex_equation_inventory: dict | None = None
 
 
 @dataclass

--- a/src/episteme_graph/agents/equation_semantics/agent.py
+++ b/src/episteme_graph/agents/equation_semantics/agent.py
@@ -252,6 +252,14 @@ class EquationSemanticsAgent:
             if progress_callback:
                 progress_callback(idx, total)
 
+        # Issue #416: guarantee completeness — every accepted/provisional candidate
+        # must resolve to a final EquationRecord. A candidate can be silently lost
+        # before reaching the LLM loop (e.g. its source block could not be
+        # resolved in build_llm_inputs). Recover such candidates with a reasoned
+        # provisional record instead of dropping them; downstream artifacts must
+        # never reference an equation id that has no record.
+        self._recover_dropped_candidates(reconstructable, records)
+
         _apply_content_hashes(records)
         result = EquationSemanticsResult(
             document_id=structure.document_id,
@@ -265,6 +273,37 @@ class EquationSemanticsAgent:
         fidelity_issues = apply_fidelity_guards(result)
         result.validation_issues = self._validator.validate(result, cartridge) + fidelity_issues
         return result
+
+    @staticmethod
+    def _recover_dropped_candidates(
+        reconstructable: list[EquationCandidate],
+        records: list[EquationRecord],
+    ) -> None:
+        """Create reasoned provisional records for unprocessed candidates (#416).
+
+        Any accepted/provisional candidate whose ``accepted_equation_id`` does not
+        resolve to a record in ``records`` is recovered with a minimal provisional
+        record so the candidate→record relation is complete and no downstream
+        stage can reference a missing equation.
+        """
+        record_ids = {r.equation_id for r in records}
+        for candidate in reconstructable:
+            if candidate.acceptance_status not in {"accepted", "provisional"}:
+                continue
+            accepted_id = candidate.accepted_equation_id
+            if accepted_id and accepted_id in record_ids:
+                continue
+            if "candidate_dropped_before_record" not in candidate.review_reason:
+                candidate.review_reason.append("candidate_dropped_before_record")
+            logger.warning(
+                "document=%s candidate=%s produced no equation record; "
+                "recovering as provisional (#416)",
+                candidate.document_id,
+                candidate.candidate_id,
+            )
+            provisional = _make_provisional_record(candidate)
+            record_ids.add(provisional.equation_id)
+            records.append(provisional)
 
     def _load_cartridge(self, cartridge_id: str | None) -> CartridgeContext | None:
         if not cartridge_id:

--- a/src/episteme_graph/agents/equation_semantics/schema.py
+++ b/src/episteme_graph/agents/equation_semantics/schema.py
@@ -98,6 +98,10 @@ CANDIDATE_REVIEW_REASONS = [
     # Issue #368: the candidate originates from a table / table-cell and must
     # not be auto-confirmed as a standalone independent equation.
     "table_derived_equation_candidate",
+    # Issue #416: an accepted/provisional candidate produced no EquationRecord
+    # (e.g. its source block could not be resolved). A reasoned provisional
+    # record is created instead of silently dropping the candidate.
+    "candidate_dropped_before_record",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/episteme_graph/agents/equation_semantics/validator.py
+++ b/src/episteme_graph/agents/equation_semantics/validator.py
@@ -50,7 +50,79 @@ class EquationSemanticsValidator:
             issues += self._check_cartridge_terms(record, cartridge)
 
         issues += self._check_duplicate_content_hashes(result.equations)
+        issues += self._check_candidate_record_completeness(result)
 
+        return issues
+
+    # ------------------------------------------------------------------
+    # Candidate → record completeness (issue #416)
+    # ------------------------------------------------------------------
+
+    def _check_candidate_record_completeness(
+        self, result: EquationSemanticsResult
+    ) -> list[ValidationIssue]:
+        """Guarantee accepted/provisional candidates resolve to a final record.
+
+        A candidate that was accepted/provisional but whose ``accepted_equation_id``
+        is empty or points at no EquationRecord is a hard error
+        (``accepted_candidate_missing_equation``): downstream claim / component /
+        derivation could otherwise reference an equation that does not exist. A
+        large silent shrink from candidate count to record count is also surfaced.
+
+        This check only runs on the full result (candidates + equations both
+        present); per-record partial validation passes an empty candidate list and
+        is unaffected.
+        """
+        candidates = result.equation_candidates
+        if not candidates:
+            return []
+
+        issues: list[ValidationIssue] = []
+        record_ids = {r.equation_id for r in result.equations}
+        accepted_like = [
+            c for c in candidates
+            if c.acceptance_status in ("accepted", "provisional")
+        ]
+        resolved = 0
+        for c in accepted_like:
+            accepted_id = c.accepted_equation_id
+            if not accepted_id:
+                issues.append(ValidationIssue(
+                    rule_id="accepted_candidate_missing_equation",
+                    severity="error",
+                    message=(
+                        f"{c.candidate_id} is {c.acceptance_status} but has no "
+                        "accepted_equation_id (no EquationRecord produced)"
+                    ),
+                    field=f"{c.candidate_id}.accepted_equation_id",
+                ))
+                continue
+            if accepted_id not in record_ids:
+                issues.append(ValidationIssue(
+                    rule_id="accepted_candidate_missing_equation",
+                    severity="error",
+                    message=(
+                        f"{c.candidate_id} accepted_equation_id "
+                        f"{accepted_id!r} does not resolve to any EquationRecord"
+                    ),
+                    field=f"{c.candidate_id}.accepted_equation_id",
+                ))
+                continue
+            resolved += 1
+
+        # Large silent shrink: many accepted/provisional candidates collapsed into
+        # far fewer records without each being individually accounted for above.
+        if accepted_like and resolved < len(accepted_like):
+            issues.append(ValidationIssue(
+                rule_id="equation_candidate_silent_shrink",
+                severity="warning",
+                message=(
+                    f"{len(accepted_like)} accepted/provisional candidate(s) but "
+                    f"only {resolved} resolved to an EquationRecord — "
+                    "candidate→record shrink requires review"
+                ),
+                field="equation_candidates",
+            ))
         return issues
 
     @staticmethod

--- a/src/tests/agents/component_assembly/test_split_recommendation_contract.py
+++ b/src/tests/agents/component_assembly/test_split_recommendation_contract.py
@@ -1,0 +1,216 @@
+"""Split-recommendation contract regression tests (#417).
+
+The granularity analyzer, ComponentRefiner, and the revision checkpoint planner
+must agree on a single split-recommendation schema whose canonical key is
+``required``. Legacy ``split_required`` / ``should_split`` keys must still be
+honored during the migration period.
+"""
+from episteme_graph.agents.component_assembly.granularity_analyzer import (
+    ComponentGranularityAnalyzer,
+)
+from episteme_graph.agents.component_assembly.component_refiner import ComponentRefiner
+from episteme_graph.agents.component_assembly.schema import (
+    COMPONENTS_VERSION,
+    ComponentAssemblyResult,
+    ComponentRecord,
+)
+from episteme_graph.agents.component_assembly.split_recommendation import (
+    CANONICAL_SPLIT_KEY,
+    normalize_split_recommendation,
+    split_is_required,
+)
+
+
+def _component(**kwargs):
+    defaults = dict(
+        component_id="comp_1",
+        component_type="RelationComponent",
+        label="component",
+        summary="summary",
+        inputs=[{"name": "input"}],
+        outputs=[{"name": "output"}],
+        preconditions=[],
+        cautions=[],
+        dependencies=[],
+        evidence_refs={},
+        reason="reason",
+        confidence=0.8,
+        review_notes=[],
+        responsibility_type="equation_system",
+        primary_operation="linearize",
+    )
+    defaults.update(kwargs)
+    return ComponentRecord(**defaults)
+
+
+def _result(components):
+    return ComponentAssemblyResult("doc", COMPONENTS_VERSION, None, components, [], [], 0.8)
+
+
+# ---------------------------------------------------------------------------
+# normalize / split_is_required
+# ---------------------------------------------------------------------------
+
+def test_split_is_required_reads_all_legacy_keys():
+    assert split_is_required({"required": True}) is True
+    assert split_is_required({"split_required": True}) is True
+    assert split_is_required({"should_split": True}) is True
+    assert split_is_required({"required": False}) is False
+    assert split_is_required({}) is False
+    assert split_is_required(None) is False
+
+
+def test_normalize_emits_canonical_key_and_drops_legacy_aliases():
+    norm = normalize_split_recommendation({"split_required": True, "reasons": ["x"]})
+    assert norm[CANONICAL_SPLIT_KEY] is True
+    assert "split_required" not in norm
+    assert "should_split" not in norm
+    assert norm["reasons"] == ["x"]
+    assert norm["suggested_components"] == []
+
+
+def test_normalize_should_split_alias():
+    norm = normalize_split_recommendation({"should_split": True})
+    assert norm["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Analyzer emits canonical schema
+# ---------------------------------------------------------------------------
+
+def test_analyzer_emits_canonical_required_key():
+    component = _component(
+        component_id="comp_big",
+        linked_equation_ids=[f"eq_{i}" for i in range(10)],
+        evidence_refs={"equation_ids": [f"eq_{i}" for i in range(10)]},
+    )
+    analyzed = ComponentGranularityAnalyzer().analyze(_result([component]))
+    rec = analyzed.components[0].split_recommendation
+    assert "required" in rec
+    assert "split_required" not in rec
+    assert rec["required"] is True
+
+
+def test_suggested_children_do_not_share_identical_equation_sets():
+    # A mixed-responsibility component must hand each suggested child *distinct*
+    # candidate equations (#417), not a duplicate of the whole set.
+    component = _component(
+        component_id="comp_mix",
+        responsibility_type="constraint",
+        primary_operation="construct model",
+        secondary_operations=["derive consequence"],
+        linked_equation_ids=["eq_1", "eq_2", "eq_3", "eq_4"],
+        internal_flow=[{"from": "eq_0", "relation": "derive", "to": "eq_1"}],
+    )
+    analyzed = ComponentGranularityAnalyzer().analyze(_result([component]))
+    suggested = analyzed.components[0].split_recommendation["suggested_components"]
+    assert len(suggested) >= 2
+    seen: set[str] = set()
+    for child in suggested:
+        eqs = set(child.get("linked_equation_ids") or [])
+        # No equation is duplicated across children.
+        assert not (eqs & seen), "suggested children share equations"
+        seen |= eqs
+
+
+# ---------------------------------------------------------------------------
+# derivation_step_count via equation overlap
+# ---------------------------------------------------------------------------
+
+class _Step:
+    def __init__(self, inputs, outputs, operation="derive"):
+        self.input_equation_ids = inputs
+        self.output_equation_ids = outputs
+        self.operation = operation
+
+
+class _Chain:
+    def __init__(self, steps, linked_component_ids=None):
+        self.steps = steps
+        self.linked_component_ids = linked_component_ids or []
+        self.derivation_id = "der_1"
+
+
+class _Derivations:
+    def __init__(self, chains):
+        self.chains = chains
+
+
+def test_derivation_step_count_uses_equation_overlap_when_link_empty():
+    # A derivation chain with no linked_component_ids still contributes steps to
+    # a component that shares its equations (#417).
+    component = _component(
+        component_id="comp_eq",
+        linked_equation_ids=["eq_1", "eq_2"],
+        evidence_refs={"equation_ids": ["eq_1", "eq_2"]},
+    )
+    derivations = _Derivations([
+        _Chain([
+            _Step(["eq_1"], ["eq_2"]),
+            _Step(["eq_2"], ["eq_3"]),
+        ], linked_component_ids=[]),
+    ])
+    analyzed = ComponentGranularityAnalyzer().analyze(
+        _result([component]), derivations=derivations
+    )
+    quality = analyzed.components[0].component_quality
+    assert quality["derivation_step_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# refiner: required:true never silently unprocessed
+# ---------------------------------------------------------------------------
+
+class _LLMInput:
+    def __init__(self, equations=None):
+        self.equations = equations or []
+        self.available_equations = []
+        self.available_claims = []
+        self.accepted_claims = []
+
+
+def test_required_split_is_never_silently_unprocessed():
+    component = _component(
+        component_id="comp_req",
+        component_type="ClaimBundleComponent",
+        linked_claim_ids=["claim_1"],
+        split_recommendation={
+            "required": True,
+            "reasons": ["responsibility type has more than one primary value"],
+            # Only one usable responsibility → cannot actually split.
+            "suggested_components": [
+                {"name": "Only def", "responsibility_type": "definition"}
+            ],
+        },
+    )
+    refined = ComponentRefiner().refine(
+        _result([component]), llm_input=_LLMInput(), derivations=None
+    )
+    validation = refined.component_refinement["refinement_validation"]
+    # It must be accounted for (review_required), not silently left unprocessed.
+    assert validation["unprocessed_split_required"] == []
+    assert "comp_req" in validation["review_required_refinements"]
+
+
+def test_legacy_split_required_key_still_drives_refiner():
+    component = _component(
+        component_id="comp_legacy",
+        linked_equation_ids=["eq_def", "eq_der"],
+        split_recommendation={
+            "split_required": True,  # legacy key only
+            "reasons": ["mixed"],
+            "suggested_components": [
+                {"name": "Def", "responsibility_type": "definition"},
+                {"name": "Der", "responsibility_type": "derivation"},
+            ],
+        },
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_der", "role": "transformation"},
+    ])
+    refined = ComponentRefiner().refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
+    ids = [c.component_id for c in refined.components]
+    assert "comp_legacy" not in ids  # it was split despite using the legacy key

--- a/src/tests/agents/course_mapping/test_agent.py
+++ b/src/tests/agents/course_mapping/test_agent.py
@@ -155,3 +155,20 @@ def test_empty_component_concepts_safe_fallback():
     topic = agent.run("doc_test", [comp]).topics[0]
     assert topic.introduced_concepts == []
     assert "zero-recoil limit" in topic.prerequisite_concepts
+
+
+def test_topic_links_only_its_components_derivations():
+    # Issue #418: a topic links the derivations of its own component, determined
+    # from the component (not attached indiscriminately).
+    comp = _make_component("comp_d")
+    comp.linked_derivation_ids = ["der_1", "der_2"]  # type: ignore[attr-defined]
+    result = CourseMappingAgent().run("doc", [comp])
+    topic = result.topics[0]
+    assert topic.linked_component_ids == ["comp_d"]
+    assert topic.linked_derivation_ids == ["der_1", "der_2"]
+
+
+def test_topic_has_no_derivations_when_component_has_none():
+    comp = _make_component("comp_nd")
+    result = CourseMappingAgent().run("doc", [comp])
+    assert result.topics[0].linked_derivation_ids == []

--- a/src/tests/agents/equation_semantics/test_equation_completeness.py
+++ b/src/tests/agents/equation_semantics/test_equation_completeness.py
@@ -1,0 +1,145 @@
+"""Candidate→EquationRecord completeness regression tests (#416).
+
+Accepted/provisional equation candidates must always resolve to a final
+EquationRecord; a candidate that produced no record is recovered as a reasoned
+provisional record (never silently dropped), and any unresolved
+``accepted_equation_id`` is a hard validation error.
+"""
+from episteme_graph.agents.equation_semantics.agent import (
+    EquationSemanticsAgent,
+    _make_provisional_record,
+)
+from episteme_graph.agents.equation_semantics.schema import (
+    EquationCandidate,
+    EquationSemanticsResult,
+)
+from episteme_graph.agents.equation_semantics.validator import (
+    EquationSemanticsValidator,
+)
+
+VALIDATOR = EquationSemanticsValidator()
+
+
+def _candidate(cid, acc_status="accepted", accepted_equation_id=None, block_id="blk_1"):
+    return EquationCandidate(
+        candidate_id=cid,
+        document_id="doc",
+        source_location={"page": 1, "section_id": "s1", "block_id": block_id, "bbox": []},
+        raw_text="N = a + b (1)",
+        matched_label="1",
+        detection_method=["document_structure_equation_block"],
+        candidate_score=1.0,
+        extraction_status="partial",
+        acceptance_status=acc_status,
+        accepted_equation_id=accepted_equation_id,
+        needs_math_review=True,
+        review_reason=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validator: hard error on unresolved accepted_equation_id
+# ---------------------------------------------------------------------------
+
+def test_accepted_candidate_without_equation_id_is_hard_error():
+    candidate = _candidate("cand_1", acc_status="accepted", accepted_equation_id=None)
+    result = EquationSemanticsResult("doc", None, [candidate], [])
+    issues = VALIDATOR.validate(result)
+    assert any(
+        i.rule_id == "accepted_candidate_missing_equation" and i.severity == "error"
+        for i in issues
+    )
+
+
+def test_accepted_candidate_with_dangling_equation_id_is_hard_error():
+    candidate = _candidate("cand_1", acc_status="accepted", accepted_equation_id="eq_ghost")
+    # A record exists, but not the one the candidate points at.
+    record = _make_provisional_record(_candidate("cand_other"))
+    result = EquationSemanticsResult("doc", None, [candidate], [record])
+    issues = VALIDATOR.validate(result)
+    assert any(
+        i.rule_id == "accepted_candidate_missing_equation" and i.severity == "error"
+        for i in issues
+    )
+
+
+def test_provisional_candidate_must_resolve_to_record():
+    candidate = _candidate("cand_1", acc_status="provisional", accepted_equation_id=None)
+    result = EquationSemanticsResult("doc", None, [candidate], [])
+    issues = VALIDATOR.validate(result)
+    assert any(i.rule_id == "accepted_candidate_missing_equation" for i in issues)
+
+
+def test_resolved_candidate_has_no_completeness_error():
+    candidate = _candidate("cand_1", acc_status="accepted")
+    record = _make_provisional_record(candidate)  # sets accepted_equation_id
+    result = EquationSemanticsResult("doc", None, [candidate], [record])
+    issues = VALIDATOR.validate(result)
+    assert not any(
+        i.rule_id == "accepted_candidate_missing_equation" for i in issues
+    )
+
+
+def test_rejected_candidate_is_not_required_to_resolve():
+    # rejected / context_only candidates never need a record.
+    for status in ("rejected", "needs_merge", "context_only"):
+        candidate = _candidate("cand_x", acc_status=status, accepted_equation_id=None)
+        result = EquationSemanticsResult("doc", None, [candidate], [])
+        issues = VALIDATOR.validate(result)
+        assert not any(
+            i.rule_id == "accepted_candidate_missing_equation" for i in issues
+        ), status
+
+
+# ---------------------------------------------------------------------------
+# Agent recovery: dropped candidates become reasoned provisional records
+# ---------------------------------------------------------------------------
+
+def test_recover_dropped_candidate_creates_provisional_record():
+    # A reconstructable accepted candidate that produced no record (its source
+    # block could not be resolved) is recovered, not silently dropped (#416).
+    dropped = _candidate("cand_dropped", acc_status="accepted", accepted_equation_id=None)
+    records = []
+    EquationSemanticsAgent._recover_dropped_candidates([dropped], records)
+
+    assert len(records) == 1
+    assert dropped.accepted_equation_id == records[0].equation_id
+    assert "candidate_dropped_before_record" in dropped.review_reason
+    # The recovered record is a non-source-backed provisional record.
+    assert records[0].confidence_policy.can_support_claim is False
+
+
+def test_recovery_then_validation_is_complete():
+    dropped = _candidate("cand_dropped", acc_status="provisional", accepted_equation_id=None)
+    records = []
+    EquationSemanticsAgent._recover_dropped_candidates([dropped], records)
+    result = EquationSemanticsResult("doc", None, [dropped], records)
+    issues = VALIDATOR.validate(result)
+    assert not any(
+        i.rule_id == "accepted_candidate_missing_equation" for i in issues
+    )
+
+
+def test_already_resolved_candidate_is_not_duplicated():
+    candidate = _candidate("cand_ok", acc_status="accepted")
+    record = _make_provisional_record(candidate)  # sets accepted_equation_id
+    records = [record]
+    EquationSemanticsAgent._recover_dropped_candidates([candidate], records)
+    # No duplicate record was created.
+    assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Silent shrink detection
+# ---------------------------------------------------------------------------
+
+def test_large_silent_shrink_is_reported():
+    # Five accepted candidates but only one resolves to a record.
+    candidates = [
+        _candidate(f"cand_{i}", acc_status="accepted", accepted_equation_id=None)
+        for i in range(5)
+    ]
+    resolved = _make_provisional_record(candidates[0])
+    result = EquationSemanticsResult("doc", None, candidates, [resolved])
+    issues = VALIDATOR.validate(result)
+    assert any(i.rule_id == "equation_candidate_silent_shrink" for i in issues)

--- a/src/tests/agents/equation_semantics/test_validator.py
+++ b/src/tests/agents/equation_semantics/test_validator.py
@@ -92,7 +92,12 @@ def _record(
     )
 
 
-def _candidate(cid: str = "eqcand_blk_e1", ext_status: str = "complete", acc_status: str = "accepted") -> EquationCandidate:
+def _candidate(
+    cid: str = "eqcand_blk_e1",
+    ext_status: str = "complete",
+    acc_status: str = "accepted",
+    accepted_equation_id: str | None = "eq_1_1",
+) -> EquationCandidate:
     return EquationCandidate(
         candidate_id=cid,
         document_id="doc_test",
@@ -103,6 +108,8 @@ def _candidate(cid: str = "eqcand_blk_e1", ext_status: str = "complete", acc_sta
         candidate_score=1.0,
         extraction_status=ext_status,
         acceptance_status=acc_status,
+        # An accepted/provisional candidate resolves to its EquationRecord (#416).
+        accepted_equation_id=accepted_equation_id,
         needs_math_review=False,
         review_reason=[],
     )

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1508,3 +1508,101 @@ def test_resolved_claim_refs_produce_no_leak_warning():
         w.code not in ("PROVISIONAL_CLAIM_REF_IN_ARTIFACT", "UNRESOLVED_CLAIM_REF_IN_ARTIFACT")
         for w in result.warnings
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #418: cross-artifact canonicalization / integrity
+# ---------------------------------------------------------------------------
+
+class _CourseTopicWithDerivations:
+    def __init__(self, linked_component_ids=None, linked_derivation_ids=None):
+        self.linked_component_ids = linked_component_ids or []
+        self.linked_derivation_ids = linked_derivation_ids or []
+
+
+def test_graph_node_parent_component_must_resolve():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [
+            {"component_id": "comp_main", "label": "Main", "component_type": "TheoryOperationNode"},
+            {"component_id": "op_1", "label": "op", "component_type": "EquationOperationNode",
+             "parent_component_id": "comp_ghost"},
+        ],
+        "edges": [],
+    })
+    result = _run_gate(artifacts=artifacts)
+    codes = {e.code for e in result.errors}
+    assert "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID" in codes
+    bad = next(e for e in result.errors if e.code == "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID")
+    assert bad.target_type == "graph_node"
+    assert bad.target_id == "op_1"
+
+
+def test_graph_node_member_component_must_resolve():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [
+            {"component_id": "comp_main", "label": "Main", "component_type": "TheoryOperationNode",
+             "member_component_ids": ["op_missing"]},
+        ],
+        "edges": [],
+    })
+    result = _run_gate(artifacts=artifacts)
+    assert "COMPONENT_GRAPH_MEMBER_COMPONENT_INVALID" in {e.code for e in result.errors}
+
+
+def test_graph_node_valid_parent_and_member_pass():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [
+            {"component_id": "comp_main", "label": "Main", "component_type": "TheoryOperationNode",
+             "member_component_ids": ["op_1"]},
+            {"component_id": "op_1", "label": "op", "component_type": "EquationOperationNode",
+             "parent_component_id": "comp_main"},
+        ],
+        "edges": [],
+    })
+    result = _run_gate(artifacts=artifacts)
+    codes = {e.code for e in result.errors}
+    assert "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID" not in codes
+    assert "COMPONENT_GRAPH_MEMBER_COMPONENT_INVALID" not in codes
+
+
+def test_course_topic_unrelated_derivation_is_flagged():
+    component = _ComponentRecord(component_id="comp_1")
+    component.linked_derivation_ids = ["der_1"]
+    comp_result = _ComponentResult([component])
+    course = _CourseMappingResult([
+        _CourseTopicWithDerivations(
+            linked_component_ids=["comp_1"],
+            linked_derivation_ids=["der_1", "der_unrelated"],
+        )
+    ])
+    result = _run_gate(component_result=comp_result, course_mapping=course)
+    unrelated = [w for w in result.warnings if w.code == "COURSE_TOPIC_UNRELATED_DERIVATION"]
+    assert len(unrelated) == 1
+    assert unrelated[0].target_type == "derivation"
+    assert unrelated[0].target_id == "der_unrelated"
+
+
+def test_course_topic_relevant_derivation_passes():
+    component = _ComponentRecord(component_id="comp_1")
+    component.linked_derivation_ids = ["der_1"]
+    comp_result = _ComponentResult([component])
+    course = _CourseMappingResult([
+        _CourseTopicWithDerivations(
+            linked_component_ids=["comp_1"],
+            linked_derivation_ids=["der_1"],
+        )
+    ])
+    result = _run_gate(component_result=comp_result, course_mapping=course)
+    assert not any(w.code == "COURSE_TOPIC_UNRELATED_DERIVATION" for w in result.warnings)
+
+
+def test_validation_entry_serializes_target_fields():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [{"component_id": "comp_main", "label": "Main",
+                   "component_type": "TheoryOperationNode", "member_component_ids": ["x"]}],
+        "edges": [],
+    })
+    result = _run_gate(artifacts=artifacts)
+    payload = result.to_dict()
+    entry = next(e for e in payload["errors"] if e["code"] == "COMPONENT_GRAPH_MEMBER_COMPONENT_INVALID")
+    assert "target_type" in entry and "target_id" in entry


### PR DESCRIPTION
## Summary

This PR addresses three critical data-integrity issues across the document processing pipeline:

1. **Issue #417**: Unify split-recommendation schema across component assembly stages (granularity analyzer, refiner, checkpoint planner) to use a canonical `required` key, ensuring split signals are never silently dropped due to key mismatches.

2. **Issue #416**: Guarantee equation-artifact completeness by detecting when accepted/provisional candidates fail to resolve to final EquationRecords, and recover dropped candidates with reasoned provisional records instead of silently losing them.

3. **Issue #418**: Add cross-artifact integrity checks for component graph nodes and course topic derivation links, with explicit `target_type`/`target_id` fields in validation entries for precise error attribution.

## Key Changes

### Split-Recommendation Canonicalization (#417)
- **New module** `src/episteme_graph/agents/component_assembly/split_recommendation.py`: Single source of truth for split-recommendation schema with `CANONICAL_SPLIT_KEY = "required"`. Provides `split_is_required()` (reads all legacy keys) and `normalize_split_recommendation()` (always emits canonical shape).
- **ComponentGranularityAnalyzer**: Now calls `normalize_split_recommendation()` when building split recommendations, ensuring the canonical `required` key is always present.
- **ComponentRefiner**: Uses `split_is_required()` to read split state, honoring both canonical and legacy keys.
- **RevisionCheckpointPlanner** (`backend/core/document_pipeline/revision/checkpoints.py`): Imports and uses `split_is_required()` to detect split signals, fixing the silent-skip bug where `required: true` was ignored.
- **RevisionInventory** (`backend/core/document_pipeline/revision/inventory.py`): Normalizes stored component split recommendations to canonical schema.
- **New regression tests** (`src/tests/agents/component_assembly/test_split_recommendation_contract.py`): Comprehensive coverage of legacy key handling, analyzer/refiner/planner agreement, and the mixed-responsibility partitioning fix.

### Equation Completeness & Recovery (#416)
- **EquationSemanticsAgent** (`src/episteme_graph/agents/equation_semantics/agent.py`): New `_recover_dropped_candidates()` method creates reasoned provisional records for accepted/provisional candidates that failed to produce a final EquationRecord (e.g., source block unresolved). Candidates are marked with `candidate_dropped_before_record` review reason.
- **EquationSemanticsValidator** (`src/episteme_graph/agents/equation_semantics/validator.py`): New `_check_candidate_record_completeness()` enforces hard errors on unresolved `accepted_equation_id` and detects large silent shrinks from candidate to record counts.
- **TeX equation inventory** (`backend/core/document_pipeline/completeness.py`): New `tex_equation_inventory()` counts display math blocks and symbolic `\label{...}` targets; new `analyze_equation_artifact_coverage()` compares TeX math / candidates / records to catch the #416 silent pass (pages=0 + math but no registry).
- **ExportValidationGate** (`backend/core/document_pipeline/export_validation_gate.py`): New `_refresh_equation_artifact_coverage()` recomputes coverage on precomputed completeness reports (orchestrator runs before equation_semantics). Adds `DOCUMENT_EQUATION_ARTIFACT_COVERAGE_INCOMPLETE` warning.
- **New regression tests** (`src/tests/agents/equation_semantics/test_equation_completeness.py`): Validator hard errors, recovery flow, and completeness guarantees.
- **Gate tests** (`backend/tests/test_document_completeness.py`): TeX inventory, pages=0 silent-pass detection, and coverage refresh.

### Cross-Artifact Integrity (#418)
- **ValidationEntry** (`backend/core/document_pipeline/export_validation_gate.py`): New `target_type` / `target_id` fields to store the concrete entity a finding is about, enabling revision inventory to resolve it without parsing JSON paths.

https://claude.ai/code/session_017mSmMrUhDbR9nMmcAq2UE4