### PR TITLE
Route component links by responsibility and equation role (#421)

### DIFF
--- a/backend/api/routes/export.py
+++ b/backend/api/routes/export.py
@@ -344,6 +344,18 @@ def _resolve_artifact_first_graph(
     Returns ``{"component_graph", "operation_graph", "component_operation_links"}``.
     """
     known_component_ids = {str(c.get("component_id")) for c in components if c.get("component_id")}
+    component_aliases: dict[str, str] = {}
+    for component in components:
+        canonical = str(component.get("component_id") or "")
+        if not canonical:
+            continue
+        for alias in (
+            list(component.get("legacy_ids") or [])
+            + [component.get("agent_component_id"), component.get("legacy_component_id")]
+        ):
+            alias = str(alias or "")
+            if alias and alias != canonical:
+                component_aliases[alias] = canonical
 
     component_nodes: list[dict] = []
     component_edges: list[dict] = []
@@ -363,7 +375,10 @@ def _resolve_artifact_first_graph(
         artifact = (artifacts_by_doc.get(doc_id) or {}).get("component_graph")
         if artifact:
             _merge(build_component_graph_export(
-                artifact, document_id=doc_id, known_component_ids=known_component_ids
+                artifact,
+                document_id=doc_id,
+                known_component_ids=known_component_ids,
+                component_aliases=component_aliases,
             ))
             continue
         # Fallback (issues #390 / #400): this document has no current-run
@@ -380,7 +395,10 @@ def _resolve_artifact_first_graph(
         db_graph = load_db_graph(doc_id) if callable(load_db_graph) else None
         if isinstance(db_graph, dict) and (db_graph.get("nodes") or db_graph.get("edges")):
             _merge(build_component_graph_export(
-                db_graph, document_id=doc_id, known_component_ids=known_component_ids
+                db_graph,
+                document_id=doc_id,
+                known_component_ids=known_component_ids,
+                component_aliases=component_aliases,
             ))
 
     # Back-compat: when no per-document loader is supplied but every document fell
@@ -388,7 +406,10 @@ def _resolve_artifact_first_graph(
     # do not provide ``load_db_graph`` still export the DB graph (issue #387 split).
     if any_db_fallback and not callable(load_db_graph) and not component_nodes and not operation_nodes:
         return build_component_graph_export(
-            db_component_graph, document_id="", known_component_ids=known_component_ids
+            db_component_graph,
+            document_id="",
+            known_component_ids=known_component_ids,
+            component_aliases=component_aliases,
         )
     return {
         "component_graph": {
@@ -2050,6 +2071,26 @@ def _validate_export_references(
     # operation nodes is incomplete even if extraction succeeded, and equations /
     # evidence should be able to reach a claim/component through operation links.
     op_nodes = [n for n in operation_graph.get("nodes", []) or [] if isinstance(n, dict)]
+    for idx, node in enumerate(op_nodes):
+        operation_id = str(node.get("operation_id") or "")
+        parent_id = str(node.get("parent_component_id") or "")
+        unresolved_parent = str(node.get("unresolved_parent_component_id") or "")
+        if parent_id and parent_id not in component_ids:
+            add(
+                "OPERATION_PARENT_COMPONENT_INVALID",
+                f"operation {operation_id!r} parent_component_id {parent_id!r} is not canonical",
+                "graph/operation_graph.json",
+                f"$.nodes[{idx}].parent_component_id",
+                parent_id,
+            )
+        if unresolved_parent:
+            review(
+                "OPERATION_PARENT_COMPONENT_UNRESOLVED",
+                f"operation {operation_id!r} could not resolve parent component {unresolved_parent!r}",
+                "graph/operation_graph.json",
+                f"$.nodes[{idx}].unresolved_parent_component_id",
+                unresolved_parent,
+            )
     if op_nodes:
         linked_op_ids: set[str] = set()
         for edge in operation_graph.get("edges", []) or []:

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -1640,6 +1640,16 @@ def build_component_graph_export(
             (identifier for identifier in identifiers if identifier in known_component_ids),
             "",
         )
+        provenance_candidates = _ordered_unique_str(
+            value
+            for value in (
+                [n.get("representative_component_id")]
+                + list(n.get("linked_component_ids") or [])
+            )
+            if value and str(value) in known_component_ids
+        )
+        if not canonical and len(provenance_candidates) == 1:
+            canonical = provenance_candidates[0]
         if not known_component_ids and _graph_node_is_component(n, known_component_ids):
             canonical = str(
                 n.get("component_id") or n.get("node_id") or n.get("id") or ""
@@ -1667,34 +1677,33 @@ def build_component_graph_export(
         if not known_component_ids and _graph_node_is_component(n, known_component_ids):
             canonical_component_id = node_id
         if canonical_component_id:
-            if canonical_component_id in component_node_ids:
-                continue
-            component_node_ids.add(canonical_component_id)
-            legacy_ids = []
-            for value in _ordered_unique_str(
-                value
-                for value in [
-                    node_id,
-                    n.get("agent_component_id"),
-                    n.get("legacy_component_id"),
-                    *(n.get("legacy_ids") or []),
-                ]
-                if value
-            ):
-                if value != canonical_component_id:
-                    legacy_ids.append(value)
-            component_nodes.append({
-                "node_id": canonical_component_id,
-                "node_type": "component",
-                "label": n.get("label") or n.get("name") or "",
-                "component_type": n.get("component_type") or "",
-                "review_status": n.get("review_status") or "teacher_review_required",
-                "source_backing_status": n.get("source_backing_status") or "",
-                "graph_layer": n.get("graph_layer") or "main",
-                "legacy_ids": legacy_ids,
-                "member_component_ids": list(n.get("member_component_ids") or []),
-                "detail_node_ids": list(n.get("detail_node_ids") or []),
-            })
+            if canonical_component_id not in component_node_ids:
+                component_node_ids.add(canonical_component_id)
+                legacy_ids = []
+                for value in _ordered_unique_str(
+                    value
+                    for value in [
+                        node_id,
+                        n.get("agent_component_id"),
+                        n.get("legacy_component_id"),
+                        *(n.get("legacy_ids") or []),
+                    ]
+                    if value
+                ):
+                    if value != canonical_component_id:
+                        legacy_ids.append(value)
+                component_nodes.append({
+                    "node_id": canonical_component_id,
+                    "node_type": "component",
+                    "label": n.get("label") or n.get("name") or "",
+                    "component_type": n.get("component_type") or "",
+                    "review_status": n.get("review_status") or "teacher_review_required",
+                    "source_backing_status": n.get("source_backing_status") or "",
+                    "graph_layer": n.get("graph_layer") or "main",
+                    "legacy_ids": legacy_ids,
+                    "member_component_ids": list(n.get("member_component_ids") or []),
+                    "detail_node_ids": list(n.get("detail_node_ids") or []),
+                })
             # Component → operation links (issue #387): a main node aggregates
             # equation_detail nodes via member_component_ids / detail_node_ids.
             for op_id in list(n.get("member_component_ids") or []) + list(n.get("detail_node_ids") or []):

--- a/backend/api/routes/export_artifacts.py
+++ b/backend/api/routes/export_artifacts.py
@@ -1454,6 +1454,18 @@ def build_components_export(
             "constraint_equation_ids": [str(v) for v in (r.get("constraint_equation_ids") or []) if v],
             "definition_equation_ids": [str(v) for v in (r.get("definition_equation_ids") or []) if v],
             "review_required_equation_ids": [str(v) for v in (r.get("review_required_equation_ids") or []) if v],
+            # Canonical component endpoint resolution (#422). These identifiers
+            # are provenance aliases only; component_id remains authoritative.
+            "legacy_ids": _ordered_unique_str(
+                [
+                    value
+                    for value in (
+                        list(r.get("legacy_ids") or [])
+                        + [r.get("agent_component_id"), r.get("legacy_component_id")]
+                    )
+                    if value
+                ]
+            ),
         })
     return out
 
@@ -1578,6 +1590,7 @@ def build_component_graph_export(
     *,
     document_id: str,
     known_component_ids: set[str] | None = None,
+    component_aliases: dict[str, str] | None = None,
 ) -> dict:
     """Split a ``component_graph`` artifact into separate component / operation graphs.
 
@@ -1594,6 +1607,46 @@ def build_component_graph_export(
     raw_nodes = cg.get("nodes") if isinstance(cg.get("nodes"), list) else []
     raw_edges = cg.get("edges") if isinstance(cg.get("edges"), list) else []
     known_component_ids = known_component_ids or set()
+    alias_to_component: dict[str, str] = {
+        str(component_id): str(component_id)
+        for component_id in known_component_ids
+        if component_id
+    }
+    for alias, canonical in (component_aliases or {}).items():
+        alias = str(alias or "")
+        canonical = str(canonical or "")
+        if alias and canonical in known_component_ids:
+            alias_to_component[alias] = canonical
+
+    # Graph nodes may carry the canonical DB id alongside an agent/legacy id.
+    # Build the full alias map before classifying operations so parent references
+    # can be canonicalized regardless of node order.
+    for n in raw_nodes:
+        if not isinstance(n, dict):
+            continue
+        identifiers = _ordered_unique_str(
+            value
+            for value in [
+                n.get("component_id"),
+                n.get("node_id"),
+                n.get("id"),
+                n.get("agent_component_id"),
+                n.get("legacy_component_id"),
+                *(n.get("legacy_ids") or []),
+            ]
+            if value
+        )
+        canonical = next(
+            (identifier for identifier in identifiers if identifier in known_component_ids),
+            "",
+        )
+        if not known_component_ids and _graph_node_is_component(n, known_component_ids):
+            canonical = str(
+                n.get("component_id") or n.get("node_id") or n.get("id") or ""
+            )
+        if canonical:
+            for identifier in identifiers:
+                alias_to_component[identifier] = canonical
 
     component_node_ids: set[str] = set()
     operation_node_ids: set[str] = set()
@@ -1610,17 +1663,28 @@ def build_component_graph_export(
         node_id = _node_id(n)
         if not node_id:
             continue
-        if _graph_node_is_component(n, known_component_ids):
-            if node_id in component_node_ids:
+        canonical_component_id = alias_to_component.get(node_id, "")
+        if not known_component_ids and _graph_node_is_component(n, known_component_ids):
+            canonical_component_id = node_id
+        if canonical_component_id:
+            if canonical_component_id in component_node_ids:
                 continue
-            component_node_ids.add(node_id)
+            component_node_ids.add(canonical_component_id)
             legacy_ids = []
-            for key in ("agent_component_id", "legacy_component_id"):
-                value = n.get(key)
-                if value and str(value) != node_id:
-                    legacy_ids.append(str(value))
+            for value in _ordered_unique_str(
+                value
+                for value in [
+                    node_id,
+                    n.get("agent_component_id"),
+                    n.get("legacy_component_id"),
+                    *(n.get("legacy_ids") or []),
+                ]
+                if value
+            ):
+                if value != canonical_component_id:
+                    legacy_ids.append(value)
             component_nodes.append({
-                "node_id": node_id,
+                "node_id": canonical_component_id,
                 "node_type": "component",
                 "label": n.get("label") or n.get("name") or "",
                 "component_type": n.get("component_type") or "",
@@ -1635,7 +1699,10 @@ def build_component_graph_export(
             # equation_detail nodes via member_component_ids / detail_node_ids.
             for op_id in list(n.get("member_component_ids") or []) + list(n.get("detail_node_ids") or []):
                 if op_id:
-                    links.append({"component_id": node_id, "operation_id": str(op_id)})
+                    links.append({
+                        "component_id": canonical_component_id,
+                        "operation_id": str(op_id),
+                    })
         else:
             if node_id in operation_node_ids:
                 continue
@@ -1677,6 +1744,12 @@ def build_component_graph_export(
             )
             if review_required_value and not node_review_reasons:
                 node_review_reasons.append("operation_node_missing_equation_link")
+            raw_parent = str(n.get("parent_component_id") or "")
+            canonical_parent = alias_to_component.get(raw_parent, "")
+            if raw_parent and not canonical_parent:
+                review_required_value = True
+                if "unresolved_parent_component" not in node_review_reasons:
+                    node_review_reasons.append("unresolved_parent_component")
             operation_nodes.append({
                 "operation_id": node_id,
                 "node_type": "operation",
@@ -1689,14 +1762,19 @@ def build_component_graph_export(
                 "source_backing_status": n.get("source_backing_status") or "",
                 "review_status": n.get("review_status") or "teacher_review_required",
                 "review_required": review_required_value,
-                "parent_component_id": str(n.get("parent_component_id") or ""),
+                "parent_component_id": canonical_parent,
+                "unresolved_parent_component_id": (
+                    raw_parent if raw_parent and not canonical_parent else ""
+                ),
                 "linked_equation_ids": list(n.get("linked_equation_ids") or []),
                 "linked_derivation_ids": list(n.get("linked_derivation_ids") or []),
                 "review_reasons": node_review_reasons,
             })
-            parent = str(n.get("parent_component_id") or "")
-            if parent:
-                links.append({"component_id": parent, "operation_id": node_id})
+            if canonical_parent:
+                links.append({
+                    "component_id": canonical_parent,
+                    "operation_id": node_id,
+                })
 
     component_edges: list[dict] = []
     operation_edges: list[dict] = []
@@ -1704,8 +1782,10 @@ def build_component_graph_export(
         if not isinstance(e, dict):
             continue
         evidence = e.get("evidence") if isinstance(e.get("evidence"), dict) else {}
-        source = str(e.get("source_component_id") or e.get("source") or e.get("from") or "")
-        target = str(e.get("target_component_id") or e.get("target") or e.get("to") or "")
+        raw_source = str(e.get("source_component_id") or e.get("source") or e.get("from") or "")
+        raw_target = str(e.get("target_component_id") or e.get("target") or e.get("to") or "")
+        source = alias_to_component.get(raw_source, raw_source)
+        target = alias_to_component.get(raw_target, raw_target)
         edge = {
             "edge_id": e.get("edge_id") or f"component_edge_{i+1:04d}",
             "source": source,
@@ -1724,6 +1804,8 @@ def build_component_graph_export(
     seen_links: set[tuple[str, str]] = set()
     unique_links: list[dict] = []
     for link in links:
+        if known_component_ids and link["component_id"] not in known_component_ids:
+            continue
         key = (link["component_id"], link["operation_id"])
         if key in seen_links:
             continue

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -82,6 +82,10 @@ def _empty_refinement_validation() -> dict:
         "unchanged_components": [],
         "failed_refinements": [],
         "review_required_refinements": [],
+        # Components whose split was required but were neither split, failed, nor
+        # review_required — a silent contract violation that must hard-block
+        # publish (#421).
+        "unprocessed_split_required": [],
         "unassigned_links": [],
         "dangling_component_refs": [],
         "teaching_granularity_warnings": [],
@@ -1283,6 +1287,26 @@ class ExportValidationGate:
                 artifact="component_assembly",
                 path=f"$.component_refinement[{original_id}]",
                 source_stage="export_validation",
+                target_type="component",
+                target_id=str(original_id),
+            ))
+
+        # A component whose split was required but was left unprocessed (neither
+        # split, failed, nor review_required) is a silent contract violation
+        # (#421): it must be a hard error so it can never reach publish-ready.
+        for original_id in result["unprocessed_split_required"]:
+            errors.append(ValidationEntry(
+                code="COMPONENT_REFINEMENT_REQUIRED_BUT_UNPROCESSED",
+                message=(
+                    f"component {original_id!r} requires a split but was left "
+                    "unprocessed (not split, failed, or review_required); it "
+                    "cannot be published in this state"
+                ),
+                artifact="component_assembly",
+                path="$.component_refinement.refinement_validation.unprocessed_split_required",
+                source_stage="export_validation",
+                target_type="component",
+                target_id=str(original_id),
             ))
 
         for entry in result["dangling_component_refs"]:
@@ -1297,6 +1321,8 @@ class ExportValidationGate:
                 artifact="component_assembly",
                 path=f"$.component_refinement.component_graph_updates.unresolved_edges",
                 source_stage="export_validation",
+                target_type="component",
+                target_id=str(owner),
             ))
 
         for entry in result["unassigned_links"]:
@@ -1327,6 +1353,8 @@ class ExportValidationGate:
                 artifact="component_assembly",
                 path=f"$.component_refinement[{original_id}]",
                 source_stage="export_validation",
+                target_type="component",
+                target_id=str(original_id),
             ))
 
         return result

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -510,7 +510,9 @@ class ExportValidationGate:
             self._check_dsl_edges(dsl, errors, warnings)
 
         # 5. Component graph export structure
-        self._check_component_graph_artifact(artifacts, errors, warnings)
+        self._check_component_graph_artifact(
+            artifacts, component_result, errors, warnings
+        )
 
         # 6. Required artifact presence
         self._check_required_artifacts(artifacts, errors)
@@ -843,6 +845,8 @@ class ExportValidationGate:
                     artifact=stage,
                     path=path,
                     source_stage=stage,
+                    target_type=issue.get("target_type"),
+                    target_id=issue.get("target_id"),
                 )
 
                 if code in _NEEDS_REVIEW_RULE_IDS:
@@ -930,23 +934,35 @@ class ExportValidationGate:
                     ))
 
             dsl_refs = refs.get("dsl_refs") or {}
-            for nid in dsl_refs.get("node_ids") or []:
-                if known_dsl_node_ids and nid not in known_dsl_node_ids:
+            dsl_node_refs = _ordered_unique(
+                list(dsl_refs.get("node_ids") or [])
+                + list(getattr(component, "linked_dsl_node_ids", []) or [])
+            )
+            for nid in dsl_node_refs:
+                if nid not in known_dsl_node_ids:
                     errors.append(ValidationEntry(
                         code="UNRESOLVED_DSL_NODE_ID",
                         message=f"component {comp_id!r} references missing DSL node {nid!r}",
                         artifact="component_assembly",
                         path=f"$.components[{comp_id}].evidence_refs.dsl_refs.node_ids",
                         source_stage="export_validation",
+                        target_type="dsl_node",
+                        target_id=str(nid),
                     ))
-            for eid in dsl_refs.get("edge_ids") or []:
-                if known_dsl_edge_ids and eid not in known_dsl_edge_ids:
+            dsl_edge_refs = _ordered_unique(
+                list(dsl_refs.get("edge_ids") or [])
+                + list(getattr(component, "linked_dsl_edge_ids", []) or [])
+            )
+            for eid in dsl_edge_refs:
+                if eid not in known_dsl_edge_ids:
                     errors.append(ValidationEntry(
                         code="UNRESOLVED_DSL_EDGE_ID",
                         message=f"component {comp_id!r} references missing DSL edge {eid!r}",
                         artifact="component_assembly",
                         path=f"$.components[{comp_id}].evidence_refs.dsl_refs.edge_ids",
                         source_stage="export_validation",
+                        target_type="dsl_edge",
+                        target_id=str(eid),
                     ))
 
             # Warn on summary-only (no claim or evidence)
@@ -2061,6 +2077,7 @@ class ExportValidationGate:
     def _check_component_graph_artifact(
         self,
         artifacts: dict,
+        component_result,
         errors: list,
         warnings: list,
     ) -> None:
@@ -2071,6 +2088,26 @@ class ExportValidationGate:
         edges = graph.get("edges") or []
         if not isinstance(nodes, list) or not isinstance(edges, list):
             return
+
+        canonical_component_ids = {
+            str(getattr(component, "component_id", "") or "")
+            for component in (getattr(component_result, "components", []) or [])
+            if getattr(component, "component_id", None)
+        }
+        component_aliases = {component_id: component_id for component_id in canonical_component_ids}
+        for component in (getattr(component_result, "components", []) or []):
+            canonical = str(getattr(component, "component_id", "") or "")
+            for alias in (
+                list(getattr(component, "legacy_ids", []) or [])
+                + [
+                    getattr(component, "agent_component_id", None),
+                    getattr(component, "legacy_component_id", None),
+                ]
+            ):
+                alias = str(alias or "")
+                if alias and canonical:
+                    component_aliases[alias] = canonical
+        canonical_registry_available = component_result is not None
 
         node_ids: set[str] = set()
         for node in nodes:
@@ -2092,21 +2129,34 @@ class ExportValidationGate:
                     target_type="graph_node",
                     target_id=comp_id or None,
                 ))
