### PR TITLE
Support array initializers in extractVar function

### DIFF
--- a/backend/tests/test_component_evidence_chips_ui_static.py
+++ b/backend/tests/test_component_evidence_chips_ui_static.py
@@ -271,12 +271,22 @@ function extractFrom(src, name){
   throw new Error("unbalanced "+name);
 }
 function extractMany(src, names){ return names.map(function(n){ return extractFrom(src,n); }).join("\n"); }
-// function ではない "var NAME = { ... };" 形式のモジュール定数を抽出する。
+// function ではない "var NAME = { ... };" / "var NAME = [ ... ];" 形式のモジュール
+// 定数を抽出する（オブジェクト・配列どちらの初期化子にも対応する）。
 function extractVar(src, name){
-  const s = src.indexOf("var " + name + " = {");
+  const s = src.indexOf("var " + name + " = ");
   if (s<0) throw new Error("missing var "+name);
-  let d=0,st=false;
-  for(let j=src.indexOf("{",s);j<src.length;j++){const c=src[j];if(c==="{"){d++;st=true;}else if(c==="}"){d--;if(st&&d===0)return src.slice(s,j+1)+";";}}
+  let open=-1,oc="",cc="";
+  for(let j=src.indexOf("=",s)+1;j<src.length;j++){
+    const c=src[j];
+    if(c===" "||c==="\n"||c==="\r"||c==="\t") continue;
+    if(c==="{"){open=j;oc="{";cc="}";}
+    else if(c==="["){open=j;oc="[";cc="]";}
+    break;
+  }
+  if(open<0) throw new Error("unsupported initializer for var "+name);
+  let d=0;
+  for(let j=open;j<src.length;j++){const c=src[j];if(c===oc){d++;}else if(c===cc){d--;if(d===0)return src.slice(s,j+1)+";";}}
   throw new Error("unbalanced var "+name);
 }
 """
@@ -293,10 +303,11 @@ var window = { katex: null };
 function escHtml(s){ return String(s==null?"":s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
 var materialEvidenceChipItems = {};
 eval(extractVar(app, "MATERIAL_EVIDENCE_KIND_LABELS"));
+eval(extractVar(app, "MATERIAL_ELEMENT_CONTEXT_TYPES"));
 eval(extractMany(app, ["normalizeMaterialEvidenceId","normalizeMaterialLineBreaks","normalizeKatexFormula",
   "renderMaterialKatex","renderMaterialEquationBody","renderMaterialMissingEmbed",
   "shortMaterialEvidenceSummary","renderMaterialFigureCard","registerMaterialEvidenceChipEntry",
-  "renderMaterialEvidenceChip","mdBlocksToHtml","renderMaterialChunk"]));
+  "renderMaterialEvidenceChip","renderMaterialElementContextButton","mdBlocksToHtml","renderMaterialChunk"]));
 
 const chunk = {
   text: "本文 ![[component:comp_1]] 続き 数式 ![[equation:eq_1]] 出典 ![[source:ev_1]]",

--- a/backend/tests/test_learning_material_embed_resolution.py
+++ b/backend/tests/test_learning_material_embed_resolution.py
@@ -42,13 +42,22 @@ function extractFrom(src, name){
 // eval(extractMany(...)) すること（forEach などのコールバック内で eval すると宣言が
 // そのコールバックのスコープに閉じ込められ、外から参照できなくなる）。
 function extractMany(src, names){ return names.map(function(n){ return extractFrom(src,n); }).join("\n"); }
-// function ではない "var NAME = { ... };" 形式のモジュール定数（例:
-// MATERIAL_EVIDENCE_KIND_LABELS）を抽出する。
+// function ではない "var NAME = { ... };" / "var NAME = [ ... ];" 形式のモジュール
+// 定数（例: MATERIAL_EVIDENCE_KIND_LABELS / MATERIAL_ELEMENT_CONTEXT_TYPES）を抽出する。
 function extractVar(src, name){
-  const s = src.indexOf("var " + name + " = {");
+  const s = src.indexOf("var " + name + " = ");
   if (s<0) throw new Error("missing var "+name);
-  let d=0,st=false;
-  for(let j=src.indexOf("{",s);j<src.length;j++){const c=src[j];if(c==="{"){d++;st=true;}else if(c==="}"){d--;if(st&&d===0)return src.slice(s,j+1)+";";}}
+  let open=-1,oc="",cc="";
+  for(let j=src.indexOf("=",s)+1;j<src.length;j++){
+    const c=src[j];
+    if(c===" "||c==="\n"||c==="\r"||c==="\t") continue;
+    if(c==="{"){open=j;oc="{";cc="}";}
+    else if(c==="["){open=j;oc="[";cc="]";}
+    break;
+  }
+  if(open<0) throw new Error("unsupported initializer for var "+name);
+  let d=0;
+  for(let j=open;j<src.length;j++){const c=src[j];if(c===oc){d++;}else if(c===cc){d--;if(d===0)return src.slice(s,j+1)+";";}}
   throw new Error("unbalanced var "+name);
 }
 """
