### PR TITLE
feat: Derivation steps must satisfy generic structural constraints (e…

### DIFF
--- a/backend/core/document_pipeline/export_validation_gate.py
+++ b/backend/core/document_pipeline/export_validation_gate.py
@@ -300,6 +300,31 @@ _SOFT_ERROR_RULE_IDS = {
 # A non-atomic main-result claim is a paper-level summary, not a usable claim.
 _MAIN_RESULT_CLAIM_TYPES = {"result", "conclusion", "main_result"}
 
+# Issue #433: controlled vocabulary a derivation step ``operation`` must belong
+# to. Single source of truth is derivation_chain.schema.CONTROLLED_OPERATIONS;
+# imported when available with a hardcoded mirror as a fallback so the gate never
+# fails to load if the agents package is not importable.
+try:  # pragma: no cover - import wiring
+    from episteme_graph.agents.derivation_chain.schema import (
+        CONTROLLED_OPERATIONS as _DERIVATION_CONTROLLED_OPERATIONS,
+    )
+    _DERIVATION_CONTROLLED_OPERATIONS = set(_DERIVATION_CONTROLLED_OPERATIONS)
+except Exception:  # pragma: no cover - fallback mirror
+    _DERIVATION_CONTROLLED_OPERATIONS = {
+        "state_assumption", "apply_definition", "apply_criterion",
+        "introduce_observable", "apply_equation", "substitute",
+        "solve_linear_system", "eliminate_parameter", "normalize", "approximate",
+        "compare", "branch_on_condition", "apply_measurement_or_update",
+        "apply_non_disturbance_or_independence", "infer_intermediate_claim",
+        "infer_conclusion", "flag_limitation", "define", "relate", "transform",
+        "derive_result", "apply_constraint", "linearize", "eliminate", "solve",
+        "constrain", "integrate", "eliminate_variable",
+    }
+
+# Step review states that count as "flagged for review" — an out-of-vocabulary
+# operation is tolerated (review item, not hard error) when the step is flagged.
+_DERIVATION_REVIEW_STATES = {"teacher_review_required", "needs_verification"}
+
 
 def _ordered_unique(values) -> list:
     result = []
@@ -490,6 +515,11 @@ class ExportValidationGate:
         # (axiomatic / external_reference). Domain-agnostic — only ID resolution,
         # provenance presence, and link_status are checked.
         self._check_equation_link_integrity(artifacts, errors, review_items)
+        # 2e. Derivation step structural constraints (issue #433): every step
+        # needs non-empty endpoints, all referenced equations must be registered,
+        # the operation must be in the controlled vocabulary (or the step flagged
+        # for review), and at least one source_evidence_id must be present.
+        self._check_derivation_step_constraints(artifacts, errors, review_items)
 
         # 3. Cross-artifact ID validation
         if component_result and claim_objects and evidence:
@@ -1900,6 +1930,129 @@ class ExportValidationGate:
                         artifact="derivation_chain",
                         path=f"$.chains[{chain_idx}].steps[{step_idx}].review_status",
                         source_stage="export_validation",
+                    ))
+
+    def _check_derivation_step_constraints(
+        self,
+        artifacts: dict,
+        errors: list,
+        review_items: list,
+    ) -> None:
+        """Enforce generic structural constraints on derivation steps (issue #433).
+
+        Domain-agnostic invariants, asserting nothing about paper-specific chain
+        structure:
+
+          - ``DERIVATION_STEP_MISSING_ENDPOINT`` (hard error): a step with no
+            input endpoint (equation or claim) or no output endpoint.
+          - ``DERIVATION_STEP_DANGLING_EQUATION_REF`` (hard error): an
+            input/output equation id absent from the equation registry.
+          - ``DERIVATION_STEP_UNCONTROLLED_OPERATION``: an ``operation`` outside
+            the controlled vocabulary. A hard error when the step is not flagged
+            for review; a review item when it is (the domain-specific name should
+            live in ``operation_subtype``).
+          - ``DERIVATION_STEP_MISSING_EVIDENCE`` (review item): no
+            ``source_evidence_id`` on the step.
+        """
+        raw = artifacts.get("derivation_chain")
+        if not isinstance(raw, dict):
+            return
+        chains = raw.get("chains")
+        if not isinstance(chains, list):
+            return
+        registry_ids = set(self._equation_index_from_artifacts(artifacts).keys())
+
+        for chain in chains:
+            if not isinstance(chain, dict):
+                continue
+            deriv_id = str(chain.get("derivation_id") or "")
+            for step in chain.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                step_id = str(step.get("step_id") or "")
+                target = f"{deriv_id}:{step_id}" if deriv_id else step_id
+                base_path = f"$.chains[{deriv_id}].steps[{step_id}]"
+
+                in_eq = [str(x) for x in (step.get("input_equation_ids") or []) if x]
+                out_eq = [str(x) for x in (step.get("output_equation_ids") or []) if x]
+                in_claim = [
+                    str(x) for x in (
+                        list(step.get("input_claim_ids") or [])
+                        + list(step.get("required_claim_ids") or [])
+                    ) if x
+                ]
+                out_claim = [str(x) for x in (step.get("output_claim_ids") or []) if x]
+
+                # (a) endpoints — every step needs an input and an output side.
+                if not (in_eq or in_claim) or not (out_eq or out_claim):
+                    errors.append(ValidationEntry(
+                        code="DERIVATION_STEP_MISSING_ENDPOINT",
+                        message=(
+                            f"derivation step {target!r} is missing an input or "
+                            f"output endpoint (equation or claim)"
+                        ),
+                        artifact="derivation_chain",
+                        path=base_path,
+                        source_stage="export_validation",
+                        target_type="derivation_step",
+                        target_id=target,
+                    ))
+
+                # (b) dangling equation references.
+                if registry_ids:
+                    for ref in in_eq + out_eq:
+                        if ref not in registry_ids:
+                            errors.append(ValidationEntry(
+                                code="DERIVATION_STEP_DANGLING_EQUATION_REF",
+                                message=(
+                                    f"derivation step {target!r} references "
+                                    f"non-existent equation {ref!r}"
+                                ),
+                                artifact="derivation_chain",
+                                path=base_path,
+                                source_stage="export_validation",
+                                target_type="derivation_step",
+                                target_id=target,
+                            ))
+
+                # (c) controlled operation vocabulary.
+                operation = str(step.get("operation") or "")
+                if operation not in _DERIVATION_CONTROLLED_OPERATIONS:
+                    flagged = (
+                        str(step.get("review_status") or "") in _DERIVATION_REVIEW_STATES
+                        or bool(step.get("review_reason"))
+                    )
+                    entry = ValidationEntry(
+                        code="DERIVATION_STEP_UNCONTROLLED_OPERATION",
+                        message=(
+                            f"derivation step {target!r} operation "
+                            f"{operation or 'unset'!r} is not in the controlled "
+                            f"vocabulary; domain-specific names belong in "
+                            f"operation_subtype"
+                        ),
+                        artifact="derivation_chain",
+                        path=f"{base_path}.operation",
+                        source_stage="export_validation",
+                        target_type="derivation_step",
+                        target_id=target,
+                    )
+                    if flagged:
+                        review_items.append(entry)
+                    else:
+                        errors.append(entry)
+
+                # (d) evidence presence.
+                if not (step.get("source_evidence_ids") or []):
+                    review_items.append(ValidationEntry(
+                        code="DERIVATION_STEP_MISSING_EVIDENCE",
+                        message=(
+                            f"derivation step {target!r} has no source_evidence_id"
+                        ),
+                        artifact="derivation_chain",
+                        path=f"{base_path}.source_evidence_ids",
+                        source_stage="export_validation",
+                        target_type="derivation_step",
+                        target_id=target,
                     ))
 
     def _check_equation_consistency_mismatches(

--- a/src/episteme_graph/agents/derivation_chain/agent.py
+++ b/src/episteme_graph/agents/derivation_chain/agent.py
@@ -22,6 +22,7 @@ from episteme_graph.agents.equation_semantics.schema import (
 )
 
 from .schema import (
+    CONTROLLED_OPERATIONS,
     DEFAULT_OPERATION,
     OPERATION_ONTOLOGY,
     DerivationChainRecord,
@@ -349,6 +350,7 @@ class DerivationChainAgent:
 
             operation = self._infer_operation(current_record)
             operation = self._refine_generic_operation(operation, current_record)
+            operation, operation_subtype, subtype_source = self._resolve_step_operation(operation)
             linked_claims = list(claim_link_index.get(current, []))
             sem_claims = list(current_record.semantics.linked_claim_ids) if current_record else []
             all_claim_ids = sorted(set(linked_claims + sem_claims))
@@ -358,6 +360,8 @@ class DerivationChainAgent:
                 input_equation_ids=list(sources),
                 operation=operation,
                 output_equation_ids=[current],
+                operation_subtype=operation_subtype,
+                subtype_source=subtype_source,
                 required_claim_ids=all_claim_ids,
                 assumption_refs=assumptions,
                 reason=current_record.semantics.summary if current_record else "",
@@ -429,6 +433,7 @@ class DerivationChainAgent:
                 claim_id = getattr(claim, "claim_id", None) or f"claim_{step_idx}"
                 claim_type = getattr(claim, "claim_type", "unknown") or "unknown"
                 operation = _CLAIM_TYPE_TO_OPERATION.get(claim_type, "infer_intermediate_claim")
+                operation, operation_subtype, subtype_source = self._resolve_step_operation(operation)
 
                 # Evidence IDs for this claim
                 source_ev_ids: list[str] = list(getattr(claim, "source_evidence_ids", []) or [])
@@ -438,6 +443,8 @@ class DerivationChainAgent:
                     input_equation_ids=[],
                     operation=operation,
                     output_equation_ids=[],
+                    operation_subtype=operation_subtype,
+                    subtype_source=subtype_source,
                     required_claim_ids=[prev_claim_id] if prev_claim_id else [],
                     assumption_refs=list(claim_id for c2 in section_claims[:step_idx - 1]
                                         if getattr(c2, "claim_type", "") == "assumption"
@@ -486,6 +493,24 @@ class DerivationChainAgent:
             f"Derive {', '.join(last_output)} from {', '.join(first_inputs)} "
             f"via {op_summary}"
         )
+
+    @staticmethod
+    def _resolve_step_operation(operation: str) -> tuple[str, str | None, str]:
+        """Map a step operation onto the controlled vocabulary (issue #433).
+
+        Returns ``(operation, operation_subtype, subtype_source)``. A verb in
+        CONTROLLED_OPERATIONS passes through unchanged. A domain-specific or
+        otherwise unknown verb is demoted: the controlled ``operation`` becomes
+        the generic DEFAULT_OPERATION while the original name is preserved in
+        ``operation_subtype`` with ``subtype_source="inferred"`` provenance, so no
+        information is lost and the controlled field stays domain-agnostic.
+        """
+        op = str(operation or "").strip()
+        if op in CONTROLLED_OPERATIONS:
+            return op, None, "unknown"
+        if not op:
+            return DEFAULT_OPERATION, None, "unknown"
+        return DEFAULT_OPERATION, op, "inferred"
 
     @staticmethod
     def _infer_operation(record: Optional[EquationRecord]) -> str:

--- a/src/episteme_graph/agents/derivation_chain/schema.py
+++ b/src/episteme_graph/agents/derivation_chain/schema.py
@@ -43,7 +43,20 @@ OPERATION_ONTOLOGY = [
     "eliminate",
     "solve",
     "normalize",
+    # Issue #433: additional domain-neutral generic operations. System-level and
+    # cartridge operations resolve to one of these core verbs; paper-specific
+    # names live in operation_subtype, never here.
+    "constrain",
+    "integrate",
+    "eliminate_variable",
 ]
+
+# Issue #433: the controlled vocabulary a derivation step's ``operation`` field
+# must belong to. Domain-specific operation names must be carried in
+# ``operation_subtype`` (with ``subtype_source`` provenance), never in
+# ``operation``. An operation outside this set is only acceptable on a step that
+# is explicitly flagged for review.
+CONTROLLED_OPERATIONS = frozenset(OPERATION_ONTOLOGY)
 
 STEP_REVIEW_STATUSES = [
     "auto_accepted",
@@ -58,6 +71,12 @@ class DerivationStep:
     input_equation_ids: list[str]
     operation: str
     output_equation_ids: list[str]
+    # Issue #433: two-layer operation model for steps. ``operation`` must be a
+    # CONTROLLED_OPERATIONS verb; a domain-specific name is carried here with
+    # ``subtype_source`` provenance ("cartridge" / "source_text" / "inferred" /
+    # "unknown") instead of polluting the controlled ``operation`` field.
+    operation_subtype: str | None = None
+    subtype_source: str = "unknown"
     required_claim_ids: list[str] = field(default_factory=list)
     assumption_refs: list[str] = field(default_factory=list)
     reason: str = ""
@@ -152,6 +171,8 @@ class DerivationChainResult:
                     input_equation_ids=list(s.get("input_equation_ids") or []),
                     operation=s.get("operation", DEFAULT_OPERATION),
                     output_equation_ids=list(s.get("output_equation_ids") or []),
+                    operation_subtype=s.get("operation_subtype"),
+                    subtype_source=s.get("subtype_source", "unknown"),
                     required_claim_ids=list(s.get("required_claim_ids") or []),
                     assumption_refs=list(s.get("assumption_refs") or []),
                     reason=s.get("reason", ""),

--- a/src/tests/agents/derivation_chain/test_agent.py
+++ b/src/tests/agents/derivation_chain/test_agent.py
@@ -2,7 +2,12 @@
 from __future__ import annotations
 
 from episteme_graph.agents.derivation_chain import DerivationChainAgent
-from episteme_graph.agents.derivation_chain.schema import OPERATION_ONTOLOGY
+from episteme_graph.agents.derivation_chain.schema import (
+    CONTROLLED_OPERATIONS,
+    DEFAULT_OPERATION,
+    DerivationChainResult,
+    OPERATION_ONTOLOGY,
+)
 from episteme_graph.agents.equation_semantics.schema import (
     DefinedSymbol,
     EquationCandidate,
@@ -151,6 +156,76 @@ def test_required_claim_ids_propagated():
     agent = DerivationChainAgent()
     chain_result = agent.run(result, claim_link_index={"eq_2": ["claim_xyz"]})
     assert "claim_xyz" in chain_result.chains[0].steps[0].required_claim_ids
+
+
+# ---------------------------------------------------------------------------
+# Issue #433: controlled operation vocabulary + operation_subtype provenance
+# ---------------------------------------------------------------------------
+
+def test_resolve_step_operation_passes_controlled_verb():
+    op, subtype, source = DerivationChainAgent._resolve_step_operation("substitute")
+    assert op == "substitute"
+    assert subtype is None
+    assert source == "unknown"
+
+
+def test_resolve_step_operation_demotes_unknown_to_subtype():
+    op, subtype, source = DerivationChainAgent._resolve_step_operation("schwinger_dyson")
+    assert op == DEFAULT_OPERATION
+    assert op in CONTROLLED_OPERATIONS
+    assert subtype == "schwinger_dyson"
+    assert source == "inferred"
+
+
+def test_all_step_operations_are_controlled_vocabulary():
+    result = _make_result([
+        _make_eq("eq_1_2", role="definition"),
+        _make_eq("eq_3_1", from_eqs=["eq_1_2"], role="transformation"),
+        _make_eq("eq_3_14", from_eqs=["eq_3_1"], role="result"),
+    ])
+    chain_result = DerivationChainAgent().run(result)
+    steps = [s for c in chain_result.chains for s in c.steps]
+    assert steps
+    for s in steps:
+        assert s.operation in CONTROLLED_OPERATIONS
+
+
+def test_step_subtype_fields_round_trip():
+    result = _make_result([
+        _make_eq("eq_1"),
+        _make_eq("eq_2", from_eqs=["eq_1"], role="result"),
+    ])
+    chain_result = DerivationChainAgent().run(result)
+    chain_result.chains[0].steps[0].operation_subtype = "domain_specific_move"
+    chain_result.chains[0].steps[0].subtype_source = "cartridge"
+
+    restored = DerivationChainResult.from_dict(chain_result.to_dict())
+    step = restored.chains[0].steps[0]
+    assert step.operation_subtype == "domain_specific_move"
+    assert step.subtype_source == "cartridge"
+
+
+def test_controlled_operations_are_reproducible_across_domains():
+    # Two unrelated domain vocabularies with the same chain shape must both yield
+    # controlled-vocabulary operations and resolvable endpoints — no assertion on
+    # paper-specific chain structure.
+    def _chain(summary_a, summary_b):
+        return _make_result([
+            _make_eq("eq_1", role="definition", summary=summary_a),
+            _make_eq("eq_2", from_eqs=["eq_1"], role="result", summary=summary_b),
+        ])
+
+    physics = DerivationChainAgent().run(_chain("Lagrangian density", "decay rate"))
+    economics = DerivationChainAgent().run(_chain("utility function", "market equilibrium"))
+
+    for res in (physics, economics):
+        steps = [s for c in res.chains for s in c.steps]
+        assert steps
+        eq_ids = {"eq_1", "eq_2"}
+        for s in steps:
+            assert s.operation in CONTROLLED_OPERATIONS
+            for ref in s.input_equation_ids + s.output_equation_ids:
+                assert ref in eq_ids
 
 
 def test_semantics_linked_claim_ids_propagated():

--- a/src/tests/agents/test_export_validation_gate.py
+++ b/src/tests/agents/test_export_validation_gate.py
@@ -2025,3 +2025,148 @@ def test_link_integrity_reads_flattened_export_shape():
     ]})
     result = _run_gate(artifacts=artifacts)
     assert _link_codes(result, "EQ_DANGLING_EQUATION_LINK") == {"eq_1"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: derivation step structural constraints (issue #433)
+#
+# Domain-agnostic — assertions are by error code / target id only, never by
+# paper-specific chain structure.
+# ---------------------------------------------------------------------------
+
+def _registry(*equation_ids):
+    return {"equations": [{"equation_id": e} for e in equation_ids]}
+
+
+def _step(step_id, **kw):
+    step = {
+        "step_id": step_id,
+        "input_equation_ids": [],
+        "output_equation_ids": [],
+        "input_claim_ids": [],
+        "output_claim_ids": [],
+        "required_claim_ids": [],
+        "operation": "substitute",
+        "operation_subtype": None,
+        "subtype_source": "unknown",
+        "source_evidence_ids": ["ev_1"],
+        "review_status": "teacher_review_required",
+    }
+    step.update(kw)
+    return step
+
+
+def _deriv(*steps, derivation_id="der_1"):
+    return {"chains": [{"derivation_id": derivation_id, "steps": list(steps)}]}
+
+
+def _codes(result, code):
+    return {e.target_id for e in result.errors if e.code == code}
+
+
+def _review_codes(result, code):
+    return {e.target_id for e in result.review_items if e.code == code}
+
+
+def test_derivation_step_well_formed_passes():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1", "eq_2"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_1"], output_equation_ids=["eq_2"],
+            operation="substitute", source_evidence_ids=["ev_1"],
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert not any(e.code.startswith("DERIVATION_STEP_") for e in result.errors)
+    assert not any(
+        e.code in ("DERIVATION_STEP_MISSING_EVIDENCE",
+                   "DERIVATION_STEP_UNCONTROLLED_OPERATION")
+        for e in result.review_items
+    )
+
+
+def test_derivation_step_missing_endpoint_is_hard_error():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_1"], output_equation_ids=[],
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert _codes(result, "DERIVATION_STEP_MISSING_ENDPOINT") == {"der_1:step_001"}
+    assert result.status == "failed_validation"
+
+
+def test_derivation_step_claim_endpoints_satisfy_endpoint_rule():
+    # A claim-only step (no equation ids) is well-formed via claim endpoints.
+    artifacts = _make_artifacts(
+        derivation_chain=_deriv(_step(
+            "step_001", input_claim_ids=["c_1"], output_claim_ids=["c_2"],
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert not any(e.code == "DERIVATION_STEP_MISSING_ENDPOINT" for e in result.errors)
+
+
+def test_derivation_step_dangling_equation_ref_is_hard_error():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_ghost"], output_equation_ids=["eq_1"],
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert _codes(result, "DERIVATION_STEP_DANGLING_EQUATION_REF") == {"der_1:step_001"}
+    assert result.status == "failed_validation"
+
+
+def test_uncontrolled_operation_unflagged_is_hard_error():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1", "eq_2"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_1"], output_equation_ids=["eq_2"],
+            operation="schwinger_dyson", review_status="auto_accepted",
+            review_reason="",
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert _codes(result, "DERIVATION_STEP_UNCONTROLLED_OPERATION") == {"der_1:step_001"}
+    assert result.status == "failed_validation"
+
+
+def test_uncontrolled_operation_flagged_is_review_item():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1", "eq_2"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_1"], output_equation_ids=["eq_2"],
+            operation="schwinger_dyson", review_status="teacher_review_required",
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert not any(
+        e.code == "DERIVATION_STEP_UNCONTROLLED_OPERATION" for e in result.errors
+    )
+    assert _review_codes(result, "DERIVATION_STEP_UNCONTROLLED_OPERATION") == {
+        "der_1:step_001"
+    }
+
+
+def test_derivation_step_missing_evidence_is_review_item():
+    artifacts = _make_artifacts(
+        equation_semantics=_registry("eq_1", "eq_2"),
+        derivation_chain=_deriv(_step(
+            "step_001", input_equation_ids=["eq_1"], output_equation_ids=["eq_2"],
+            source_evidence_ids=[],
+        )),
+    )
+    result = _run_gate(artifacts=artifacts)
+    assert not any(e.code == "DERIVATION_STEP_MISSING_EVIDENCE" for e in result.errors)
+    assert _review_codes(result, "DERIVATION_STEP_MISSING_EVIDENCE") == {
+        "der_1:step_001"
+    }
+
+
+def test_no_derivation_chain_artifact_is_noop():
+    result = _run_gate()
+    assert not any(e.code.startswith("DERIVATION_STEP_") for e in result.errors)
+    assert not any(e.code.startswith("DERIVATION_STEP_") for e in result.review_items)


### PR DESCRIPTION
…ndpoints, provenance, controlled vocabulary) #433

Enforce domain-agnostic structural invariants on derivation steps as part of the #430 cross-cutting rules.

- schema: define CONTROLLED_OPERATIONS as the single source of truth for the step operation vocabulary; add operation_subtype / subtype_source to DerivationStep so domain-specific operation names live in a tagged subtype with provenance instead of the controlled operation field (from_dict updated).
- agent: _resolve_step_operation demotes any out-of-vocabulary operation to a generic controlled verb while preserving the original name in operation_subtype (subtype_source="inferred"); applied to equation and claim steps.
- export_validation_gate: _check_derivation_step_constraints adds publish-gating checks — DERIVATION_STEP_MISSING_ENDPOINT / DERIVATION_STEP_DANGLING_EQUATION_REF / DERIVATION_STEP_UNCONTROLLED_OPERATION (hard error unless the step is flagged for review) / DERIVATION_STEP_MISSING_EVIDENCE (review item). Controlled vocab imported from the schema with a hardcoded fallback mirror.
- tests: derivation_chain operation resolution + subtype round-trip + two-domain reproducibility; gate constraint coverage (endpoints, dangling refs, vocab, evidence) asserted via codes/relationships, no proper nouns or hardcoded counts.