-            # Issue #418: a detail / operation node must point at an existing
-            # parent node in the same graph (parent_component_id integrity).
+            # Issue #422: graph membership alone is insufficient. An operation
+            # parent must resolve to a canonical component artifact (aliases are
+            # accepted and normalized by export), never an aggregate theory node.
+            # When this validator is invoked without a component_result (legacy
+            # standalone graph checks), retain the older graph-membership check.
             parent_id = str(node.get("parent_component_id") or "")
-            if parent_id and parent_id not in node_ids:
+            parent_known = (
+                parent_id in component_aliases
+                if canonical_registry_available
+                else parent_id in node_ids
+            )
+            if parent_id and not parent_known:
                 errors.append(ValidationEntry(
                     code="COMPONENT_GRAPH_PARENT_COMPONENT_INVALID",
                     message=(
                         f"component graph node {comp_id or idx!r} parent_component_id "
-                        f"{parent_id!r} does not resolve to a graph node"
+                        f"{parent_id!r} does not resolve to "
+                        f"{'a canonical component' if canonical_registry_available else 'a graph node'}"
                     ),
                     artifact="component_graph",
                     path=f"$.nodes[{idx}].parent_component_id",
                     source_stage="export_validation",
-                    target_type="graph_node",
-                    target_id=comp_id or None,
+                    target_type=(
+                        "component" if canonical_registry_available else "graph_node"
+                    ),
+                    target_id=(
+                        parent_id if canonical_registry_available else comp_id
+                    ) or None,
                 ))
             # Issue #418: a main node aggregates other nodes via member_component_ids;
             # each member must resolve to an existing graph node.

--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -2107,6 +2107,24 @@ class ExportValidationGate:
                 alias = str(alias or "")
                 if alias and canonical:
                     component_aliases[alias] = canonical
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            node_id = str(
+                node.get("component_id") or node.get("node_id") or node.get("id") or ""
+            )
+            provenance_candidates = _ordered_unique(
+                [
+                    value
+                    for value in (
+                        [node.get("representative_component_id")]
+                        + list(node.get("linked_component_ids") or [])
+                    )
+                    if value and str(value) in canonical_component_ids
+                ]
+            )
+            if node_id and len(provenance_candidates) == 1:
+                component_aliases[node_id] = str(provenance_candidates[0])
         canonical_registry_available = component_result is not None
 
         node_ids: set[str] = set()