@@ -116,10 +125,11 @@ var window={katex:null};
 function escHtml(s){return String(s==null?"":s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");}
 var materialEvidenceChipItems = {};
 eval(extractVar(app,"MATERIAL_EVIDENCE_KIND_LABELS"));
+eval(extractVar(app,"MATERIAL_ELEMENT_CONTEXT_TYPES"));
 eval(extractMany(app,["normalizeMaterialEvidenceId","normalizeMaterialLineBreaks","normalizeKatexFormula",
  "renderMaterialKatex","renderMaterialEquationBody","renderMaterialMissingEmbed",
  "shortMaterialEvidenceSummary","renderMaterialFigureCard","registerMaterialEvidenceChipEntry",
- "renderMaterialEvidenceChip","mdBlocksToHtml","renderMaterialChunk"]));
+ "renderMaterialEvidenceChip","renderMaterialElementContextButton","mdBlocksToHtml","renderMaterialChunk"]));
 const chunk={
   text:"本文 ![[component:comp_1]] つづき ![[claim:claim_1]] さらに ![[source:ev_1]] "
     +"数式 ![[equation:eq_1]] 未知 ![[component:missing_1]]",
@@ -171,10 +181,11 @@ var window={katex:null};
 function escHtml(s){return String(s==null?"":s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");}
 var materialEvidenceChipItems = {};
 eval(extractVar(app,"MATERIAL_EVIDENCE_KIND_LABELS"));
+eval(extractVar(app,"MATERIAL_ELEMENT_CONTEXT_TYPES"));
 eval(extractMany(app,["normalizeMaterialEvidenceId","normalizeMaterialLineBreaks","normalizeKatexFormula",
  "renderMaterialKatex","renderMaterialEquationBody","renderMaterialMissingEmbed",
  "shortMaterialEvidenceSummary","renderMaterialFigureCard","registerMaterialEvidenceChipEntry",
- "renderMaterialEvidenceChip","mdBlocksToHtml","renderMaterialChunk"]));
+ "renderMaterialEvidenceChip","renderMaterialElementContextButton","mdBlocksToHtml","renderMaterialChunk"]));
 const chunk={
   text:"取り違え ![[claim:comp_1]]",
   formulas:[], figures:[],


### PR DESCRIPTION
## Summary

Enhanced the `extractVar` JavaScript utility function to support both object (`{}`) and array (`[]`) initializers when extracting module constants. This enables extraction of array-based constants like `MATERIAL_ELEMENT_CONTEXT_TYPES` in addition to the previously supported object-based constants.

## Key Changes

- **Updated `extractVar` function logic:**
  - Changed from hardcoded search for `"var NAME = {"` to generic `"var NAME = "` pattern
  - Added detection logic to identify whether the initializer is an object (`{}`) or array (`[]`)
  - Generalized bracket matching to work with either opening/closing pair (`{}` or `[]`)
  - Improved whitespace handling when scanning for the opening bracket

- **Updated test fixtures in two test files:**
  - Added `eval(extractVar(app,"MATERIAL_ELEMENT_CONTEXT_TYPES"))` to extract the new array-based constant
  - Added `"renderMaterialElementContextButton"` to the function extraction list in both test cases
  - Applied consistent changes across `test_learning_material_embed_resolution.py` and `test_component_evidence_chips_ui_static.py`

## Implementation Details

The refactored `extractVar` function now:
1. Searches for the assignment operator (`=`) instead of a specific bracket type
2. Scans forward from the assignment, skipping whitespace characters
3. Detects the opening bracket type (`{` or `[`) and stores the corresponding closing bracket
4. Uses generic bracket counting with the detected pair instead of hardcoded `{}` logic
5. Throws an error if neither object nor array initializer is found

This change maintains backward compatibility with existing object-based constants while enabling support for array-based module constants.

https://claude.ai/code/session_01XTMBwc6WPfieVzP5tkK2Wv