--- a/backend/core/document_pipeline/revision/diff.py
+++ b/backend/core/document_pipeline/revision/diff.py
@@ -168,9 +168,12 @@ def compute_structural_summary(
 def _recommendation(quality_after: dict, candidate_invalid: bool,
                     introduced_errors: int, resolved_count: int,
                     requires_confirmation: bool) -> str:
-    if candidate_invalid or quality_after.get("hard_error_count", 0) > 0:
+    # A revision may improve an already-invalid adopted run incrementally.
+    # Unchanged base errors are carried debt, not regressions introduced by this
+    # candidate; only newly introduced errors make this proposal rejectable.
+    if candidate_invalid or introduced_errors > 0:
         return "reject"
-    if introduced_errors > 0 or requires_confirmation:
+    if requires_confirmation:
         return "manual_review"
     if resolved_count > 0:
         return "accept"
@@ -281,12 +284,15 @@ def build_diff_report(
     structural_summary = compute_structural_summary(base_artifacts, candidate_artifacts)
     protected_changes = protected_changes or []
 
-    hard_error_count = quality_after.get("hard_error_count", 0)
+    remaining_hard_error_count = quality_after.get("hard_error_count", 0)
+    # Blocking is delta-based: existing base errors must not make every
+    # incremental repair impossible to adopt. New errors are still fail-closed.
+    hard_error_count = introduced_errors
 
     # Final candidate status (#415): start from the operation-level verdict, then
-    # downgrade to blocked if the gate still has hard errors / the candidate is
-    # invalid after exclusion. A partially_adoptable candidate with no hard errors
-    # is acceptable, but only via explicit partial confirmation at accept time.
+    # downgrade to blocked if the candidate introduces hard errors or is invalid
+    # after exclusion. Hard errors already present in the base remain visible as
+    # carried debt but do not prevent incremental repair.
     op_status = operation_candidate_status or (
         "blocked" if candidate_invalid else "adoptable"
     )
@@ -328,6 +334,10 @@ def build_diff_report(
             "candidate_invalid": bool(candidate_invalid),
             "candidate_status": candidate_status,
             "hard_error_count": hard_error_count,
+            "remaining_hard_error_count": remaining_hard_error_count,
+            "carried_hard_error_count": max(
+                0, remaining_hard_error_count - introduced_errors
+            ),
             "acceptable": acceptable,
             "requires_confirmation": bool(requires_confirmation),
             "outcome": stage_summary["outcome"],

--- a/backend/core/document_pipeline/revision/operations.py
+++ b/backend/core/document_pipeline/revision/operations.py
@@ -299,6 +299,7 @@ def _op_split_entity(candidate, op, mapping):
     if not isinstance(parts, list) or not parts:
         raise _OpError("split_entity requires a non-empty after_json list")
     new_ids: list[str] = []
+    normalized_parts: list[dict] = []
     for part in parts:
         if not isinstance(part, dict):
             raise _OpError("split_entity parts must be objects")
@@ -306,8 +307,13 @@ def _op_split_entity(candidate, op, mapping):
         if not nid:
             raise _OpError("split_entity part missing id")
         new_ids.append(nid)
+        # A split replaces one entity with complete child entities. Proposal
+        # payloads normally contain only changed semantic fields, so inherit
+        # stable schema/provenance fields (document_id, source refs, status, …)
+        # from the original record while letting each child override them.
+        normalized_parts.append({**copy.deepcopy(rec), **part})
     lst.remove(rec)
-    lst.extend(parts)
+    lst.extend(normalized_parts)
     mapping[op["target_id"]] = new_ids
 
 
@@ -527,6 +533,26 @@ CAND_ADOPTABLE = "adoptable"
 CAND_PARTIALLY_ADOPTABLE = "partially_adoptable"
 CAND_BLOCKED = "blocked"
 
+_REVISION_CONTROL_ARTIFACT_KEYS = {
+    "baseline_inventory",
+    "audit_checkpoints",
+    "audit_results",
+    "proposed_operations",
+    "revision_operations",
+    "candidate",
+    "candidate_validation",
+    "diff_report",
+}
+
+
+def _domain_artifacts(artifacts: dict) -> dict:
+    """Exclude revision-control artifacts from the revisable domain snapshot."""
+    return {
+        key: value
+        for key, value in (artifacts or {}).items()
+        if key not in _REVISION_CONTROL_ARTIFACT_KEYS
+    }
+
 
 def _all_base_ids(base_inventory: dict | None, base_artifacts: dict) -> set[str]:
     """Every entity id present in the base (the ids an operation may safely consume)."""
@@ -655,7 +681,10 @@ def _apply_included(base_artifacts: dict, included: list[dict]):
     ``failure`` is ``(op_index, reason)`` for the first op whose handler raised, or
     None when all applied cleanly.
     """
-    candidate = copy.deepcopy(base_artifacts) if isinstance(base_artifacts, dict) else {}
+    candidate = copy.deepcopy(
+        _domain_artifacts(base_artifacts)
+        if isinstance(base_artifacts, dict) else {}
+    )
     id_mapping: dict[str, list[str]] = {}
     for _idx, op in _canonical_order(included):
         handler = _DISPATCH.get(op.get("operation"))
@@ -853,4 +882,3 @@ def apply_operations(
         "invalid": candidate_status == CAND_BLOCKED,
         "requires_confirmation": bool(protected_changes),
     }
-

--- a/backend/core/document_pipeline/revision/proposal.py
+++ b/backend/core/document_pipeline/revision/proposal.py
@@ -10,6 +10,7 @@ generator never auto-accepts anything.
 from __future__ import annotations
 
 import json
+import re
 from typing import Callable
 
 from .operations import ENTITY_REGISTRY, OPERATIONS, make_operation
@@ -21,6 +22,13 @@ _BUCKET = {
 }
 _MODIFYING = {"update_entity", "split_entity", "merge_entities", "remove_entity",
               "add_relation", "remove_relation", "relink_evidence"}
+_SPLIT_CONTAINER_KEYS = (
+    "split_into",
+    "new_entities",
+    "component_claims",
+    "parts",
+    "entities",
+)
 
 
 def _entity_exists(inventory: dict, target_type: str, target_id: str) -> bool:
@@ -72,6 +80,115 @@ def _dedup(values: list[str]) -> list[str]:
             seen.add(v)
             out.append(v)
     return out
+
+
+def _normalize_split_after_json(
+    raw_after: object,
+    *,
+    target_type: str,
+    target_id: str,
+    inventory: dict,
+    evidence_refs: list[str],
+) -> tuple[list[dict] | None, str]:
+    """Normalize common LLM split wrappers into the canonical list contract.
+
+    Proposal models frequently return ``{"split_into": [...]}``,
+    ``{"new_entities": [...]}``, or ``{"component_texts": [...]}`` despite the
+    operation executor requiring ``after_json`` to be a list. Preserve the
+    substantive proposal, generate deterministic child IDs, and inherit stable
+    source/link metadata from the audited entity.
+    """
+    parts: object = raw_after
+    if isinstance(raw_after, dict):
+        parts = next(
+            (
+                raw_after.get(key)
+                for key in _SPLIT_CONTAINER_KEYS
+                if isinstance(raw_after.get(key), list)
+            ),
+            None,
+        )
+        if parts is None and isinstance(raw_after.get("component_texts"), list):
+            parts = [
+                {"text": text}
+                for text in raw_after.get("component_texts") or []
+                if str(text or "").strip()
+            ]
+        if parts is None and isinstance(raw_after.get("text"), str):
+            # Some models emit an explicitly numbered decomposition in prose.
+            # Accept it only when at least two numbered clauses can be parsed.
+            clauses = [
+                match.group(1).strip().rstrip(";")
+                for match in re.finditer(
+                    r"(?:^|\s)\(\d+\)\s*(.*?)(?=\s*\(\d+\)\s*|$)",
+                    raw_after["text"],
+                    flags=re.DOTALL,
+                )
+                if match.group(1).strip()
+            ]
+            if len(clauses) >= 2:
+                parts = [{"text": clause} for clause in clauses]
+    if not isinstance(parts, list) or not parts:
+        return None, (
+            "split_after_json_requires_parts:"
+            "expected_list_or_split_into_new_entities_component_claims"
+        )
+
+    bucket = _BUCKET.get(target_type)
+    base = (
+        (inventory.get("entities", {}).get(bucket, {}) or {}).get(target_id, {})
+        if bucket else {}
+    )
+    _, _, id_field = ENTITY_REGISTRY[target_type]
+    if not id_field:
+        return None, f"split_unsupported_target_type:{target_type}"
+    existing_ids = set((inventory.get("entities", {}).get(bucket, {}) or {}).keys())
+    normalized: list[dict] = []
+    for index, raw_part in enumerate(parts, start=1):
+        if isinstance(raw_part, str):
+            part = {"text": raw_part}
+        elif isinstance(raw_part, dict):
+            part = dict(raw_part)
+        else:
+            return None, "split_part_not_object"
+        if not str(part.get("text") or part.get("normalized_text") or "").strip():
+            return None, "split_part_missing_text"
+
+        child_id = str(
+            part.get(id_field) or part.get("entity_id") or part.get("id") or ""
+        ).strip()
+        if not child_id or child_id == target_id or child_id in existing_ids:
+            stem = f"{target_id}__split_{index:02d}"
+            child_id = stem
+            suffix = 2
+            while child_id in existing_ids or any(
+                item.get(id_field) == child_id for item in normalized
+            ):
+                child_id = f"{stem}_{suffix}"
+                suffix += 1
+        part[id_field] = child_id
+        part.pop("entity_id", None)
+        part.pop("entity_type", None)
+        if target_type == "claim":
+            part.setdefault("normalized_text", part.get("text") or "")
+            part.setdefault("claim_type", base.get("claim_type") or "unknown")
+            part["atomicity"] = "atomic"
+            part["is_atomic"] = True
+            part.setdefault("support_status", base.get("support_status") or "source_backed")
+            part.setdefault("review_status", base.get("review_status") or "teacher_review_required")
+            part.setdefault("confidence", base.get("confidence") or 0.0)
+            if not part.get("source_evidence_ids"):
+                part["source_evidence_ids"] = _dedup(
+                    [str(v) for v in (part.pop("evidence_ids", []) or []) if v]
+                    + list(evidence_refs)
+                    + [str(v) for v in (base.get("evidence_ids") or []) if v]
+                )
+            part.setdefault("equation_ids", list(base.get("equation_ids") or []))
+            part.setdefault("linked_component_ids", list(base.get("component_ids") or []))
+            part.setdefault("derivation_ids", list(base.get("derivation_ids") or []))
+            part.setdefault("source_locations", list(base.get("source_locations") or []))
+        normalized.append(part)
+    return normalized, ""
 
 
 def _resolve_evidence_refs(
@@ -198,6 +315,18 @@ def validate_proposed_operation(
     if ref_reason:
         return None, ref_reason
 
+    after_json = raw_op.get("after_json")
+    if operation == "split_entity":
+        after_json, split_reason = _normalize_split_after_json(
+            after_json,
+            target_type=target_type,
+            target_id=target_id,
+            inventory=inventory,
+            evidence_refs=evidence_refs,
+        )
+        if split_reason:
+            return None, split_reason
+
     checkpoint_ids = [str(value) for value in (raw_op.get("checkpoint_ids") or []) if value]
     if audit_result.get("checkpoint_id") and audit_result["checkpoint_id"] not in checkpoint_ids:
         checkpoint_ids.append(audit_result["checkpoint_id"])
@@ -223,7 +352,7 @@ def validate_proposed_operation(
         target_type=target_type,
         target_id=target_id,
         before_json=raw_op.get("before_json"),
-        after_json=raw_op.get("after_json"),
+        after_json=after_json,
         reason=raw_op.get("reason") or (audit_result.get("findings") or [{}])[0].get("detail", "")
             if audit_result.get("findings") else raw_op.get("reason", ""),
         checkpoint_ids=checkpoint_ids,
@@ -317,6 +446,8 @@ def _proposal_messages(audit_result: dict, inventory: dict) -> list[dict]:
         "evidence_ids（登録済みevidence）とsource_chunk_ids（原文chunk）はID空間が異なるため"
         "必ず分けて出力すること。chunk IDをevidence_idとして出さない。"
         "原文根拠を必ず付け、推測だけで確定しないこと。"
+        "split_entityの場合、after_jsonは分割後entityオブジェクトの非空配列にし、"
+        "各要素に対象typeのIDフィールドとatomicな内容を入れること。"
     )
     payload = {"audit": {
         "verdict": audit_result.get("verdict"),

--- a/backend/tests/test_export_artifact_first.py
+++ b/backend/tests/test_export_artifact_first.py
@@ -128,6 +128,90 @@ def test_component_graph_export_separates_operation_nodes():
     assert {"component_id": "comp_1", "operation_id": "op_1"} in out["component_operation_links"]
 
 
+def test_component_graph_export_canonicalizes_legacy_operation_parent():
+    artifact = {
+        "graph_schema_version": "0.1.0",
+        "nodes": [
+            {
+                "component_id": "canonical_component",
+                "legacy_component_id": "legacy_component",
+                "label": "Canonical component",
+                "component_type": "TheoryOperationNode",
+                "graph_layer": "main",
+            },
+            {
+                "component_id": "op_legacy_parent",
+                "component_type": "EquationOperationNode",
+                "graph_layer": "equation_detail",
+                "parent_component_id": "legacy_component",
+                "linked_equation_ids": ["eq_1"],
+            },
+        ],
+        "edges": [],
+    }
+
+    out = ea.build_component_graph_export(
+        artifact,
+        document_id="doc_1",
+        known_component_ids={"canonical_component"},
+    )
+
+    op = out["operation_graph"]["nodes"][0]
+    assert op["parent_component_id"] == "canonical_component"
+    assert op["unresolved_parent_component_id"] == ""
+    assert out["component_operation_links"] == [{
+        "component_id": "canonical_component",
+        "operation_id": "op_legacy_parent",
+    }]
+
+
+def test_aggregate_parent_never_becomes_component_operation_endpoint():
+    artifact = {
+        "graph_schema_version": "0.1.0",
+        "nodes": [
+            {
+                "component_id": "canonical_component",
+                "label": "Canonical component",
+                "component_type": "TheoryOperationNode",
+                "graph_layer": "main",
+            },
+            {
+                "component_id": "aggregate_theory_node",
+                "label": "Aggregate",
+                "component_type": "TheoryOperationNode",
+                "graph_layer": "main",
+            },
+            {
+                "component_id": "detail_operation",
+                "component_type": "EquationOperationNode",
+                "graph_layer": "equation_detail",
+                "parent_component_id": "aggregate_theory_node",
+                "linked_equation_ids": ["eq_1"],
+            },
+        ],
+        "edges": [],
+    }
+
+    out = ea.build_component_graph_export(
+        artifact,
+        document_id="doc_1",
+        known_component_ids={"canonical_component"},
+    )
+
+    detail = next(
+        node for node in out["operation_graph"]["nodes"]
+        if node["operation_id"] == "detail_operation"
+    )
+    assert detail["parent_component_id"] == ""
+    assert detail["unresolved_parent_component_id"] == "aggregate_theory_node"
+    assert detail["review_required"] is True
+    assert "unresolved_parent_component" in detail["review_reasons"]
+    assert not any(
+        link["component_id"] == "aggregate_theory_node"
+        for link in out["component_operation_links"]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Resolvers + metadata (#383)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_export_artifact_first.py
+++ b/backend/tests/test_export_artifact_first.py
@@ -212,6 +212,43 @@ def test_aggregate_parent_never_becomes_component_operation_endpoint():
     )
 
 
+def test_aggregate_parent_resolves_via_representative_component_provenance():
+    artifact = {
+        "graph_schema_version": "0.1.0",
+        "nodes": [
+            {
+                "component_id": "theory_op_1",
+                "component_type": "TheoryOperationNode",
+                "graph_layer": "main",
+                "representative_component_id": "comp_real",
+                "linked_component_ids": ["comp_real"],
+                "member_component_ids": ["detail_op"],
+            },
+            {
+                "component_id": "detail_op",
+                "component_type": "EquationOperationNode",
+                "graph_layer": "equation_detail",
+                "parent_component_id": "theory_op_1",
+                "linked_equation_ids": ["eq_1"],
+            },
+        ],
+        "edges": [],
+    }
+
+    out = ea.build_component_graph_export(
+        artifact, document_id="doc_1", known_component_ids={"comp_real"}
+    )
+
+    assert {n["node_id"] for n in out["component_graph"]["nodes"]} == {"comp_real"}
+    detail = out["operation_graph"]["nodes"][0]
+    assert detail["parent_component_id"] == "comp_real"
+    assert detail["unresolved_parent_component_id"] == ""
+    assert out["component_operation_links"] == [{
+        "component_id": "comp_real",
+        "operation_id": "detail_op",
+    }]
+
+
 # ---------------------------------------------------------------------------
 # Resolvers + metadata (#383)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_revision_diff_report.py
+++ b/backend/tests/test_revision_diff_report.py
@@ -108,6 +108,48 @@ def test_report_has_full_schema():
     assert report["recommendation"] in ("accept", "reject", "manual_review")
 
 
+def test_existing_base_hard_errors_are_carried_not_blocking():
+    base = _artifacts()
+    gate_base = {
+        "summary": {"error_count": 2, "warning_count": 0, "review_required_count": 0},
+        "errors": [
+            {"code": "BASE_ERROR_A", "artifact": "x", "path": "$.a"},
+            {"code": "BASE_ERROR_B", "artifact": "x", "path": "$.b"},
+        ],
+        "warnings": [],
+        "review_items": [],
+    }
+    gate_candidate = {
+        "summary": {"error_count": 2, "warning_count": 0, "review_required_count": 0},
+        "errors": list(gate_base["errors"]),
+        "warnings": [],
+        "review_items": [],
+    }
+
+    report = build_diff_report(
+        base_run_id="base-1",
+        candidate_run_id="rev-1",
+        base_artifacts=base,
+        candidate_artifacts=base,
+        applied_operations=[],
+        gate_base=gate_base,
+        gate_candidate=gate_candidate,
+        operation_candidate_status="partially_adoptable",
+        operation_summary={
+            "applied_count": 1,
+            "excluded_invalid_count": 1,
+            "excluded_dependency_count": 0,
+            "requires_confirmation_count": 0,
+        },
+    )
+
+    assert report["candidate_status"] == "partially_adoptable"
+    assert report["summary"]["hard_error_count"] == 0
+    assert report["summary"]["remaining_hard_error_count"] == 2
+    assert report["summary"]["carried_hard_error_count"] == 2
+    assert report["summary"]["acceptable"] is True
+
+
 def test_entity_change_traces_to_checkpoint_and_evidence():
     report, _ = _report_for([
         make_operation(operation="update_entity", target_type="component",

--- a/backend/tests/test_revision_llm_audit_proposal.py
+++ b/backend/tests/test_revision_llm_audit_proposal.py
@@ -120,6 +120,86 @@ def test_validate_accepts_and_attaches_traceability():
     assert op["source_locations"] == [{"chunk_id": "c1"}]
 
 
+@pytest.mark.parametrize("container_key", [
+    "split_into", "new_entities", "component_claims"
+])
+def test_validate_normalizes_wrapped_split_entity_parts(container_key):
+    audit = {
+        "checkpoint_id": "ckpt_1",
+        "evidence_refs": ["ev_1"],
+        "source_locations": [{"chunk_id": "c1"}],
+        "confidence": 0.9,
+    }
+    op, reason = validate_proposed_operation(
+        {
+            "operation": "split_entity",
+            "target_type": "claim",
+            "target_id": "clm_1",
+            "after_json": {
+                container_key: [
+                    {"text": "A holds."},
+                    {"text": "B holds.", "claim_type": "result"},
+                ]
+            },
+        },
+        _inventory(),
+        audit,
+    )
+
+    assert reason == ""
+    assert op is not None
+    assert isinstance(op["after_json"], list)
+    assert [part["claim_id"] for part in op["after_json"]] == [
+        "clm_1__split_01", "clm_1__split_02"
+    ]
+    assert all(part["is_atomic"] is True for part in op["after_json"])
+    assert all(part["source_evidence_ids"] == ["ev_1"] for part in op["after_json"])
+
+
+def test_validate_normalizes_component_texts_split():
+    audit = {
+        "checkpoint_id": "ckpt_1",
+        "evidence_refs": ["ev_1"],
+        "source_locations": [{"chunk_id": "c1"}],
+    }
+    op, reason = validate_proposed_operation(
+        {
+            "operation": "split_entity",
+            "target_type": "claim",
+            "target_id": "clm_1",
+            "after_json": {"component_texts": ["A holds.", "B holds."]},
+        },
+        _inventory(),
+        audit,
+    )
+    assert reason == ""
+    assert [part["text"] for part in op["after_json"]] == ["A holds.", "B holds."]
+
+
+def test_validate_normalizes_numbered_split_prose():
+    audit = {
+        "checkpoint_id": "ckpt_1",
+        "evidence_refs": ["ev_1"],
+        "source_locations": [{"chunk_id": "c1"}],
+    }
+    op, reason = validate_proposed_operation(
+        {
+            "operation": "split_entity",
+            "target_type": "claim",
+            "target_id": "clm_1",
+            "after_json": {
+                "text": "Split into: (1) A holds; (2) B holds; (3) C holds."
+            },
+        },
+        _inventory(),
+        audit,
+    )
+    assert reason == ""
+    assert [part["text"] for part in op["after_json"]] == [
+        "A holds", "B holds", "C holds."
+    ]
+
+
 def test_validate_rejects_unknown_evidence_instead_of_dropping_it():
     audit = {"checkpoint_id": "ckpt_1", "evidence_refs": ["ev_1", "ev_GONE"],
              "source_locations": [{"chunk_id": "c1"}]}

--- a/backend/tests/test_revision_operations.py
+++ b/backend/tests/test_revision_operations.py
@@ -143,6 +143,40 @@ def test_split_entity_records_mapping_and_follows_refs():
     assert comp["linked_claim_ids"] == ["clm_1a", "clm_1b"]
 
 
+def test_split_entity_children_inherit_required_schema_fields():
+    base = _base_artifacts()
+    original = base["claim_object_builder"]["claims"][0]
+    original["document_id"] = "doc-1"
+    original["support_status"] = "source_backed"
+
+    res = apply_operations(base, [
+        make_operation(
+            operation="split_entity",
+            target_type="claim",
+            target_id="clm_1",
+            after_json=[
+                {"claim_id": "clm_1a", "text": "A holds.", "is_atomic": True},
+                {"claim_id": "clm_1b", "text": "B holds.", "is_atomic": True},
+            ],
+        ),
+    ])
+
+    children = _claims(res)
+    assert children["clm_1a"]["document_id"] == "doc-1"
+    assert children["clm_1b"]["support_status"] == "source_backed"
+
+
+def test_candidate_does_not_recursively_copy_revision_control_artifacts():
+    base = _base_artifacts()
+    base["candidate"] = {"candidate_artifacts": {"candidate": {"nested": True}}}
+    base["diff_report"] = {"summary": {"acceptable": False}}
+
+    res = apply_operations(base, [])
+
+    assert "candidate" not in res["candidate_artifacts"]
+    assert "diff_report" not in res["candidate_artifacts"]
+
+
 def test_merge_entities_maps_refs_to_merged():
     base = _base_artifacts()
     res = apply_operations(base, [

--- a/frontend/public/js/admin.js
+++ b/frontend/public/js/admin.js
@@ -9121,7 +9121,10 @@
         '<li>採用可能な変更: ' + (os.applied_count || 0) + '</li>' +
         '<li>除外（不正）: ' + (os.excluded_invalid_count || 0) + '</li>' +
         '<li>除外（依存）: ' + (os.excluded_dependency_count || 0) + '</li>' +
-        '<li>除外後の hard error: ' + ((report.summary || {}).hard_error_count || 0) + '</li></ul>';
+        '<li>この候補が新規に生じさせる hard error: ' +
+          ((report.summary || {}).hard_error_count || 0) + '</li>' +
+        '<li>元データから引き継ぐ hard error: ' +
+          ((report.summary || {}).carried_hard_error_count || 0) + '</li></ul>';
       var rows = excluded.map(function (x) {
         return '<li class="eg-rev-change"><span class="eg-rev-ctype">' +
           escHtml(EXCLUDE_LABELS[x.status] || x.status) + '</span> ' +

--- a/src/episteme_graph/agents/component_assembly/agent.py
+++ b/src/episteme_graph/agents/component_assembly/agent.py
@@ -43,7 +43,10 @@ class ComponentAssemblyAgent:
         self._cleanup = ComponentOverlapCleanup()
         self._validator = ComponentAssemblyValidator()
         self._repairer = ComponentAssemblyRepairer(cleanup=self._cleanup)
-        self._refiner = ComponentRefiner()
+        # Reuse the provider-aware assembly client for constrained refinement
+        # routing. The refiner calls it only when source-backed deterministic
+        # signals cannot identify a unique child.
+        self._refiner = ComponentRefiner(llm_client=self._llm_client)
         self._granularity_analyzer = ComponentGranularityAnalyzer()
         self._derivation_graph_aligner = DerivationGraphAligner()
         self._theory_bundle_stage = TheoryBundleStage()
@@ -500,6 +503,10 @@ def _issue_dict(issue: ValidationIssue, *, llm_input: ComponentAssemblyLLMInput)
         "message": issue.message,
         "field": issue.field,
     }
+    if issue.target_type:
+        data["target_type"] = issue.target_type
+    if issue.target_id:
+        data["target_id"] = issue.target_id
     allowed = _allowed_values_for_issue(issue.rule_id, llm_input)
     invalid = _invalid_value_from_message(issue.message)
     if invalid:

--- a/src/episteme_graph/agents/component_assembly/component_refiner.py
+++ b/src/episteme_graph/agents/component_assembly/component_refiner.py
@@ -136,6 +136,7 @@ class ComponentRefiner:
         eq_index = _equation_index(llm_input)
         claim_index = _claim_index(llm_input)
         chains = list(getattr(derivations, "chains", []) or [])
+        derivation_index = _derivation_index(chains)
         report = RefinementReport()
         self._traces = {}
 
@@ -150,7 +151,7 @@ class ComponentRefiner:
         child_map: dict[str, list[str]] = {}
         for component in result.components:
             children = self._refine_component(
-                component, eq_index, chains, report, claim_index
+                component, eq_index, chains, report, claim_index, derivation_index
             )
             child_map[component.component_id] = [c.component_id for c in children]
             if children and children[0].component_id != component.component_id:
@@ -371,8 +372,10 @@ class ComponentRefiner:
         chains: list,
         report: RefinementReport,
         claim_index: dict[str, dict] | None = None,
+        derivation_index: dict[str, dict] | None = None,
     ) -> list[ComponentRecord]:
         claim_index = claim_index or {}
+        derivation_index = derivation_index or {}
         split = component.split_recommendation if isinstance(component.split_recommendation, dict) else {}
         if split_is_required(split):
             report.oversized_components.append({
@@ -395,7 +398,7 @@ class ComponentRefiner:
         # Step 3 priority order (#324): consume Step 1 ``suggested_split`` as the
         # primary split plan before falling back to derivation-driven splitting.
         suggested_children = self._suggested_split_children(
-            component, split, eq_index, claim_index, report
+            component, split, eq_index, claim_index, report, derivation_index
         )
         if suggested_children:
             return suggested_children
@@ -497,6 +500,7 @@ class ComponentRefiner:
         eq_index: dict[str, dict],
         claim_index: dict[str, dict],
         report: RefinementReport,
+        derivation_index: dict[str, dict] | None = None,
     ) -> list[ComponentRecord]:
         """Split a component using Step 1's ``suggested_split`` plan (#324).
 
@@ -519,7 +523,9 @@ class ComponentRefiner:
         if len(suggested) < 2 or len(responsibilities) < 2:
             return []
 
-        plan, unassigned = _redistribute_links(component, suggested, eq_index, claim_index)
+        plan, unassigned = _redistribute_links(
+            component, suggested, eq_index, claim_index, derivation_index or {}
+        )
         assignable = [spec for spec in plan if _spec_has_payload(spec)]
         if len(assignable) < 2:
             return []
@@ -1494,6 +1500,7 @@ def _claim_index(llm_input) -> dict[str, dict]:
             "concepts": [str(c) for c in (row.get("concepts") or []) if c],
             "atomicity": atomicity,
             "is_atomic": bool(row.get("is_atomic", atomicity == "atomic")),
+            "claim_type": str(row.get("claim_type") or row.get("claim_type_candidate") or ""),
             "equation_ids": [str(e) for e in (row.get("equation_ids") or []) if e],
             "evidence_ids": [str(e) for e in (row.get("source_evidence_ids") or []) if e],
         })
@@ -1554,21 +1561,109 @@ def _spec_has_payload(spec: dict) -> bool:
     )
 
 
+def _claim_category(info: dict) -> str:
+    """Map a claim's declared type to a responsibility category (#421).
+
+    Domain-neutral: keys off the generic claim-type vocabulary only, so the
+    refiner can route a claim by its type when it shares no equations with any
+    child.
+    """
+    ctype = str(info.get("claim_type") or info.get("claim_type_candidate") or "").lower()
+    if not ctype:
+        return ""
+    if any(k in ctype for k in ("definition", "define", "assumption", "model")):
+        return "definition"
+    if any(k in ctype for k in ("result", "conclusion", "constraint", "consistency", "criterion")):
+        return "result"
+    if any(k in ctype for k in ("relation", "transformation", "derivation", "method", "derive")):
+        return "derivation"
+    return ""
+
+
+def _match_spec_by_evidence_provenance(
+    specs: list[dict], evidence_ids: set, claim_evidence: dict[str, set]
+) -> dict | None:
+    """Route a claim to the child that already owns a co-evidenced claim (#421)."""
+    if not evidence_ids:
+        return None
+    best: dict | None = None
+    best_n = 0
+    for spec in specs:
+        overlap = 0
+        for cid in spec["claim_ids"]:
+            overlap += len(evidence_ids & claim_evidence.get(cid, set()))
+        if overlap > best_n:
+            best_n = overlap
+            best = spec
+    return best
+
+
+def _match_spec_by_operation_families(specs: list[dict], families: list[str]) -> dict | None:
+    """Route a derivation to the child whose responsibility matches its operation family (#421)."""
+    for fam in families:
+        resp = _FAMILY_TO_RESPONSIBILITY.get(fam)
+        if not resp:
+            continue
+        for spec in specs:
+            if spec["responsibility_type"] == resp:
+                return spec
+    return None
+
+
+def _derivation_index(chains) -> dict[str, dict]:
+    """Index derivation chains by id → input/output equations and operation families (#421)."""
+    index: dict[str, dict] = {}
+    for chain in chains or []:
+        d_id = str(getattr(chain, "derivation_id", "") or "")
+        if not d_id:
+            continue
+        eqs: list[str] = []
+        families: list[str] = []
+        for step in getattr(chain, "steps", []) or []:
+            eqs.extend(_step_field(step, "input_equation_ids"))
+            eqs.extend(_step_field(step, "output_equation_ids"))
+            op = str(getattr(step, "operation", "") or "")
+            if op:
+                families.append(_generic_operation_family(op))
+        index[d_id] = {
+            "equation_ids": _ordered_unique(eqs),
+            "operation_families": _ordered_unique(families),
+        }
+    return index
+
+
 def _redistribute_links(
     component: ComponentRecord,
     suggested: list[dict],
     eq_index: dict[str, dict],
     claim_index: dict[str, dict],
+    derivation_index: dict[str, dict] | None = None,
 ) -> tuple[list[dict], list[dict]]:
-    """Reassign the parent's links across the suggested children (#324 rule 4).
+    """Reassign the parent's links across the suggested children (#324 / #421).
 
-    Returns ``(child_specs, unassigned_links)``. Links that cannot be assigned
-    confidently are recorded in ``unassigned_links`` rather than dropped.
+    Returns ``(child_specs, unassigned_links)``. Assignment is *responsibility-
+    aware*, never round-robin:
+
+    - equations are routed by their equation *role* (definition / transformation /
+      result) to the responsibility category that owns that role; the analyzer's
+      ``linked_equation_ids`` candidate field is consumed only as a hint when the
+      equation has no usable role in the index;
+    - claims are routed by equation overlap, then by claim type, then by the
+      provenance of their source evidence;
+    - derivations are routed by the overlap of their input/output equations and
+      their operation family, falling back to the sole derivational child;
+    - evidence is routed from the provenance of already-assigned claims /
+      equations.
+
+    Anything that cannot be assigned confidently is recorded in
+    ``unassigned_links`` rather than being forced onto an arbitrary child.
     """
+    derivation_index = derivation_index or {}
     specs: list[dict] = []
+    candidate_equation_hints: dict[str, dict] = {}
     for s in suggested:
         resp = canonical_responsibility_type(s.get("responsibility_type"))
-        specs.append({
+        spec = {
             "name": s.get("name") or resp.replace("_", " ").title(),
             "responsibility_type": resp,
             "operation": s.get("operation") or _operation_for_responsibility(resp),
@@ -1578,12 +1673,24 @@ def _redistribute_links(
             "derivation_ids": [],
             "review_required": False,
             "review_notes": [],
-        })
+        }
+        specs.append(spec)
+        # Consume the analyzer's responsibility-aware candidate equation plan
+        # (#421): map each suggested equation back to the spec that proposed it so
+        # the refiner can honour it when the equation role is otherwise unknown.
+        for eid in s.get("linked_equation_ids") or s.get("candidate_equation_ids") or []:
+            candidate_equation_hints.setdefault(str(eid), spec)
     unassigned: list[dict] = []
 
-    # Equations → responsibility category.
+    # Equations → responsibility category derived from the equation role. When the
+    # role is unknown, fall back to the analyzer's candidate hint; only when both
+    # are missing is the equation left unassigned (never round-robined).
     for eq_id in _all_equation_ids(component):
         target = _match_spec_by_category(specs, _equation_category(eq_index.get(eq_id) or {}))
+        if target is None:
+            hint = candidate_equation_hints.get(eq_id)
+            if hint is not None and hint in specs:
+                target = hint
         if target is None:
             unassigned.append({
                 "link_type": "equation",
@@ -1593,7 +1700,7 @@ def _redistribute_links(
             continue
         target["equation_ids"].append(eq_id)
 
-    # Claims → the child sharing the most equations; atomic fall back to first.
+    # Claims → equation overlap, then claim type, then source-evidence provenance.
     claim_ids = _ordered_unique(
         list(component.linked_claim_ids or [])
         + list((component.evidence_refs or {}).get("claim_ids") or [])
@@ -1605,15 +1712,23 @@ def _redistribute_links(
         claim_evidence[cid] = set(info.get("evidence_ids") or [])
         target = _match_spec_by_equation_overlap(specs, set(info.get("equation_ids") or []))
         if target is None:
-            if _claim_is_atomic(cid, claim_index):
-                target = specs[0]
-            else:
-                unassigned.append({
-                    "link_type": "claim",
-                    "link_id": cid,
-                    "reason": "composite claim without confident target",
-                })
-                continue
+            target = _match_spec_by_category(specs, _claim_category(info))
+        if target is None:
+            target = _match_spec_by_evidence_provenance(
+                specs, claim_evidence[cid], claim_evidence
+            )
+        if target is None:
+            reason = (
+                "composite claim without confident target"
+                if not _claim_is_atomic(cid, claim_index)
+                else "atomic claim without confident responsibility target"
+            )
+            unassigned.append({
+                "link_type": "claim",
+                "link_id": cid,
+                "reason": reason,
+            })
+            continue
         target["claim_ids"].append(cid)
 
     # Evidence → the child whose assigned claims reference it.
@@ -1639,7 +1754,8 @@ def _redistribute_links(
             continue
         target["evidence_ids"].append(ev_id)
 
-    # Derivations → the first derivational child.
+    # Derivations → by input/output equation overlap and operation family, then
+    # the sole derivational child; otherwise left unassigned (never duplicated).
     derivational = [
         spec
         for spec in specs
@@ -1647,14 +1763,24 @@ def _redistribute_links(
         in (_DERIVATION_RESPONSIBILITIES | _EQUATION_SYSTEM_RESPONSIBILITIES | {"constraint"})
     ]
     for d_id in _ordered_unique(component.linked_derivation_ids or []):
-        if derivational:
-            derivational[0]["derivation_ids"].append(d_id)
-        else:
+        info = derivation_index.get(d_id, {})
+        target = _match_spec_by_equation_overlap(specs, set(info.get("equation_ids") or []))
+        if target is None:
+            target = _match_spec_by_operation_families(specs, info.get("operation_families") or [])
+        if target is None and len(derivational) == 1:
+            target = derivational[0]
+        if target is None:
             unassigned.append({
                 "link_type": "derivation",
                 "link_id": d_id,
-                "reason": "no derivational child to receive derivation",
+                "reason": (
+                    "no derivational child to receive derivation"
+                    if not derivational
+                    else "derivation could not be routed to a single derivational child"
+                ),
             })
+            continue
+        target["derivation_ids"].append(d_id)
 
     # Children supported only by composite claims are downgraded.
     for spec in specs:

--- a/src/episteme_graph/agents/component_assembly/component_refiner.py
+++ b/src/episteme_graph/agents/component_assembly/component_refiner.py
@@ -1529,13 +1529,33 @@ def _is_review_required_status(status: object) -> bool:
     return str(status or "") in {"review_required", "teacher_review_required"}
 
 
-def _match_spec_by_category(specs: list[dict], category: str) -> dict | None:
+def _match_spec_by_category(
+    specs: list[dict], category: str, *, preferred: str = ""
+) -> dict | None:
+    """Route an artifact to the child owning its responsibility category (#421).
+
+    Categories such as ``result`` cover several distinct responsibilities
+    (constraint / application / limitation). When more than one suggested child
+    falls in the category, returning the first one would mis-route — e.g. a
+    constraint equation into an application child — because the children are
+    sorted by responsibility. To avoid that, an exact ``preferred``
+    responsibility (derived from the equation role / claim type) is required to
+    disambiguate; if the category is ambiguous and no unique exact match exists,
+    the caller leaves the artifact unassigned rather than guessing.
+    """
     if not category:
         return None
     allowed = _CATEGORY_TO_RESPONSIBILITIES.get(category, set())
-    for spec in specs:
-        if spec["responsibility_type"] in allowed:
-            return spec
+    candidates = [spec for spec in specs if spec["responsibility_type"] in allowed]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    if preferred:
+        exact = [spec for spec in candidates if spec["responsibility_type"] == preferred]
+        if len(exact) == 1:
+            return exact[0]
+    # Ambiguous category with multiple candidates and no unique exact match.
     return None
 
 
@@ -1561,6 +1581,26 @@ def _spec_has_payload(spec: dict) -> bool:
     )
 
 
+# Equation role → the exact responsibility it belongs to (#421). Used to
+# disambiguate a coarse responsibility category (``result`` covers constraint /
+# application / limitation). ``result`` is intentionally absent: a bare "result"
+# role does not name a single exact responsibility, so it stays ambiguous.
+_EQUATION_ROLE_TO_RESPONSIBILITY = {
+    "definition": "definition",
+    "equation_definition": "definition",
+    "constraint": "constraint",
+    "condition": "constraint",
+    "consistency_relation": "constraint",
+    "transformation": "equation_system",
+    "relation": "equation_system",
+}
+
+
+def _equation_responsibility(eq: dict) -> str:
+    role = str(eq.get("role") or eq.get("equation_type") or "").lower()
+    return _EQUATION_ROLE_TO_RESPONSIBILITY.get(role, "")
+
+
 def _claim_category(info: dict) -> str:
     """Map a claim's declared type to a responsibility category (#421).
 
@@ -1573,11 +1613,46 @@ def _claim_category(info: dict) -> str:
         return ""
     if any(k in ctype for k in ("definition", "define", "assumption", "model")):
         return "definition"
-    if any(k in ctype for k in ("result", "conclusion", "constraint", "consistency", "criterion")):
+    if any(k in ctype for k in (
+        "result", "conclusion", "constraint", "consistency", "criterion",
+        "application", "forecast", "limitation", "caveat",
+    )):
         return "result"
     if any(k in ctype for k in ("relation", "transformation", "derivation", "method", "derive")):
         return "derivation"
     return ""
+
+
+def _claim_responsibility(info: dict) -> str:
+    """Exact responsibility a claim's type names, to disambiguate a category (#421)."""
+    ctype = str(info.get("claim_type") or info.get("claim_type_candidate") or "").lower()
+    if not ctype:
+        return ""
+    if ctype in CANONICAL_RESPONSIBILITY_TYPES:
+        return ctype
+    if "constraint" in ctype or "consistency" in ctype or "criterion" in ctype:
+        return "constraint"
+    if "application" in ctype or "forecast" in ctype:
+        return "application"
+    if "limitation" in ctype or "caveat" in ctype:
+        return "limitation"
+    if "definition" in ctype or "define" in ctype:
+        return "definition"
+    if "model" in ctype or "assumption" in ctype:
+        return "model"
+    if "derivation" in ctype or "derive" in ctype:
+        return "derivation"
+    return ""
+
+
+def _equation_evidence_ids(eq: dict) -> list[str]:
+    """Evidence ids an equation is sourced from, for evidence provenance (#421)."""
+    ids: list[str] = []
+    for key in ("source_evidence_ids", "evidence_ids"):
+        for value in eq.get(key) or []:
+            if value:
+                ids.append(str(value))
+    return _ordered_unique(ids)
 
 
 def _match_spec_by_evidence_provenance(
@@ -1682,11 +1757,20 @@ def _redistribute_links(
             candidate_equation_hints.setdefault(str(eid), spec)
     unassigned: list[dict] = []
 
-    # Equations → responsibility category derived from the equation role. When the
-    # role is unknown, fall back to the analyzer's candidate hint; only when both
-    # are missing is the equation left unassigned (never round-robined).
+    # Equations → responsibility category derived from the equation role. When a
+    # category covers several responsibilities (e.g. result → constraint /
+    # application / limitation), the equation's exact role responsibility
+    # disambiguates so a constraint equation cannot fall into an application
+    # child. When the role is unknown, fall back to the analyzer's candidate hint;
+    # only when nothing resolves is the equation left unassigned (never
+    # round-robined).
+    equation_evidence: dict[str, set] = {}
     for eq_id in _all_equation_ids(component):
-        target = _match_spec_by_category(specs, _equation_category(eq_index.get(eq_id) or {}))
+        eq = eq_index.get(eq_id) or {}
+        equation_evidence[eq_id] = set(_equation_evidence_ids(eq))
+        target = _match_spec_by_category(
+            specs, _equation_category(eq), preferred=_equation_responsibility(eq)
+        )
         if target is None:
             hint = candidate_equation_hints.get(eq_id)
             if hint is not None and hint in specs:
@@ -1712,7 +1796,9 @@ def _redistribute_links(
         claim_evidence[cid] = set(info.get("evidence_ids") or [])
         target = _match_spec_by_equation_overlap(specs, set(info.get("equation_ids") or []))
         if target is None:
-            target = _match_spec_by_category(specs, _claim_category(info))
+            target = _match_spec_by_category(
+                specs, _claim_category(info), preferred=_claim_responsibility(info)
+            )
         if target is None:
             target = _match_spec_by_evidence_provenance(
                 specs, claim_evidence[cid], claim_evidence
@@ -1731,7 +1817,10 @@ def _redistribute_links(
             continue
         target["claim_ids"].append(cid)
 
-    # Evidence → the child whose assigned claims reference it.
+    # Evidence → the child whose assigned claims OR assigned equations reference
+    # it (#421). Equation provenance matters: an evidence item cited only by an
+    # equation (no claim) is still routed to the child that owns that equation
+    # instead of being dropped as unassigned.
     evidence_ids = _ordered_unique(
         list(component.linked_evidence_ids or [])
         + list((component.evidence_refs or {}).get("evidence_ids") or [])
@@ -1746,10 +1835,19 @@ def _redistribute_links(
             None,
         )
         if target is None:
+            target = next(
+                (
+                    spec
+                    for spec in specs
+                    if any(ev_id in equation_evidence.get(eid, set()) for eid in spec["equation_ids"])
+                ),
+                None,
+            )
+        if target is None:
             unassigned.append({
                 "link_type": "evidence",
                 "link_id": ev_id,
-                "reason": "no child claim references this evidence",
+                "reason": "no child claim or equation references this evidence",
             })
             continue
         target["evidence_ids"].append(ev_id)

--- a/src/episteme_graph/agents/component_assembly/component_refiner.py
+++ b/src/episteme_graph/agents/component_assembly/component_refiner.py
@@ -7,11 +7,12 @@ too coarse to be reusable theory parts. A single coarse component (for example a
 distinct theoretical operations (linearization, parameter solving/elimination,
 residual / final-constraint derivations).
 
-``ComponentRefiner`` is a deterministic (non-LLM) post-processing pass run after
+``ComponentRefiner`` is primarily a deterministic post-processing pass run after
 the initial components are assembled. It uses the derivation chains — which carry
 the real theory structure (one step = one operation, with input/output equations,
-eliminated/retained symbols) — to detect over-large components and split them so
-that:
+eliminated/retained symbols) — to detect over-large components and split them.
+Only artifact-to-child assignments that are ambiguous or based on low-confidence
+upstream semantics are sent to a constrained LLM re-judgement step.
 
     1 component = 1 reusable theory unit
 
@@ -29,6 +30,8 @@ inputs change, outputs change, the operation family changes, symbols change.
 from __future__ import annotations
 
 import copy
+import json
+import logging
 from dataclasses import dataclass, field
 
 from ..theory_operations import operation_family as _generic_operation_family
@@ -67,6 +70,12 @@ SIZE_THRESHOLDS = {
     "max_component_types_per_component": 1,
     "max_distinct_responsibility_labels": 1,
 }
+
+logger = logging.getLogger(__name__)
+
+_DETERMINISTIC_CONFIDENCE_THRESHOLD = 0.8
+_LLM_ROUTING_CONFIDENCE_THRESHOLD = 0.7
+_LLM_ROUTING_REVIEW_THRESHOLD = 0.85
 
 
 @dataclass
@@ -121,8 +130,9 @@ class TheoryOperationCandidate:
 
 
 class ComponentRefiner:
-    def __init__(self) -> None:
+    def __init__(self, llm_client=None) -> None:
         self._classifier = EquationRoleClassifier()
+        self._llm_client = llm_client
         # Per-component refinement trace populated during a single refine() call
         # (issue #324). Reset at the start of refine().
         self._traces: dict[str, dict] = {}
@@ -524,7 +534,12 @@ class ComponentRefiner:
             return []
 
         plan, unassigned = _redistribute_links(
-            component, suggested, eq_index, claim_index, derivation_index or {}
+            component,
+            suggested,
+            eq_index,
+            claim_index,
+            derivation_index or {},
+            llm_client=self._llm_client,
         )
         assignable = [spec for spec in plan if _spec_has_payload(spec)]
         if len(assignable) < 2:
@@ -547,6 +562,7 @@ class ComponentRefiner:
                 "assigned_evidence_ids": list(spec.get("evidence_ids") or []),
                 "assigned_derivation_ids": list(spec.get("derivation_ids") or []),
                 "assigned_concepts": list(child.concepts or []),
+                "routing_decisions": list(spec.get("routing_decisions") or []),
             })
 
         # introduced vs reused depends on cross-child ordering (issue #8 / #324).
@@ -1497,12 +1513,16 @@ def _claim_index(llm_input) -> dict[str, dict]:
             continue
         atomicity = str(row.get("atomicity", "atomic") or "atomic")
         entry = index.setdefault(cid, {
+            "text": str(row.get("text") or ""),
             "concepts": [str(c) for c in (row.get("concepts") or []) if c],
             "atomicity": atomicity,
             "is_atomic": bool(row.get("is_atomic", atomicity == "atomic")),
             "claim_type": str(row.get("claim_type") or row.get("claim_type_candidate") or ""),
             "equation_ids": [str(e) for e in (row.get("equation_ids") or []) if e],
             "evidence_ids": [str(e) for e in (row.get("source_evidence_ids") or []) if e],
+            "confidence": row.get("confidence"),
+            "support_status": str(row.get("support_status") or ""),
+            "review_status": str(row.get("review_status") or ""),
         })
     return index
 
@@ -1562,14 +1582,26 @@ def _match_spec_by_category(
 def _match_spec_by_equation_overlap(specs: list[dict], claim_eqs: set) -> dict | None:
     if not claim_eqs:
         return None
-    best: dict | None = None
-    best_n = 0
-    for spec in specs:
-        overlap = len(set(spec["equation_ids"]) & claim_eqs)
-        if overlap > best_n:
-            best_n = overlap
-            best = spec
-    return best
+    scored = [
+        (len(set(spec["equation_ids"]) & claim_eqs), spec)
+        for spec in specs
+    ]
+    best_n = max((score for score, _ in scored), default=0)
+    if best_n <= 0:
+        return None
+    winners = [spec for score, spec in scored if score == best_n]
+    return winners[0] if len(winners) == 1 else None
+
+
+def _equation_overlap_is_ambiguous(specs: list[dict], equation_ids: set) -> bool:
+    if not equation_ids:
+        return False
+    scores = [
+        len(set(spec["equation_ids"]) & equation_ids)
+        for spec in specs
+    ]
+    best_n = max(scores, default=0)
+    return best_n > 0 and sum(score == best_n for score in scores) > 1
 
 
 def _spec_has_payload(spec: dict) -> bool:
@@ -1655,34 +1687,99 @@ def _equation_evidence_ids(eq: dict) -> list[str]:
     return _ordered_unique(ids)
 
 
+def _has_any_key(record: dict, keys: tuple[str, ...]) -> bool:
+    return any(key in record for key in keys)
+
+
+def _safe_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value if value not in (None, "") else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _equation_is_high_confidence(eq: dict) -> bool:
+    """Whether an equation role is safe to consume without re-judgement.
+
+    Production ComponentAssembly input carries these quality fields. Legacy
+    callers and compact unit fixtures may not; in that compatibility case the
+    previous deterministic behavior is retained. Once any quality metadata is
+    present, all source-backed checks below are enforced.
+    """
+    quality_keys = (
+        "confidence",
+        "semantic_status",
+        "review_flags",
+        "needs_math_review",
+        "confidence_policy",
+        "reconstruction_status",
+    )
+    if not _has_any_key(eq, quality_keys):
+        return True
+    policy = eq.get("confidence_policy") if isinstance(eq.get("confidence_policy"), dict) else {}
+    confidence = _safe_float(eq.get("confidence"))
+    return bool(
+        confidence >= _DETERMINISTIC_CONFIDENCE_THRESHOLD
+        and str(eq.get("semantic_status") or "") == "source_backed"
+        and not bool(eq.get("review_flags"))
+        and not bool(eq.get("needs_math_review"))
+        and eq.get("reconstruction_status") in (None, "", "none")
+        and not bool(policy.get("must_not_treat_as_source_extracted"))
+        and policy.get("allowed_downstream_use") not in {"blocked", "semantic_hint_only"}
+    )
+
+
+def _claim_is_high_confidence(info: dict) -> bool:
+    quality_keys = ("confidence", "support_status", "review_status")
+    if not _has_any_key(info, quality_keys) or all(
+        info.get(key) in (None, "") for key in quality_keys
+    ):
+        return True
+    confidence = _safe_float(info.get("confidence"))
+    support_status = str(info.get("support_status") or "")
+    review_status = str(info.get("review_status") or "")
+    return bool(
+        confidence >= _DETERMINISTIC_CONFIDENCE_THRESHOLD
+        and support_status in {"source_backed", "equation_backed", "derived_from_linked_artifacts"}
+        and review_status not in {"review_required", "teacher_review_required", "needs_verification"}
+    )
+
+
 def _match_spec_by_evidence_provenance(
     specs: list[dict], evidence_ids: set, claim_evidence: dict[str, set]
 ) -> dict | None:
     """Route a claim to the child that already owns a co-evidenced claim (#421)."""
     if not evidence_ids:
         return None
-    best: dict | None = None
-    best_n = 0
+    scored: list[tuple[int, dict]] = []
     for spec in specs:
         overlap = 0
         for cid in spec["claim_ids"]:
             overlap += len(evidence_ids & claim_evidence.get(cid, set()))
-        if overlap > best_n:
-            best_n = overlap
-            best = spec
-    return best
+        scored.append((overlap, spec))
+    best_n = max((score for score, _ in scored), default=0)
+    if best_n <= 0:
+        return None
+    winners = [spec for score, spec in scored if score == best_n]
+    return winners[0] if len(winners) == 1 else None
 
 
 def _match_spec_by_operation_families(specs: list[dict], families: list[str]) -> dict | None:
     """Route a derivation to the child whose responsibility matches its operation family (#421)."""
+    matched_responsibilities: set[str] = set()
     for fam in families:
         resp = _FAMILY_TO_RESPONSIBILITY.get(fam)
         if not resp:
             continue
-        for spec in specs:
-            if spec["responsibility_type"] == resp:
-                return spec
-    return None
+        if any(spec["responsibility_type"] == resp for spec in specs):
+            matched_responsibilities.add(resp)
+    if len(matched_responsibilities) != 1:
+        return None
+    responsibility = next(iter(matched_responsibilities))
+    matches = [
+        spec for spec in specs if spec["responsibility_type"] == responsibility
+    ]
+    return matches[0] if len(matches) == 1 else None
 
 
 def _derivation_index(chains) -> dict[str, dict]:
@@ -1694,17 +1791,173 @@ def _derivation_index(chains) -> dict[str, dict]:
             continue
         eqs: list[str] = []
         families: list[str] = []
+        step_confidences: list[float] = []
+        step_review_statuses: list[str] = []
         for step in getattr(chain, "steps", []) or []:
             eqs.extend(_step_field(step, "input_equation_ids"))
             eqs.extend(_step_field(step, "output_equation_ids"))
             op = str(getattr(step, "operation", "") or "")
             if op:
                 families.append(_generic_operation_family(op))
+            step_confidences.append(_safe_float(getattr(step, "confidence", 0.0)))
+            step_review_statuses.append(str(getattr(step, "review_status", "") or ""))
         index[d_id] = {
             "equation_ids": _ordered_unique(eqs),
             "operation_families": _ordered_unique(families),
+            "confidence": _safe_float(getattr(chain, "confidence", 0.0)),
+            "review_status": str(getattr(chain, "review_status", "") or ""),
+            "review_required": bool(getattr(chain, "review_required", False)),
+            "step_confidences": step_confidences,
+            "step_review_statuses": step_review_statuses,
         }
     return index
+
+
+def _derivation_is_high_confidence(info: dict) -> bool:
+    if not info:
+        return False
+    confidence = _safe_float(info.get("confidence"))
+    step_confidences = list(info.get("step_confidences") or [])
+    statuses = {
+        str(info.get("review_status") or ""),
+        *(str(value or "") for value in (info.get("step_review_statuses") or [])),
+    }
+    # Older derivation records often expose confidence only on steps.
+    effective_confidence = confidence or (min(step_confidences) if step_confidences else 0.0)
+    return bool(
+        effective_confidence >= _DETERMINISTIC_CONFIDENCE_THRESHOLD
+        and not bool(info.get("review_required"))
+        and not statuses.intersection(
+            {"review_required", "teacher_review_required", "needs_verification"}
+        )
+    )
+
+
+def _routing_candidate_payload(specs: list[dict]) -> list[dict]:
+    return [
+        {
+            "responsibility_type": spec["responsibility_type"],
+            "name": spec["name"],
+            "assigned_equation_ids": list(spec["equation_ids"]),
+            "assigned_claim_ids": list(spec["claim_ids"]),
+        }
+        for spec in specs
+    ]
+
+
+def _resolve_pending_with_llm(
+    *,
+    component: ComponentRecord,
+    specs: list[dict],
+    pending: list[dict],
+    llm_client,
+) -> tuple[list[dict], list[dict]]:
+    """Resolve only ambiguous/low-confidence links against a closed candidate set."""
+    if not pending:
+        return [], []
+    if llm_client is None:
+        return [], pending
+
+    candidate_responsibilities = {
+        spec["responsibility_type"] for spec in specs if spec["responsibility_type"]
+    }
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You route scientific artifacts to one of the supplied child components. "
+                "Use the artifact text, semantic metadata, explicit IDs, and parent context. "
+                "Do not invent artifacts or children. If the evidence is insufficient or "
+                "conflicting, select 'unassigned'. Return JSON only as "
+                "{\"assignments\":[{\"artifact_type\":\"equation|claim|derivation\","
+                "\"artifact_id\":\"...\",\"selected_responsibility\":\"...|unassigned\","
+                "\"confidence\":0.0,\"reason\":\"...\"}]}."
+            ),
+        },
+        {
+            "role": "user",
+            "content": json.dumps({
+                "parent_component": {
+                    "component_id": component.component_id,
+                    "label": component.label,
+                    "summary": component.summary,
+                    "reason": component.reason,
+                },
+                "candidate_children": _routing_candidate_payload(specs),
+                "artifacts_to_route": pending,
+            }, ensure_ascii=False),
+        },
+    ]
+    try:
+        raw = llm_client.generate(messages)
+    except Exception as exc:
+        logger.warning(
+            "Component refinement routing LLM failed component=%s error=%s",
+            component.component_id,
+            exc,
+        )
+        return [], pending
+
+    pending_by_key = {
+        (entry["artifact_type"], entry["artifact_id"]): entry for entry in pending
+    }
+    resolved: list[dict] = []
+    resolved_keys: set[tuple[str, str]] = set()
+    for row in raw.get("assignments", []) if isinstance(raw, dict) else []:
+        if not isinstance(row, dict):
+            continue
+        artifact_type = str(row.get("artifact_type") or "")
+        artifact_id = str(row.get("artifact_id") or "")
+        key = (artifact_type, artifact_id)
+        if key not in pending_by_key or key in resolved_keys:
+            continue
+        responsibility = canonical_responsibility_type(row.get("selected_responsibility"))
+        confidence = _safe_float(row.get("confidence"))
+        if (
+            responsibility not in candidate_responsibilities
+            or confidence < _LLM_ROUTING_CONFIDENCE_THRESHOLD
+        ):
+            continue
+        target = next(
+            (
+                spec
+                for spec in specs
+                if spec["responsibility_type"] == responsibility
+            ),
+            None,
+        )
+        if target is None:
+            continue
+        field_name = {
+            "equation": "equation_ids",
+            "claim": "claim_ids",
+            "derivation": "derivation_ids",
+        }.get(artifact_type)
+        if field_name is None:
+            continue
+        target[field_name].append(artifact_id)
+        decision = {
+            "artifact_type": artifact_type,
+            "artifact_id": artifact_id,
+            "method": "llm_rejudgement",
+            "confidence": confidence,
+            "reason": str(row.get("reason") or ""),
+        }
+        target["routing_decisions"].append(decision)
+        if confidence < _LLM_ROUTING_REVIEW_THRESHOLD:
+            target["review_required"] = True
+            target["review_notes"].append(
+                f"LLM routing confidence {confidence:.2f} for {artifact_type} {artifact_id}"
+            )
+        resolved.append(decision)
+        resolved_keys.add(key)
+
+    unresolved = [
+        entry
+        for entry in pending
+        if (entry["artifact_type"], entry["artifact_id"]) not in resolved_keys
+    ]
+    return resolved, unresolved
 
 
 def _redistribute_links(
@@ -1713,6 +1966,8 @@ def _redistribute_links(
     eq_index: dict[str, dict],
     claim_index: dict[str, dict],
     derivation_index: dict[str, dict] | None = None,
+    *,
+    llm_client=None,
 ) -> tuple[list[dict], list[dict]]:
     """Reassign the parent's links across the suggested children (#324 / #421).
 
@@ -1748,41 +2003,69 @@ def _redistribute_links(
             "derivation_ids": [],
             "review_required": False,
             "review_notes": [],
+            "routing_decisions": [],
         }
         specs.append(spec)
-        # Consume the analyzer's responsibility-aware candidate equation plan
-        # (#421): map each suggested equation back to the spec that proposed it so
-        # the refiner can honour it when the equation role is otherwise unknown.
+        # Preserve the analyzer's responsibility-aware candidate equation plan as
+        # an LLM hint. It is never sufficient to finalize an assignment by itself.
         for eid in s.get("linked_equation_ids") or s.get("candidate_equation_ids") or []:
             candidate_equation_hints.setdefault(str(eid), spec)
     unassigned: list[dict] = []
+    pending: list[dict] = []
 
     # Equations → responsibility category derived from the equation role. When a
     # category covers several responsibilities (e.g. result → constraint /
     # application / limitation), the equation's exact role responsibility
     # disambiguates so a constraint equation cannot fall into an application
-    # child. When the role is unknown, fall back to the analyzer's candidate hint;
-    # only when nothing resolves is the equation left unassigned (never
-    # round-robined).
+    # child. Unknown, low-confidence, or ambiguous roles are sent to constrained
+    # LLM re-judgement with the analyzer candidate included only as a hint.
     equation_evidence: dict[str, set] = {}
     for eq_id in _all_equation_ids(component):
         eq = eq_index.get(eq_id) or {}
         equation_evidence[eq_id] = set(_equation_evidence_ids(eq))
-        target = _match_spec_by_category(
-            specs, _equation_category(eq), preferred=_equation_responsibility(eq)
-        )
+        category = _equation_category(eq)
+        target = None
+        if _equation_is_high_confidence(eq):
+            target = _match_spec_by_category(
+                specs, category, preferred=_equation_responsibility(eq)
+            )
         if target is None:
             hint = candidate_equation_hints.get(eq_id)
-            if hint is not None and hint in specs:
-                target = hint
-        if target is None:
-            unassigned.append({
-                "link_type": "equation",
-                "link_id": eq_id,
-                "reason": "no responsibility category match",
+            pending.append({
+                "artifact_type": "equation",
+                "artifact_id": eq_id,
+                "reason": (
+                    "low-confidence equation semantics"
+                    if not _equation_is_high_confidence(eq)
+                    else "ambiguous or missing responsibility match"
+                ),
+                "suggested_responsibility": (
+                    hint["responsibility_type"] if hint is not None else ""
+                ),
+                "artifact": {
+                    key: eq.get(key)
+                    for key in (
+                        "role",
+                        "equation_type",
+                        "summary",
+                        "plain_text",
+                        "latex",
+                        "semantic_status",
+                        "confidence",
+                        "review_flags",
+                        "source_evidence_ids",
+                        "linked_claim_ids",
+                    )
+                    if eq.get(key) not in (None, "", [])
+                },
             })
             continue
         target["equation_ids"].append(eq_id)
+        target["routing_decisions"].append({
+            "artifact_type": "equation",
+            "artifact_id": eq_id,
+            "method": "deterministic_high_confidence",
+        })
 
     # Claims → equation overlap, then claim type, then source-evidence provenance.
     claim_ids = _ordered_unique(
@@ -1794,63 +2077,53 @@ def _redistribute_links(
     for cid in claim_ids:
         info = claim_index.get(cid, {})
         claim_evidence[cid] = set(info.get("evidence_ids") or [])
-        target = _match_spec_by_equation_overlap(specs, set(info.get("equation_ids") or []))
+        target = None
+        claim_eqs = set(info.get("equation_ids") or [])
+        ambiguous_overlap = _equation_overlap_is_ambiguous(specs, claim_eqs)
+        if _claim_is_high_confidence(info):
+            target = _match_spec_by_equation_overlap(specs, claim_eqs)
+            if target is None and not ambiguous_overlap:
+                target = _match_spec_by_category(
+                    specs, _claim_category(info), preferred=_claim_responsibility(info)
+                )
+            if target is None and not ambiguous_overlap:
+                target = _match_spec_by_evidence_provenance(
+                    specs, claim_evidence[cid], claim_evidence
+                )
         if target is None:
-            target = _match_spec_by_category(
-                specs, _claim_category(info), preferred=_claim_responsibility(info)
-            )
-        if target is None:
-            target = _match_spec_by_evidence_provenance(
-                specs, claim_evidence[cid], claim_evidence
-            )
-        if target is None:
-            reason = (
-                "composite claim without confident target"
-                if not _claim_is_atomic(cid, claim_index)
-                else "atomic claim without confident responsibility target"
-            )
-            unassigned.append({
-                "link_type": "claim",
-                "link_id": cid,
-                "reason": reason,
+            pending.append({
+                "artifact_type": "claim",
+                "artifact_id": cid,
+                "reason": (
+                    "low-confidence claim classification"
+                    if not _claim_is_high_confidence(info)
+                    else (
+                        "claim equation overlap is tied across responsibilities"
+                        if ambiguous_overlap
+                        else "claim has no unique responsibility target"
+                    )
+                ),
+                "artifact": {
+                    key: info.get(key)
+                    for key in (
+                        "text",
+                        "claim_type",
+                        "equation_ids",
+                        "evidence_ids",
+                        "confidence",
+                        "support_status",
+                        "review_status",
+                    )
+                    if info.get(key) not in (None, "", [])
+                },
             })
             continue
         target["claim_ids"].append(cid)
-
-    # Evidence → the child whose assigned claims OR assigned equations reference
-    # it (#421). Equation provenance matters: an evidence item cited only by an
-    # equation (no claim) is still routed to the child that owns that equation
-    # instead of being dropped as unassigned.
-    evidence_ids = _ordered_unique(
-        list(component.linked_evidence_ids or [])
-        + list((component.evidence_refs or {}).get("evidence_ids") or [])
-    )
-    for ev_id in evidence_ids:
-        target = next(
-            (
-                spec
-                for spec in specs
-                if any(ev_id in claim_evidence.get(cid, set()) for cid in spec["claim_ids"])
-            ),
-            None,
-        )
-        if target is None:
-            target = next(
-                (
-                    spec
-                    for spec in specs
-                    if any(ev_id in equation_evidence.get(eid, set()) for eid in spec["equation_ids"])
-                ),
-                None,
-            )
-        if target is None:
-            unassigned.append({
-                "link_type": "evidence",
-                "link_id": ev_id,
-                "reason": "no child claim or equation references this evidence",
-            })
-            continue
-        target["evidence_ids"].append(ev_id)
+        target["routing_decisions"].append({
+            "artifact_type": "claim",
+            "artifact_id": cid,
+            "method": "deterministic_high_confidence",
+        })
 
     # Derivations → by input/output equation overlap and operation family, then
     # the sole derivational child; otherwise left unassigned (never duplicated).
@@ -1862,23 +2135,98 @@ def _redistribute_links(
     ]
     for d_id in _ordered_unique(component.linked_derivation_ids or []):
         info = derivation_index.get(d_id, {})
-        target = _match_spec_by_equation_overlap(specs, set(info.get("equation_ids") or []))
+        target = None
+        derivation_eqs = set(info.get("equation_ids") or [])
+        ambiguous_overlap = _equation_overlap_is_ambiguous(specs, derivation_eqs)
+        if _derivation_is_high_confidence(info):
+            target = _match_spec_by_equation_overlap(specs, derivation_eqs)
+            if target is None and not ambiguous_overlap:
+                target = _match_spec_by_operation_families(
+                    specs, info.get("operation_families") or []
+                )
+            if target is None and not ambiguous_overlap and len(derivational) == 1:
+                target = derivational[0]
         if target is None:
-            target = _match_spec_by_operation_families(specs, info.get("operation_families") or [])
-        if target is None and len(derivational) == 1:
-            target = derivational[0]
-        if target is None:
-            unassigned.append({
-                "link_type": "derivation",
-                "link_id": d_id,
+            pending.append({
+                "artifact_type": "derivation",
+                "artifact_id": d_id,
                 "reason": (
-                    "no derivational child to receive derivation"
-                    if not derivational
-                    else "derivation could not be routed to a single derivational child"
+                    "low-confidence derivation semantics"
+                    if not _derivation_is_high_confidence(info)
+                    else (
+                        "derivation equation overlap is tied across responsibilities"
+                        if ambiguous_overlap
+                        else "derivation has no unique responsibility target"
+                    )
                 ),
+                "artifact": {
+                    key: info.get(key)
+                    for key in (
+                        "equation_ids",
+                        "operation_families",
+                        "confidence",
+                        "review_status",
+                        "review_required",
+                    )
+                    if info.get(key) not in (None, "", [])
+                },
             })
             continue
         target["derivation_ids"].append(d_id)
+        target["routing_decisions"].append({
+            "artifact_type": "derivation",
+            "artifact_id": d_id,
+            "method": "deterministic_high_confidence",
+        })
+
+    # Ambiguous and low-confidence artifacts are re-judged in one constrained
+    # call. The LLM may select only one of the supplied responsibilities or
+    # leave an artifact unassigned; invalid/low-confidence answers are ignored.
+    _, unresolved = _resolve_pending_with_llm(
+        component=component,
+        specs=specs,
+        pending=pending,
+        llm_client=llm_client,
+    )
+    for entry in unresolved:
+        unassigned.append({
+            "link_type": entry["artifact_type"],
+            "link_id": entry["artifact_id"],
+            "reason": entry["reason"],
+        })
+
+    # Evidence references are not exclusive ownership. Route an evidence item to
+    # every child whose assigned claim or equation explicitly cites it.
+    evidence_ids = _ordered_unique(
+        list(component.linked_evidence_ids or [])
+        + list((component.evidence_refs or {}).get("evidence_ids") or [])
+    )
+    for ev_id in evidence_ids:
+        targets = [
+            spec
+            for spec in specs
+            if (
+                any(ev_id in claim_evidence.get(cid, set()) for cid in spec["claim_ids"])
+                or any(
+                    ev_id in equation_evidence.get(eid, set())
+                    for eid in spec["equation_ids"]
+                )
+            )
+        ]
+        if not targets:
+            unassigned.append({
+                "link_type": "evidence",
+                "link_id": ev_id,
+                "reason": "no child claim or equation references this evidence",
+            })
+            continue
+        for target in targets:
+            target["evidence_ids"].append(ev_id)
+            target["routing_decisions"].append({
+                "artifact_type": "evidence",
+                "artifact_id": ev_id,
+                "method": "explicit_shared_provenance",
+            })
 
     # Children supported only by composite claims are downgraded.
     for spec in specs:
@@ -2014,6 +2362,7 @@ def _build_suggested_component(
     evidence_refs = copy.deepcopy(parent.evidence_refs or {})
     evidence_refs["equation_ids"] = eq_ids
     evidence_refs["claim_ids"] = claim_ids
+    evidence_refs["evidence_ids"] = evidence_ids
 
     eqsys_like = {"equation_system", "derivation", "constraint"}
     return ComponentRecord(

--- a/src/episteme_graph/agents/component_assembly/granularity_analyzer.py
+++ b/src/episteme_graph/agents/component_assembly/granularity_analyzer.py
@@ -222,61 +222,79 @@ def _detected_responsibilities(component: ComponentRecord) -> set[str]:
     return canonical_responsibility_types(values)
 
 
-def _suggested_split(component: ComponentRecord, responsibilities: set[str]) -> list[dict]:
-    """Build suggested children with *distinct* candidate links (#417).
+# Responsibility type → the component equation-role fields whose equations
+# belong to that responsibility (#421). Domain-neutral: it relies only on the
+# generic equation-role classification already attached to the component
+# (definition / input / intermediate / output / constraint), never on
+# paper-specific terminology.
+#   - definition / model / observable basis  ← definition (and output for an
+#     observable basis, whose defining equation is its result)
+#   - equation system                        ← input / intermediate (the
+#     transformation / relation equations)
+#   - derivation                             ← intermediate / output
+#   - constraint / application / limitation  ← constraint / output (result /
+#     consistency-relation equations)
+_RESPONSIBILITY_EQUATION_ROLE_FIELDS = {
+    "definition": ("definition_equation_ids",),
+    "model": ("definition_equation_ids",),
+    "observation_model": ("definition_equation_ids",),
+    "observable_basis": ("definition_equation_ids", "output_equation_ids"),
+    "equation_system": ("input_equation_ids", "intermediate_equation_ids"),
+    "derivation": ("intermediate_equation_ids", "output_equation_ids"),
+    "constraint": ("constraint_equation_ids", "output_equation_ids"),
+    "application": ("constraint_equation_ids", "output_equation_ids"),
+    "limitation": ("constraint_equation_ids",),
+}
 
-    Each suggested child must carry its own candidate equations/claims/derivations
-    rather than a duplicate of the parent's full link set, so the downstream
-    refiner has identifying information to redistribute by responsibility. The
-    parent's links are partitioned deterministically across the suggested
-    children (round-robin by sorted responsibility order); the ComponentRefiner
-    later performs the role-aware reassignment using equation roles.
+_ROLE_FIELDS = (
+    "definition_equation_ids",
+    "input_equation_ids",
+    "intermediate_equation_ids",
+    "output_equation_ids",
+    "constraint_equation_ids",
+)
+
+
+def _suggested_split(component: ComponentRecord, responsibilities: set[str]) -> list[dict]:
+    """Build suggested children with *responsibility-aware* candidate equations (#421).
+
+    Each suggested child receives the parent's equations whose *role* matches the
+    child's responsibility — definition equations go to a definition / model /
+    observable child, transformation/relation equations to an equation_system /
+    derivation child, and result / constraint equations to a constraint /
+    application child. Equations are never round-robined: an equation whose role
+    does not map to any of the suggested responsibilities is left out of every
+    suggested child (recorded as ``unassigned_equation_ids``) so a definition
+    equation can never be forced into a constraint child. Each equation is
+    assigned to a single responsibility (the first, in sorted order, whose roles
+    claim it) so suggested children never share equations. The ComponentRefiner —
+    which holds the full equation index — performs the authoritative reassignment
+    and keeps anything it still cannot place confidently in ``unassigned_links``.
     """
     ordered = sorted(responsibilities)
     if not ordered:
         return []
-    equation_partition = _partition(_component_equation_refs(component), len(ordered))
-    claim_partition = _partition(_component_claim_refs(component), len(ordered))
-    derivation_partition = _partition(
-        list(component.linked_derivation_ids or []), len(ordered)
-    )
-    evidence_partition = _partition(
-        _ordered_unique(
-            list(component.linked_evidence_ids or [])
-            + list((component.evidence_refs or {}).get("evidence_ids") or [])
-        ),
-        len(ordered),
-    )
+    role_equations = {
+        field_name: _ordered_unique(getattr(component, field_name, []) or [])
+        for field_name in _ROLE_FIELDS
+    }
+    assigned: set[str] = set()
+    candidate_map: dict[str, list[str]] = {resp: [] for resp in ordered}
+    for resp in ordered:
+        for field_name in _RESPONSIBILITY_EQUATION_ROLE_FIELDS.get(resp, ()):
+            for eid in role_equations.get(field_name, []):
+                if eid in assigned:
+                    continue
+                assigned.add(eid)
+                candidate_map[resp].append(eid)
     return [
         {
             "name": responsibility.replace("_", " ").title(),
             "responsibility_type": responsibility,
-            "linked_equation_ids": equation_partition[idx],
-            "candidate_claim_ids": claim_partition[idx],
-            "candidate_derivation_ids": derivation_partition[idx],
-            "candidate_evidence_ids": evidence_partition[idx],
+            "linked_equation_ids": candidate_map[responsibility],
         }
-        for idx, responsibility in enumerate(ordered)
+        for responsibility in ordered
     ]
-
-
-def _partition(values: list[str], buckets: int) -> list[list[str]]:
-    """Split ``values`` into ``buckets`` disjoint lists, deterministically.
-
-    No value appears in more than one bucket, so suggested children never share
-    an identical link set (#417).
-    """
-    out: list[list[str]] = [[] for _ in range(max(buckets, 1))]
-    for i, value in enumerate(values):
-        out[i % len(out)].append(value)
-    return out
-
-
-def _component_claim_refs(component: ComponentRecord) -> list[str]:
-    return _ordered_unique(
-        list((component.evidence_refs or {}).get("claim_ids") or [])
-        + list(component.linked_claim_ids or [])
-    )
 
 
 def _component_derivation_step_index(derivations) -> dict[str, list]:

--- a/src/episteme_graph/agents/component_assembly/repair.py
+++ b/src/episteme_graph/agents/component_assembly/repair.py
@@ -148,6 +148,10 @@ def _issue_dict(issue: ValidationIssue, llm_input: ComponentAssemblyLLMInput) ->
         "message": issue.message,
         "field": issue.field,
     }
+    if issue.target_type:
+        data["target_type"] = issue.target_type
+    if issue.target_id:
+        data["target_id"] = issue.target_id
     allowed = _allowed_values_for_issue(issue.rule_id, llm_input)
     invalid = _invalid_value_from_message(issue.message)
     if invalid:

--- a/src/episteme_graph/agents/component_assembly/schema.py
+++ b/src/episteme_graph/agents/component_assembly/schema.py
@@ -204,6 +204,8 @@ class ValidationIssue:
     severity: str
     message: str
     field: str | None = None
+    target_type: str | None = None
+    target_id: str | None = None
 
 
 @dataclass

--- a/src/episteme_graph/agents/component_assembly/validator.py
+++ b/src/episteme_graph/agents/component_assembly/validator.py
@@ -581,27 +581,35 @@ class ComponentAssemblyValidator:
         # Check DSL node/edge refs
         dsl_refs = refs.get("dsl_refs") or {}
         known_dsl_nodes = available.get("dsl_node_ids", set())
-        if known_dsl_nodes:
-            all_node_ids = list(dsl_refs.get("node_ids") or []) + list(component.linked_dsl_node_ids or [])
-            unknown = [nid for nid in all_node_ids if nid not in known_dsl_nodes]
-            for nid in unknown:
-                issues.append(ValidationIssue(
-                    "unresolved_dsl_node_id",
-                    "error",
-                    f"{component.component_id} contains unresolved DSL node ID: {nid!r}",
-                    f"components[{component.component_id}].linked_dsl_node_ids",
-                ))
+        all_node_ids = _ordered_unique(
+            list(dsl_refs.get("node_ids") or [])
+            + list(component.linked_dsl_node_ids or [])
+        )
+        unknown = [nid for nid in all_node_ids if nid not in known_dsl_nodes]
+        for nid in unknown:
+            issues.append(ValidationIssue(
+                "unresolved_dsl_node_id",
+                "error",
+                f"{component.component_id} contains unresolved DSL node ID: {nid!r}",
+                f"components[{component.component_id}].linked_dsl_node_ids",
+                target_type="dsl_node",
+                target_id=str(nid),
+            ))
         known_dsl_edges = available.get("dsl_edge_ids", set())
-        if known_dsl_edges:
-            all_edge_ids = list(dsl_refs.get("edge_ids") or []) + list(component.linked_dsl_edge_ids or [])
-            unknown = [eid for eid in all_edge_ids if eid not in known_dsl_edges]
-            for eid in unknown:
-                issues.append(ValidationIssue(
-                    "unresolved_dsl_edge_id",
-                    "error",
-                    f"{component.component_id} contains unresolved DSL edge ID: {eid!r}",
-                    f"components[{component.component_id}].linked_dsl_edge_ids",
-                ))
+        all_edge_ids = _ordered_unique(
+            list(dsl_refs.get("edge_ids") or [])
+            + list(component.linked_dsl_edge_ids or [])
+        )
+        unknown = [eid for eid in all_edge_ids if eid not in known_dsl_edges]
+        for eid in unknown:
+            issues.append(ValidationIssue(
+                "unresolved_dsl_edge_id",
+                "error",
+                f"{component.component_id} contains unresolved DSL edge ID: {eid!r}",
+                f"components[{component.component_id}].linked_dsl_edge_ids",
+                target_type="dsl_edge",
+                target_id=str(eid),
+            ))
 
         # Detect summary-only: no typed claim/evidence links in either legacy or new fields
         has_claim_link = bool(refs.get("claim_ids")) or bool(component.linked_claim_ids)

--- a/src/tests/agents/component_assembly/test_component_refinement_stage.py
+++ b/src/tests/agents/component_assembly/test_component_refinement_stage.py
@@ -59,6 +59,16 @@ class _LLMInput:
         self.accepted_claims = []
 
 
+class _RoutingLLM:
+    def __init__(self, assignments):
+        self.assignments = assignments
+        self.calls = []
+
+    def generate(self, messages):
+        self.calls.append(messages)
+        return {"assignments": list(self.assignments)}
+
+
 def _split_rec(*suggested, reasons=None):
     return {
         "required": True,
@@ -357,6 +367,166 @@ def test_evidence_routed_by_equation_provenance_when_no_claim_cites_it():
     assert not any(u["link_id"] == "ev_from_eq" for u in unassigned)
 
 
+def test_shared_evidence_is_linked_to_every_explicit_provenance_child():
+    component = _component(
+        component_id="comp_shared_ev",
+        linked_equation_ids=["eq_def", "eq_con"],
+        linked_evidence_ids=["ev_shared"],
+        evidence_refs={
+            "equation_ids": ["eq_def", "eq_con"],
+            "evidence_ids": ["ev_shared"],
+        },
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition",
+         "source_evidence_ids": ["ev_shared"]},
+        {"equation_id": "eq_con", "role": "constraint",
+         "source_evidence_ids": ["ev_shared"]},
+    ])
+
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    assert definition.linked_evidence_ids == ["ev_shared"]
+    assert constraint.linked_evidence_ids == ["ev_shared"]
+
+
+def test_low_confidence_ambiguous_equation_is_rejudged_by_constrained_llm():
+    component = _component(
+        component_id="comp_llm_route",
+        linked_equation_ids=["eq_def", "eq_result"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {
+            "equation_id": "eq_result",
+            "role": "result",
+            "plain_text": "The parameters must satisfy this consistency condition.",
+            "confidence": 0.55,
+            "semantic_status": "context_inferred",
+            "review_flags": ["low_confidence"],
+        },
+    ])
+    routing_llm = _RoutingLLM([{
+        "artifact_type": "equation",
+        "artifact_id": "eq_result",
+        "selected_responsibility": "constraint",
+        "confidence": 0.91,
+        "reason": "The equation states a consistency condition.",
+    }])
+
+    refined = ComponentRefiner(llm_client=routing_llm).refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
+
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    assert constraint.linked_equation_ids == ["eq_result"]
+    assert len(routing_llm.calls) == 1
+    mapping = refined.component_refinement["component_refinement_records"][0][
+        "split_candidate_mapping"
+    ]
+    decision = next(
+        d
+        for candidate in mapping
+        for d in candidate["routing_decisions"]
+        if d["artifact_id"] == "eq_result"
+    )
+    assert decision["method"] == "llm_rejudgement"
+
+
+def test_low_confidence_or_candidate_outside_llm_answer_stays_unassigned():
+    component = _component(
+        component_id="comp_llm_reject",
+        linked_equation_ids=["eq_def", "eq_con", "eq_result"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_con", "role": "constraint"},
+        {
+            "equation_id": "eq_result",
+            "role": "result",
+            "confidence": 0.4,
+            "semantic_status": "unknown",
+            "review_flags": ["low_confidence"],
+        },
+    ])
+    routing_llm = _RoutingLLM([{
+        "artifact_type": "equation",
+        "artifact_id": "eq_result",
+        "selected_responsibility": "application",
+        "confidence": 0.95,
+        "reason": "Invalid candidate for this split.",
+    }])
+
+    refined = ComponentRefiner(llm_client=routing_llm).refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
+
+    unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
+    assert any(
+        row["link_type"] == "equation" and row["link_id"] == "eq_result"
+        for row in unassigned
+    )
+
+
+def test_equal_equation_overlap_is_rejudged_instead_of_choosing_first_child():
+    component = _component(
+        component_id="comp_overlap_tie",
+        linked_equation_ids=["eq_def", "eq_con"],
+        linked_claim_ids=["claim_both"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(
+        equations=[
+            {"equation_id": "eq_def", "role": "definition"},
+            {"equation_id": "eq_con", "role": "constraint"},
+        ],
+        claims=[{
+            "claim_id": "claim_both",
+            "claim_type": "constraint",
+            "text": "The defined quantity must satisfy the stated condition.",
+            "equation_ids": ["eq_def", "eq_con"],
+            "confidence": 0.95,
+            "support_status": "source_backed",
+            "review_status": "auto_accepted",
+            "atomicity": "atomic",
+            "is_atomic": True,
+        }],
+    )
+    routing_llm = _RoutingLLM([{
+        "artifact_type": "claim",
+        "artifact_id": "claim_both",
+        "selected_responsibility": "constraint",
+        "confidence": 0.9,
+        "reason": "The proposition asserts a constraint, despite equal equation overlap.",
+    }])
+
+    refined = ComponentRefiner(llm_client=routing_llm).refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    assert "claim_both" not in definition.linked_claim_ids
+    assert "claim_both" in constraint.linked_claim_ids
+
+
 def test_derivation_routed_by_operation_family():
     # With two derivational-capable children, a derivation is routed by the
     # operation family of its steps, not to a fixed "first derivational child".
@@ -393,9 +563,14 @@ def test_derivation_routed_by_operation_family():
                         input_equation_ids=[],
                         operation="evaluate the constraint condition",
                         output_equation_ids=[],
+                        confidence=0.95,
+                        review_status="auto_accepted",
                     ),
                 ],
                 linked_component_ids=[],
+                review_status="auto_accepted",
+                confidence=0.95,
+                review_required=False,
             )
         ],
     )
@@ -425,7 +600,19 @@ def test_derivation_links_redistributed_to_derivational_child():
         {"equation_id": "eq_def", "role": "definition"},
         {"equation_id": "eq_der", "role": "transformation"},
     ])
-    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+    routing_llm = _RoutingLLM([
+        {
+            "artifact_type": "derivation",
+            "artifact_id": derivation_id,
+            "selected_responsibility": "derivation",
+            "confidence": 0.9,
+            "reason": "The only derivational responsibility is the derivation child.",
+        }
+        for derivation_id in ("d_a", "d_b")
+    ])
+    refined = ComponentRefiner(llm_client=routing_llm).refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
 
     definition = next(c for c in refined.components if c.responsibility_type == "definition")
     derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
@@ -489,7 +676,16 @@ def test_low_confidence_equation_forces_child_review_required():
             },
         },
     ])
-    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+    routing_llm = _RoutingLLM([{
+        "artifact_type": "equation",
+        "artifact_id": "eq_blocked",
+        "selected_responsibility": "derivation",
+        "confidence": 0.9,
+        "reason": "The equation is a transformation despite its restricted downstream use.",
+    }])
+    refined = ComponentRefiner(llm_client=routing_llm).refine(
+        _result([component]), llm_input=llm_input, derivations=None
+    )
 
     derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
     assert "eq_blocked" in derivation.linked_equation_ids

--- a/src/tests/agents/component_assembly/test_component_refinement_stage.py
+++ b/src/tests/agents/component_assembly/test_component_refinement_stage.py
@@ -193,6 +193,146 @@ def test_links_redistributed_not_duplicated_and_unassigned_reported():
 
 
 # ---------------------------------------------------------------------------
+# 3a. Responsibility / equation-role consistency (#421)
+# ---------------------------------------------------------------------------
+
+def test_equations_routed_to_responsibility_matching_their_role():
+    # A definition equation must land in the definition child and a result/
+    # constraint equation in the constraint child — driven by the equation ROLE,
+    # never round-robin (#421).
+    component = _component(
+        component_id="comp_roleconsistency",
+        linked_equation_ids=["eq_def", "eq_con"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_con", "role": "constraint"},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    assert definition.linked_equation_ids == ["eq_def"]
+    assert constraint.linked_equation_ids == ["eq_con"]
+    # The definition equation never leaks into the constraint child and vice versa.
+    assert "eq_def" not in constraint.linked_equation_ids
+    assert "eq_con" not in definition.linked_equation_ids
+    # Role-classified buckets agree with the assignment.
+    assert definition.definition_equation_ids == ["eq_def"]
+    assert "eq_def" not in (constraint.definition_equation_ids or [])
+
+
+def test_unrouteable_equation_is_unassigned_not_round_robined():
+    # An equation whose role matches none of the suggested responsibilities is
+    # left in unassigned_links, never forced onto an arbitrary child (#421).
+    component = _component(
+        component_id="comp_orphan_role",
+        linked_equation_ids=["eq_def", "eq_con", "eq_unknown"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition"},
+        {"equation_id": "eq_con", "role": "constraint"},
+        {"equation_id": "eq_unknown", "role": ""},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    for child in refined.components:
+        assert "eq_unknown" not in child.linked_equation_ids
+    unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
+    assert any(
+        u["link_id"] == "eq_unknown" and u["link_type"] == "equation" for u in unassigned
+    )
+
+
+def test_claim_routed_by_type_when_no_equation_overlap():
+    # A claim sharing no equations with any child is routed by its claim TYPE,
+    # not dropped onto the first child (#421).
+    component = _component(
+        component_id="comp_claimtype",
+        linked_equation_ids=["eq_def", "eq_con"],
+        linked_claim_ids=["claim_typed"],
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(
+        equations=[
+            {"equation_id": "eq_def", "role": "definition"},
+            {"equation_id": "eq_con", "role": "constraint"},
+        ],
+        claims=[
+            {"claim_id": "claim_typed", "is_atomic": True, "atomicity": "atomic",
+             "claim_type": "constraint", "equation_ids": [], "concepts": ["gamma"]},
+        ],
+    )
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    assert "claim_typed" in constraint.linked_claim_ids
+    assert "claim_typed" not in definition.linked_claim_ids
+
+
+def test_derivation_routed_by_operation_family():
+    # With two derivational-capable children, a derivation is routed by the
+    # operation family of its steps, not to a fixed "first derivational child".
+    from episteme_graph.agents.derivation_chain.schema import (
+        DerivationChainRecord,
+        DerivationChainResult,
+        DerivationStep,
+    )
+
+    component = _component(
+        component_id="comp_derfamily",
+        linked_equation_ids=["eq_sys", "eq_res"],
+        linked_derivation_ids=["d_constraint"],
+        split_recommendation=_split_rec(
+            _suggested("Equation system", "equation_system"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_sys", "role": "transformation"},
+        {"equation_id": "eq_res", "role": "constraint"},
+    ])
+    derivations = DerivationChainResult(
+        document_id="doc",
+        cartridge_id=None,
+        chains=[
+            DerivationChainRecord(
+                derivation_id="d_constraint",
+                document_id="doc",
+                source_section_ids=["s1"],
+                steps=[
+                    DerivationStep(
+                        step_id="s0",
+                        input_equation_ids=[],
+                        operation="evaluate the constraint condition",
+                        output_equation_ids=[],
+                    ),
+                ],
+                linked_component_ids=[],
+            )
+        ],
+    )
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=derivations)
+
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    eqsys = next(c for c in refined.components if c.responsibility_type == "equation_system")
+    assert constraint.linked_derivation_ids == ["d_constraint"]
+    assert eqsys.linked_derivation_ids == []
+
+
+# ---------------------------------------------------------------------------
 # 3b. Derivation link redistribution (#324 rule 4)
 # ---------------------------------------------------------------------------
 

--- a/src/tests/agents/component_assembly/test_component_refinement_stage.py
+++ b/src/tests/agents/component_assembly/test_component_refinement_stage.py
@@ -282,6 +282,81 @@ def test_claim_routed_by_type_when_no_equation_overlap():
     assert "claim_typed" not in definition.linked_claim_ids
 
 
+def test_constraint_equation_not_misrouted_to_application_child():
+    # #421 review (P1): constraint and application share the coarse "result"
+    # category. With both children present and responsibilities sorted
+    # (application < constraint), the first-match rule would mis-route the
+    # constraint equation/claim into the application child. The exact role
+    # responsibility must keep the constraint equation in the constraint child.
+    component = _component(
+        component_id="comp_result_pair",
+        linked_equation_ids=["eq_con", "eq_ambig"],
+        linked_claim_ids=["claim_con", "claim_app"],
+        split_recommendation=_split_rec(
+            _suggested("Application", "application"),
+            _suggested("Constraint", "constraint"),
+        ),
+    )
+    llm_input = _LLMInput(
+        equations=[
+            {"equation_id": "eq_con", "role": "constraint"},
+            {"equation_id": "eq_ambig", "role": "result"},
+        ],
+        claims=[
+            {"claim_id": "claim_con", "is_atomic": True, "atomicity": "atomic",
+             "claim_type": "constraint", "equation_ids": [], "concepts": ["c"]},
+            {"claim_id": "claim_app", "is_atomic": True, "atomicity": "atomic",
+             "claim_type": "application", "equation_ids": [], "concepts": ["a"]},
+        ],
+    )
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    constraint = next(c for c in refined.components if c.responsibility_type == "constraint")
+    application = next(c for c in refined.components if c.responsibility_type == "application")
+    # The constraint equation stays in the constraint child, not application.
+    assert "eq_con" in constraint.linked_equation_ids
+    assert "eq_con" not in application.linked_equation_ids
+    # Each claim is routed by its exact type to the matching child.
+    assert "claim_con" in constraint.linked_claim_ids
+    assert "claim_app" in application.linked_claim_ids
+    assert "claim_con" not in application.linked_claim_ids
+    # eq_ambig (bare "result" role) is ambiguous between the two result-category
+    # children, so it is left unassigned rather than guessed onto application.
+    unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
+    assert any(
+        u["link_id"] == "eq_ambig" and u["link_type"] == "equation" for u in unassigned
+    )
+
+
+def test_evidence_routed_by_equation_provenance_when_no_claim_cites_it():
+    # #421 review (P2): an evidence item referenced only by an assigned equation
+    # (no claim cites it) must be routed to that equation's child via equation
+    # provenance, not dropped as unassigned.
+    component = _component(
+        component_id="comp_eqprov",
+        linked_equation_ids=["eq_def", "eq_der"],
+        linked_evidence_ids=["ev_from_eq"],
+        evidence_refs={"equation_ids": ["eq_def", "eq_der"], "evidence_ids": ["ev_from_eq"]},
+        split_recommendation=_split_rec(
+            _suggested("Definition", "definition"),
+            _suggested("Derivation", "derivation"),
+        ),
+    )
+    llm_input = _LLMInput(equations=[
+        {"equation_id": "eq_def", "role": "definition", "source_evidence_ids": ["ev_from_eq"]},
+        {"equation_id": "eq_der", "role": "transformation"},
+    ])
+    refined = REFINER.refine(_result([component]), llm_input=llm_input, derivations=None)
+
+    definition = next(c for c in refined.components if c.responsibility_type == "definition")
+    derivation = next(c for c in refined.components if c.responsibility_type == "derivation")
+    # The evidence follows its equation (eq_def → definition child).
+    assert "ev_from_eq" in definition.linked_evidence_ids
+    assert "ev_from_eq" not in derivation.linked_evidence_ids
+    unassigned = refined.component_refinement["refinement_validation"]["unassigned_links"]
+    assert not any(u["link_id"] == "ev_from_eq" for u in unassigned)
+
+
 def test_derivation_routed_by_operation_family():
     # With two derivational-capable children, a derivation is routed by the
     # operation family of its steps, not to a fixed "first derivational child".

--- a/src/tests/agents/component_assembly/test_granularity_analyzer.py
+++ b/src/tests/agents/component_assembly/test_granularity_analyzer.py
@@ -103,6 +103,49 @@ def test_analyzer_detects_mixed_responsibility_with_canonical_aliases():
     assert len(detected) >= 2
 
 
+def test_suggested_split_routes_equations_by_role_not_round_robin():
+    # #421 regression: a coarse component that mixes a definition responsibility
+    # and a constraint responsibility must route its equations to the suggested
+    # child whose responsibility matches the equation ROLE — the definition
+    # equation to the definition child, the constraint equation to the constraint
+    # child — never round-robin (which could drop a definition equation into the
+    # constraint child).
+    component = _component(
+        component_id="comp_roles",
+        responsibility_type="definition",
+        primary_operation="define relation",
+        secondary_operations=["evaluate condition"],
+        evidence_refs={
+            "claim_ids": ["claim_1"],
+            "equation_ids": ["eq_def", "eq_con"],
+            "thesis_refs": [],
+            "dsl_refs": {"node_ids": [], "edge_ids": []},
+        },
+        definition_equation_ids=["eq_def"],
+        constraint_equation_ids=["eq_con"],
+        internal_flow=[
+            {"from": "eq_def", "relation": "define", "to": "eq_con"},
+        ],
+    )
+
+    analyzed = ANALYZER.analyze(_result([component]))
+    quality = analyzed.components[0].component_quality
+    assert quality["split_required"] is True
+
+    suggested = {s["responsibility_type"]: s for s in quality["suggested_split"]}
+    assert "definition" in suggested and "constraint" in suggested
+    assert suggested["definition"]["linked_equation_ids"] == ["eq_def"]
+    assert suggested["constraint"]["linked_equation_ids"] == ["eq_con"]
+    # The definition equation never leaks into the constraint child.
+    assert "eq_def" not in suggested["constraint"]["linked_equation_ids"]
+    # Children never share an equation.
+    seen: set[str] = set()
+    for child in quality["suggested_split"]:
+        eqs = set(child.get("linked_equation_ids") or [])
+        assert not (eqs & seen)
+        seen |= eqs
+
+
 def test_teaching_takeaway_is_not_a_step1_split_reason():
     component = _component(
         component_id="comp_teaching",

--- a/src/tests/agents/component_assembly/test_step3_step4_integration.py
+++ b/src/tests/agents/component_assembly/test_step3_step4_integration.py
@@ -76,6 +76,28 @@ class _LLMInput:
         self.claim_centered_plan = claim_centered_plan or {}
 
 
+class _RoutingLLM:
+    def generate(self, messages):
+        return {
+            "assignments": [
+                {
+                    "artifact_type": "equation",
+                    "artifact_id": "eq_blocked",
+                    "selected_responsibility": "derivation",
+                    "confidence": 0.9,
+                    "reason": "The artifact is a transformation equation.",
+                },
+                {
+                    "artifact_type": "derivation",
+                    "artifact_id": "d1",
+                    "selected_responsibility": "derivation",
+                    "confidence": 0.9,
+                    "reason": "The artifact is a derivation chain.",
+                },
+            ]
+        }
+
+
 def _step(step_id, op, inputs, outputs, **kwargs):
     return DerivationStep(
         step_id=step_id,
@@ -205,7 +227,9 @@ def test_low_confidence_equation_propagates_refiner_to_aligner_path():
         },
     ])
 
-    refined = REFINER.refine(_result([cx]), llm_input=llm_input, derivations=None)
+    refined = ComponentRefiner(llm_client=_RoutingLLM()).refine(
+        _result([cx]), llm_input=llm_input, derivations=None
+    )
     derivation_child = next(
         c for c in refined.components if c.responsibility_type == "derivation"
     )
@@ -260,6 +284,8 @@ def test_cannot_render_as_final_formula_downgrades_in_step4_not_step3():
         {
             "equation_id": "eq_final",
             "role": "result",
+            "confidence": 0.95,
+            "semantic_status": "source_backed",
             "confidence_policy": {
                 # otherwise healthy: only the final-formula flag is false.
                 "can_support_claim": True,

--- a/src/tests/agents/component_assembly/test_theory_bundle.py
+++ b/src/tests/agents/component_assembly/test_theory_bundle.py
@@ -357,6 +357,8 @@ def test_step3_4_5_integration_bundle_separation_and_refined_ids():
             {
                 "equation_id": "eq_final",
                 "role": "result",
+                "confidence": 0.95,
+                "semantic_status": "source_backed",
                 "confidence_policy": {
                     "can_support_claim": True,
                     "can_be_used_in_derivation": True,

--- a/src/tests/agents/component_assembly/test_validator.py
+++ b/src/tests/agents/component_assembly/test_validator.py
@@ -298,6 +298,41 @@ def test_valid_linkage_no_errors():
     assert cross_errors == []
 
 
+def test_empty_dsl_rejects_nested_and_typed_component_refs():
+    llm_input = _make_llm_input(
+        available_dsl_nodes=[],
+        available_dsl_edges=[],
+    )
+    component = _component(
+        evidence_refs={
+            "claim_ids": [],
+            "evidence_ids": [],
+            "equation_ids": [],
+            "dsl_refs": {
+                "node_ids": ["ghost_nested_node"],
+                "edge_ids": ["ghost_nested_edge"],
+            },
+        },
+        linked_dsl_node_ids=["ghost_typed_node"],
+        linked_dsl_edge_ids=["ghost_typed_edge"],
+    )
+
+    issues = VALIDATOR.validate(
+        _result(components=[component]), llm_input=llm_input
+    )
+
+    node_issues = [i for i in issues if i.rule_id == "unresolved_dsl_node_id"]
+    edge_issues = [i for i in issues if i.rule_id == "unresolved_dsl_edge_id"]
+    assert {i.target_id for i in node_issues} == {
+        "ghost_nested_node", "ghost_typed_node"
+    }
+    assert {i.target_id for i in edge_issues} == {
+        "ghost_nested_edge", "ghost_typed_edge"
+    }
+    assert all(i.target_type == "dsl_node" for i in node_issues)
+    assert all(i.target_type == "dsl_edge" for i in edge_issues)
+
+
 def test_component_support_cannot_use_split_required_claim():
     llm_input = _make_llm_input(
         available_claims=[

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1302,6 +1302,36 @@ def test_component_refinement_review_required_and_teaching_warning():
     assert any(w.code == "COMPONENT_REFINEMENT_TEACHING_GRANULARITY" for w in result.warnings)
 
 
+def test_unprocessed_split_required_is_hard_error_and_not_publish_ready():
+    # #421: a split-required component that was left unprocessed (neither split,
+    # failed, nor review_required) must surface as a hard error carrying the
+    # component target, block export, and forbid publish-ready.
+    comp_result = _RefinedComponentResult({
+        "split_components": [],
+        "unchanged_components": ["comp_unproc"],
+        "failed_refinements": [],
+        "review_required_refinements": [],
+        "unprocessed_split_required": ["comp_unproc"],
+        "unassigned_links": [],
+        "dangling_component_refs": [],
+        "teaching_granularity_warnings": [],
+    })
+    result = _run_gate(component_result=comp_result)
+
+    assert result.status == "failed_validation"
+    assert result.exportable is False
+    assert result.publish_ready is False
+    # The unprocessed split is preserved all the way into the export report.
+    assert result.component_refinement_validation["unprocessed_split_required"] == ["comp_unproc"]
+    unprocessed = [
+        e for e in result.errors
+        if e.code == "COMPONENT_REFINEMENT_REQUIRED_BUT_UNPROCESSED"
+    ]
+    assert len(unprocessed) == 1
+    assert unprocessed[0].target_type == "component"
+    assert unprocessed[0].target_id == "comp_unproc"
+
+
 # ---------------------------------------------------------------------------
 # Step 5: theory bundle + teaching output (issue #326)
 # ---------------------------------------------------------------------------

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -51,6 +51,8 @@ class _ComponentRecord:
         *,
         linked_claim_ids=None,
         linked_equation_ids=None,
+        linked_dsl_node_ids=None,
+        linked_dsl_edge_ids=None,
         input_equation_ids=None,
         output_equation_ids=None,
         review_required_equation_ids=None,
@@ -78,6 +80,8 @@ class _ComponentRecord:
         self.evidence_refs = evidence_refs or {}
         self.linked_claim_ids = linked_claim_ids or []
         self.linked_equation_ids = linked_equation_ids or []
+        self.linked_dsl_node_ids = linked_dsl_node_ids or []
+        self.linked_dsl_edge_ids = linked_dsl_edge_ids or []
         self.input_equation_ids = input_equation_ids or []
         self.output_equation_ids = output_equation_ids or []
         self.review_required_equation_ids = review_required_equation_ids or []
@@ -1332,6 +1336,40 @@ def test_unprocessed_split_required_is_hard_error_and_not_publish_ready():
     assert unprocessed[0].target_id == "comp_unproc"
 
 
+def test_empty_dsl_hard_fails_nested_and_typed_component_refs_with_targets():
+    component = _ComponentRecord(
+        "comp_dsl",
+        {
+            "claim_ids": [],
+            "evidence_ids": [],
+            "dsl_refs": {
+                "node_ids": ["ghost_nested_node"],
+                "edge_ids": ["ghost_nested_edge"],
+            },
+        },
+        linked_dsl_node_ids=["ghost_typed_node"],
+        linked_dsl_edge_ids=["ghost_typed_edge"],
+    )
+    result = _run_gate(
+        component_result=_ComponentResult([component]),
+        claim_objects=_ClaimObjectResult([]),
+        evidence=_EvidenceResult([]),
+        dsl=_DslResult([], []),
+    )
+
+    assert result.status == "failed_validation"
+    node_errors = [e for e in result.errors if e.code == "UNRESOLVED_DSL_NODE_ID"]
+    edge_errors = [e for e in result.errors if e.code == "UNRESOLVED_DSL_EDGE_ID"]
+    assert {e.target_id for e in node_errors} == {
+        "ghost_nested_node", "ghost_typed_node"
+    }
+    assert {e.target_id for e in edge_errors} == {
+        "ghost_nested_edge", "ghost_typed_edge"
+    }
+    assert all(e.target_type == "dsl_node" for e in node_errors)
+    assert all(e.target_type == "dsl_edge" for e in edge_errors)
+
+
 # ---------------------------------------------------------------------------
 # Step 5: theory bundle + teaching output (issue #326)
 # ---------------------------------------------------------------------------
@@ -1593,6 +1631,45 @@ def test_graph_node_valid_parent_and_member_pass():
     codes = {e.code for e in result.errors}
     assert "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID" not in codes
     assert "COMPONENT_GRAPH_MEMBER_COMPONENT_INVALID" not in codes
+
+
+def test_graph_operation_parent_must_be_canonical_component_not_aggregate_node():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [
+            {
+                "component_id": "comp_real",
+                "label": "Real",
+                "component_type": "TheoryOperationNode",
+            },
+            {
+                "component_id": "aggregate_theory_node",
+                "label": "Aggregate",
+                "component_type": "TheoryOperationNode",
+            },
+            {
+                "component_id": "detail_operation",
+                "label": "Detail",
+                "component_type": "EquationOperationNode",
+                "parent_component_id": "aggregate_theory_node",
+            },
+        ],
+        "edges": [],
+    })
+    component_result = _ComponentResult([
+        _ComponentRecord("comp_real", {"claim_ids": [], "evidence_ids": []})
+    ])
+
+    result = _run_gate(
+        artifacts=artifacts,
+        component_result=component_result,
+    )
+
+    bad = next(
+        e for e in result.errors
+        if e.code == "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID"
+    )
+    assert bad.target_type == "component"
+    assert bad.target_id == "aggregate_theory_node"
 
 
 def test_course_topic_unrelated_derivation_is_flagged():

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -1672,6 +1672,39 @@ def test_graph_operation_parent_must_be_canonical_component_not_aggregate_node()
     assert bad.target_id == "aggregate_theory_node"
 
 
+def test_graph_operation_parent_resolves_through_representative_component():
+    artifacts = _make_artifacts(component_graph={
+        "nodes": [
+            {
+                "component_id": "theory_op_1",
+                "label": "Aggregate",
+                "component_type": "TheoryOperationNode",
+                "representative_component_id": "comp_real",
+                "linked_component_ids": ["comp_real"],
+            },
+            {
+                "component_id": "detail_operation",
+                "label": "Detail",
+                "component_type": "EquationOperationNode",
+                "parent_component_id": "theory_op_1",
+            },
+        ],
+        "edges": [],
+    })
+    component_result = _ComponentResult([
+        _ComponentRecord("comp_real", {"claim_ids": [], "evidence_ids": []})
+    ])
+
+    result = _run_gate(
+        artifacts=artifacts,
+        component_result=component_result,
+    )
+
+    assert "COMPONENT_GRAPH_PARENT_COMPONENT_INVALID" not in {
+        error.code for error in result.errors
+    }
+
+
 def test_course_topic_unrelated_derivation_is_flagged():
     component = _ComponentRecord(component_id="comp_1")
     component.linked_derivation_ids = ["der_1"]


### PR DESCRIPTION
## Summary

Implement responsibility-aware and role-driven link redistribution in component refinement. When a coarse component is split into children with distinct responsibilities, equations, claims, and derivations are now routed based on their semantic role and type rather than round-robin assignment. This ensures that definition equations land in definition children, constraint equations in constraint children, and derivations are matched to their operation families.

## Key Changes

### Component Refiner (`component_refiner.py`)

- **Derivation indexing**: Added `_derivation_index()` to build a lookup of derivation chains by ID, capturing their input/output equations and operation families. This enables operation-family-aware routing.
- **Claim type extraction**: Extended `_claim_index()` to capture `claim_type` and `claim_type_candidate` fields, enabling claims to be routed by their declared type when they share no equations with any child.
- **Claim category mapping**: Added `_claim_category()` to map claim types to responsibility categories (definition, result, derivation) in a domain-neutral way.
- **Evidence provenance matching**: Added `_match_spec_by_evidence_provenance()` to route claims to children that already own co-evidenced claims, improving coherence.
- **Operation family matching**: Added `_match_spec_by_operation_families()` to route derivations by their operation family (e.g., "constraint" operations → constraint responsibility).
- **Enhanced `_redistribute_links()`**: Completely refactored to implement a multi-stage routing strategy:
  - **Equations**: Route by equation role (definition/transformation/constraint) to matching responsibility; fall back to analyzer's candidate hints; leave unrouteable equations unassigned (never round-robin).
  - **Claims**: Route by equation overlap, then by claim type, then by source-evidence provenance; composite claims without confident targets are left unassigned.
  - **Derivations**: Route by input/output equation overlap and operation family; only assign to the sole derivational child if no better match exists; never duplicate.
  - **Evidence**: Route from provenance of already-assigned claims and equations.

### Granularity Analyzer (`granularity_analyzer.py`)

- **Responsibility-equation role mapping**: Added `_RESPONSIBILITY_EQUATION_ROLE_FIELDS` constant mapping each responsibility type to the equation-role fields it owns (e.g., `definition` owns `definition_equation_ids`; `equation_system` owns `input_equation_ids` and `intermediate_equation_ids`).
- **Role-aware suggested split**: Refactored `_suggested_split()` to assign equations to suggested children based on their role, not round-robin. Each equation is assigned to at most one child; equations whose role matches no suggested responsibility are left out (recorded as unassigned).
- **Removed round-robin partitioning**: Deleted `_partition()` and `_component_claim_refs()` helper functions that were used for round-robin distribution.

### Export Validation Gate (`export_validation_gate.py`)

- **Unprocessed split detection**: Added `unprocessed_split_required` field to refinement validation to track components whose split was required but were neither split, failed, nor marked review_required.
- **Hard error for unprocessed splits**: Added validation check that surfaces unprocessed split-required components as hard errors with code `COMPONENT_REFINEMENT_REQUIRED_BUT_UNPROCESSED`, blocking export and publish-ready status.
- **Enhanced error metadata**: Added `target_type` and `target_id` fields to validation errors for better traceability.

## Tests

Added comprehensive test coverage in `test_component_refinement_stage.py`:
- `test_equations_routed_to_responsibility_matching_their_role()`: Verifies definition and constraint equations land in matching children.
- `test_unrouteable_equation_is_unassigned_not_round_robined()`: Confirms equations with unknown roles are left unassigned.
- `test_claim_routed_by_type_when_no_equation_overlap()`: Tests claim routing by type when no equation overlap exists.
- `test_derivation_routed_by_operation_family()`: Validates derivation routing by operation family.

Added regression test in `

https://claude.ai/code/session_01Lp8KRarWZMMNSTMYAhPkU4